### PR TITLE
Fix frontend Docker runtime dependencies

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -20,6 +20,7 @@ FROM node:20-slim AS runtime
 WORKDIR /app
 
 COPY --from=build /app/build ./build
+COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/package.json ./
 
 ENV PORT=3000


### PR DESCRIPTION
Copies runtime dependencies into the frontend image so the built server can resolve packages like `clsx`.