### PR TITLE
Fix Debian package name in backend Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Browser (localhost:5173)
 - [uv](https://docs.astral.sh/uv/) — Python package manager
 - [Bun](https://bun.sh/) — JavaScript runtime
 - **WeasyPrint system dependencies** (for PDF generation):
-  - Ubuntu/Debian: `apt-get install libcairo2 libpango-1.0-0 libgdk-pixbuf2.0-0 libffi7 shared-mime-info`
+  - Ubuntu/Debian: `apt-get install libcairo2 libpango-1.0-0 libgdk-pixbuf-2.0-0 libffi-dev shared-mime-info`
   - macOS: `brew install cairo pango gdk-pixbuf`
   - Windows: Included in the WeasyPrint pip package
 - An LLM API key (optional — required for AI features):

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpango-1.0-0 \
     libpangocairo-1.0-0 \
     libpangoft2-1.0-0 \
-    libgdk-pixbuf2.0-0 \
+    libgdk-pixbuf-2.0-0 \
     libffi-dev \
     shared-mime-info \
     libjpeg-dev \


### PR DESCRIPTION
Replaces an obsolete Debian package name in the backend Docker image and updates the matching README example.

Validated with `docker compose build backend`.