### PR TITLE
feat(generate): split-screen live CV preview with SSE streaming

### DIFF
--- a/backend/app/routes/generate.py
+++ b/backend/app/routes/generate.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from collections.abc import AsyncIterable
@@ -180,6 +181,65 @@ def generate_cv(req: GenerateCvRequest, db: Session = Depends(get_db)):
     db.commit()
 
     return GenerateCvResponse(enhanced=enhanced, profile=result_profile)
+
+
+@router.post("/generate/cv/stream", response_class=EventSourceResponse)
+async def generate_cv_stream(req: GenerateCvRequest, db: Session = Depends(get_db)):
+    """SSE endpoint: emits 'profile' (original) then 'done' (enhanced + saved id)."""
+    profile = get_profile_or_404(req.profile_id, db)
+    profile_data = profile_to_schema(profile)
+
+    yield ServerSentEvent(data=profile_data.model_dump_json(), event="profile")
+
+    enhanced = False
+    result_profile = profile_data
+    provider, api_key = _get_llm_config_raw(db)
+
+    if req.enhance and provider and api_key:
+        try:
+            user_prompt = format_profile_for_llm(profile_data)
+            if req.job_description:
+                user_prompt += f"\n\n---\nTARGET JOB DESCRIPTION:\n{req.job_description}"
+            if req.extra_context and req.extra_context.strip():
+                user_prompt += f"\n\nADDITIONAL CONTEXT FROM CANDIDATE: {req.extra_context.strip()}"
+            user_prompt += f"\n\n---\nORIGINAL DATA (use this schema for your JSON output):\n{profile_data.model_dump_json()}"
+
+            llm_output = await asyncio.to_thread(
+                call_llm,
+                user_prompt,
+                system=ATS_SYSTEM_PROMPT,
+                provider=provider,
+                api_key=api_key,
+                operation=OPERATION_CV_GENERATION,
+                profile_id=req.profile_id,
+            )
+            cleaned = clean_llm_json(llm_output)
+            ats = ATSEnhancement(**json.loads(cleaned))
+            result_profile = profile_data.model_copy(
+                update={"summary": ats.summary, "work_experience": ats.work_experience}
+            )
+            enhanced = True
+        except RateLimitError as e:
+            yield ServerSentEvent(data=str(e), event="rate_limit")
+            return
+        except Exception as exc:
+            logger.warning("ATS enhancement failed, falling back to original profile: %s", exc)
+
+    entry = GeneratedCV(
+        enhanced=int(enhanced),
+        profile_snapshot=result_profile.model_dump_json(),
+        profile_id=req.profile_id,
+        application_id=req.application_id,
+    )
+    db.add(entry)
+    db.commit()
+
+    done_payload = json.dumps({
+        "enhanced": enhanced,
+        "profile": result_profile.model_dump(mode="json"),
+        "id": entry.id,
+    })
+    yield ServerSentEvent(data=done_payload, event="done")
 
 
 @router.post("/generate/cv/pdf")

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -143,6 +143,13 @@ export const generateCv = (data: GenerateCvRequest) =>
 export const generateCvPdf = (data: CvPdfRequest) =>
     requestBlob('/generate/cv/pdf', { method: 'POST', body: JSON.stringify(data) });
 
+export const generateCvStream = (data: GenerateCvRequest): Promise<Response> =>
+    fetch(`${BASE_URL}/generate/cv/stream`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+    });
+
 // ---------------------------------------------------------------------------
 // Generate Cover Letter
 // ---------------------------------------------------------------------------

--- a/frontend/src/lib/stream.ts
+++ b/frontend/src/lib/stream.ts
@@ -76,3 +76,49 @@ export async function consumeStream(response: Response, options: StreamOptions =
     reader.releaseLock();
   }
 }
+
+export interface StructuredStreamOptions {
+  onEvent: (event: string, data: unknown) => void;
+  onError?: (msg: string) => void;
+}
+
+export async function consumeStructuredStream(
+  response: Response,
+  options: StructuredStreamOptions
+): Promise<void> {
+  if (!response.body) return;
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let currentEvent = 'message';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        if (line.startsWith('event: ')) {
+          currentEvent = line.slice(7).trim();
+        } else if (line.startsWith('data: ')) {
+          const raw = line.slice(6);
+          try {
+            const parsed = JSON.parse(raw);
+            const data = typeof parsed === 'string' ? JSON.parse(parsed) : parsed;
+            options.onEvent(currentEvent, data);
+          } catch {
+            options.onError?.(raw);
+          }
+          currentEvent = 'message';
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/frontend/src/routes/generate/+page.svelte
+++ b/frontend/src/routes/generate/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { activeProfile } from '$lib/activeProfile.svelte';
-  import { generateCv, generateCvPdf, getProfile } from '$lib/api';
+  import { generateCvPdf, generateCvStream, getProfile } from '$lib/api';
   import CvPreview from '$lib/components/CvPreview.svelte';
   import EmptyState from '$lib/components/EmptyState.svelte';
   import PageHeader from '$lib/components/PageHeader.svelte';
@@ -9,6 +9,7 @@
   import { Label } from '$lib/components/ui/label';
   import { Skeleton } from '$lib/components/ui/skeleton';
   import { Textarea } from '$lib/components/ui/textarea';
+  import { consumeStructuredStream } from '$lib/stream';
   import { toastState } from '$lib/toast.svelte';
   import type { ProfileData } from '$lib/types';
   import { errorMessage } from '$lib/utils';
@@ -22,10 +23,12 @@
   let enhanced = $state(false);
   let loading = $state(false);
   let downloading = $state(false);
-  let previewEl: HTMLDivElement | undefined = $state(undefined);
   let jobDescription = $state('');
   let activeProfileData: ProfileData | null = $state(null);
   let profileLoading = $state(true);
+
+  // Always show something in the preview: the generated CV if available, else the raw profile
+  const previewProfile = $derived(profile ?? activeProfileData);
 
   const isProfileEmpty = $derived.by(() => {
     if (profileLoading || !activeProfileData) return true;
@@ -54,16 +57,33 @@
     if (!ap) return;
     loading = true;
     profile = null;
+    enhanced = false;
     try {
-      const res = await generateCv({ profile_id: ap.id, enhance: true, job_description: jobDescription.trim() || null });
-      profile = res.profile;
-      enhanced = res.enhanced;
-      toastState.success('CV Generated Successfully!');
-      confetti({
-        particleCount: 150,
-        spread: 70,
-        origin: { y: 0.6 },
-        colors: ['#3b82f6', '#8b5cf6', '#10b981']
+      const response = await generateCvStream({
+        profile_id: ap.id,
+        enhance: true,
+        job_description: jobDescription.trim() || null,
+      });
+      await consumeStructuredStream(response, {
+        onEvent(event, eventData) {
+          if (event === 'done') {
+            const d = eventData as { enhanced: boolean; profile: ProfileData; id: number };
+            profile = d.profile;
+            enhanced = d.enhanced;
+            toastState.success('CV Generated Successfully!');
+            confetti({
+              particleCount: 150,
+              spread: 70,
+              origin: { y: 0.6 },
+              colors: ['#3b82f6', '#8b5cf6', '#10b981'],
+            });
+          } else if (event === 'rate_limit') {
+            toastState.error(`Rate limit reached. Please wait before generating again.`);
+          }
+        },
+        onError(msg) {
+          toastState.error(`Generation failed: ${msg}`);
+        },
       });
     } catch (e: unknown) {
       toastState.error(`Generation failed: ${errorMessage(e)}`);
@@ -92,133 +112,152 @@
   }
 </script>
 
-
-<div class="space-y-8 max-w-4xl pb-10 relative">
+<div class="pb-10">
   <PageHeader
     title="Generate CV"
     subtitle="Create an ATS-optimized CV tailored from your profile."
-  >
-    {#snippet actions()}
-      {#if profile}
-        <Button variant="outline" size="sm" onclick={handleDownloadPdf} disabled={downloading} class="shadow-sm">
-          <Download class="w-4 h-4 mr-2" />
-          {downloading ? 'Downloading…' : 'Download PDF'}
-        </Button>
+  />
+
+  <div class="mt-6 lg:grid lg:grid-cols-2 lg:gap-10 lg:items-start">
+
+    <!-- Left panel: controls (sticky on desktop) -->
+    <div class="lg:sticky lg:top-6 space-y-5">
+
+      <div class="space-y-2">
+        <Label for="jd" class="font-semibold">
+          Job Description
+          <span class="text-muted-foreground text-xs font-normal">(optional — helps AI tailor your CV)</span>
+        </Label>
+        <Textarea
+          id="jd"
+          bind:value={jobDescription}
+          placeholder="Paste the job posting here to get a CV tailored to this specific role…"
+          rows={6}
+          class="bg-background/50 resize-y max-h-[40vh]"
+        />
+      </div>
+
+      {#if activeProfile.current}
+        <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-muted/50 border text-sm">
+          <span class="text-base leading-none">{activeProfile.current.icon}</span>
+          <span class="font-medium">{activeProfile.current.label}</span>
+        </div>
       {/if}
-      <Button onclick={handleGenerate} disabled={loading || !isOnboarded || isProfileEmpty || profileLoading} size="sm" class="shadow-md h-9">
-        {#if !isOnboarded}
-          <Lock class="w-4 h-4 mr-2" /> Locked
-        {:else}
-          <Sparkles class="w-4 h-4 mr-2 {loading ? 'animate-pulse' : ''}" />
-          {loading ? 'Generating…' : 'Generate ATS CV'}
-        {/if}
-      </Button>
-    {/snippet}
-  </PageHeader>
 
-  <!-- Job Description + Profile Context -->
-  <div class="grid sm:grid-cols-[1fr_auto] gap-4 items-start">
-    <div class="space-y-2">
-      <Label for="jd" class="font-semibold">Job Description <span class="text-muted-foreground text-xs font-normal">(optional — helps AI tailor your CV)</span></Label>
-      <Textarea
-        id="jd"
-        bind:value={jobDescription}
-        placeholder="Paste the job posting here to get a CV tailored to this specific role…"
-        rows={4}
-        class="bg-background/50 resize-y max-h-[30vh]"
-      />
-    </div>
-    {#if activeProfile.current}
-      <div class="flex items-center gap-2 sm:mt-7 px-3 py-2 rounded-lg bg-muted/50 border text-sm shrink-0">
-        <span class="text-base leading-none">{activeProfile.current.icon}</span>
-        <span class="font-medium">{activeProfile.current.label}</span>
-      </div>
-    {/if}
-  </div>
-
-  {#if !profile && !loading}
-    {#if isProfileEmpty}
-      <Card class="border-dashed border-2 border-yellow-400/60 bg-yellow-50/30 dark:bg-yellow-900/10">
-        <CardContent>
-          <EmptyState
-            icon={UserRoundPen}
-            iconClass="text-yellow-600 dark:text-yellow-400"
-            iconBg="bg-yellow-100 dark:bg-yellow-900/30"
-            title="Profile is empty"
-            description="Add your work experience, education, or skills to {activeProfile.current?.label ?? 'this profile'} before generating a CV."
-          >
-            <Button href="/profile" variant="default">Fill in my profile</Button>
-          </EmptyState>
-        </CardContent>
-      </Card>
-    {:else}
-      <Card class="border-dashed border-2 bg-muted/30">
-        <CardContent>
-          <EmptyState
-            icon={FileText}
-            title="Ready to generate your CV?"
-            description='Click the "Generate ATS CV" button above to dynamically create a beautifully formatted resume. If your API key is configured, AI will enhance your bullet points for ATS systems.'
-          />
-        </CardContent>
-      </Card>
-    {/if}
-  {/if}
-
-  {#if loading}
-    <div class="space-y-4">
-      <div class="flex items-center gap-2 text-sm bg-primary/5 p-3 rounded-lg border border-primary/20 animate-pulse">
-        <Sparkles class="w-4 h-4 text-primary" />
-        <span class="text-primary font-medium">AI is crafting your tailored CV...</span>
-      </div>
-      <div class="bg-muted/30 p-4 sm:p-8 rounded-xl border shadow-inner">
-        <div class="bg-white dark:bg-zinc-950/40 p-12 space-y-8 rounded-lg shadow-xl mx-auto max-w-212.5 min-h-150 transition-colors">
-          <div class="space-y-4">
-            <Skeleton class="h-10 w-1/3" />
-            <Skeleton class="h-4 w-1/4" />
-          </div>
-          <div class="space-y-2">
-            <Skeleton class="h-4 w-full" />
-            <Skeleton class="h-4 w-full" />
-            <Skeleton class="h-4 w-2/3" />
-          </div>
-          <div class="space-y-6 pt-8">
-            {#each Array(3) as _}
-              <div class="space-y-3">
-                <Skeleton class="h-6 w-1/4" />
-                <Skeleton class="h-4 w-full" />
-                <Skeleton class="h-4 w-5/6" />
-              </div>
-            {/each}
-          </div>
-        </div>
-      </div>
-    </div>
-  {/if}
-
-  {#if profile}
-    <div class="animate-in fade-in slide-in-from-bottom-4 duration-500 space-y-4">
-      <div class="flex items-center gap-2 text-sm bg-muted/50 p-3 rounded-lg border">
-        {#if enhanced}
-          <div class="flex items-center gap-1.5 font-medium text-amber-600 dark:text-amber-400">
-            <Sparkles class="w-4 h-4" /> AI Enhanced
-          </div>
-          <span class="text-muted-foreground flex-1">— Your CV was optimized with AI assistance.</span>
-        {:else}
-          <div class="font-medium text-muted-foreground">No Enhancement</div>
-          <span class="text-muted-foreground flex-1">— Generated from profile without AI (API key not set).</span>
-        {/if}
-      </div>
-
-      <div class="bg-muted/30 p-4 sm:p-8 rounded-xl border shadow-inner">
-        <div
-          class="border rounded-lg overflow-hidden bg-white dark:bg-zinc-950/40 print:bg-white print:border-0 print:shadow-none shadow-xl mx-auto max-w-212.5 transition-colors"
-          bind:this={previewEl}
+      <div class="flex flex-wrap gap-3">
+        <Button
+          onclick={handleGenerate}
+          disabled={loading || !isOnboarded || isProfileEmpty || profileLoading}
+          class="shadow-md"
         >
-          <CvPreview {profile} />
-        </div>
+          {#if !isOnboarded}
+            <Lock class="w-4 h-4 mr-2" /> Locked
+          {:else}
+            <Sparkles class="w-4 h-4 mr-2 {loading ? 'animate-pulse' : ''}" />
+            {loading ? 'Generating…' : 'Generate ATS CV'}
+          {/if}
+        </Button>
+
+        {#if profile}
+          <Button variant="outline" onclick={handleDownloadPdf} disabled={downloading} class="shadow-sm">
+            <Download class="w-4 h-4 mr-2" />
+            {downloading ? 'Downloading…' : 'Download PDF'}
+          </Button>
+        {/if}
       </div>
+
+      <!-- Status messages -->
+      {#if loading}
+        <div class="flex items-center gap-2 text-sm bg-primary/5 p-3 rounded-lg border border-primary/20 animate-pulse">
+          <Sparkles class="w-4 h-4 text-primary" />
+          <span class="text-primary font-medium">AI is crafting your tailored CV…</span>
+        </div>
+      {:else if profile}
+        <div class="flex items-center gap-2 text-sm bg-muted/50 p-3 rounded-lg border">
+          {#if enhanced}
+            <div class="flex items-center gap-1.5 font-medium text-amber-600 dark:text-amber-400">
+              <Sparkles class="w-4 h-4" /> AI Enhanced
+            </div>
+            <span class="text-muted-foreground flex-1">— Your CV was optimized with AI assistance.</span>
+          {:else}
+            <div class="font-medium text-muted-foreground">No Enhancement</div>
+            <span class="text-muted-foreground flex-1">— Generated from profile without AI (API key not set).</span>
+          {/if}
+        </div>
+      {:else if isProfileEmpty && !profileLoading}
+        <Card class="border-dashed border-2 border-yellow-400/60 bg-yellow-50/30 dark:bg-yellow-900/10">
+          <CardContent>
+            <EmptyState
+              icon={UserRoundPen}
+              iconClass="text-yellow-600 dark:text-yellow-400"
+              iconBg="bg-yellow-100 dark:bg-yellow-900/30"
+              title="Profile is empty"
+              description="Add your work experience, education, or skills to {activeProfile.current?.label ?? 'this profile'} before generating a CV."
+            >
+              <Button href="/profile" variant="default">Fill in my profile</Button>
+            </EmptyState>
+          </CardContent>
+        </Card>
+      {/if}
     </div>
-  {/if}
+
+    <!-- Right panel: live CV preview -->
+    <div class="mt-8 lg:mt-0">
+      {#if profileLoading}
+        <div class="bg-muted/30 p-4 sm:p-8 rounded-xl border shadow-inner">
+          <div class="bg-white dark:bg-zinc-950/40 p-12 space-y-8 rounded-lg shadow-xl mx-auto max-w-212.5 min-h-150 transition-colors">
+            <div class="space-y-4">
+              <Skeleton class="h-10 w-1/3" />
+              <Skeleton class="h-4 w-1/4" />
+            </div>
+            <div class="space-y-2">
+              <Skeleton class="h-4 w-full" />
+              <Skeleton class="h-4 w-full" />
+              <Skeleton class="h-4 w-2/3" />
+            </div>
+            <div class="space-y-6 pt-8">
+              {#each Array(3) as _}
+                <div class="space-y-3">
+                  <Skeleton class="h-6 w-1/4" />
+                  <Skeleton class="h-4 w-full" />
+                  <Skeleton class="h-4 w-5/6" />
+                </div>
+              {/each}
+            </div>
+          </div>
+        </div>
+
+      {:else if previewProfile}
+        <div class="relative">
+          {#if loading}
+            <div class="absolute inset-0 bg-background/60 backdrop-blur-[2px] rounded-xl z-10 flex items-center justify-center pointer-events-none">
+              <div class="flex items-center gap-2 text-sm font-medium text-primary bg-background border rounded-lg px-4 py-2 shadow-lg">
+                <Sparkles class="w-4 h-4 animate-pulse" />
+                Enhancing with AI…
+              </div>
+            </div>
+          {/if}
+          <div class="bg-muted/30 p-4 sm:p-8 rounded-xl border shadow-inner transition-opacity duration-300 {loading ? 'opacity-60' : 'opacity-100'}">
+            <div class="border rounded-lg overflow-hidden bg-white dark:bg-zinc-950/40 print:bg-white print:border-0 print:shadow-none shadow-xl mx-auto max-w-212.5 transition-colors">
+              <CvPreview profile={previewProfile} />
+            </div>
+          </div>
+        </div>
+
+      {:else}
+        <Card class="border-dashed border-2 bg-muted/30 min-h-64 flex items-center">
+          <CardContent class="w-full">
+            <EmptyState
+              icon={FileText}
+              title="CV preview will appear here"
+              description="Set up your profile and click Generate to see your CV."
+            />
+          </CardContent>
+        </Card>
+      {/if}
+    </div>
+
+  </div>
 </div>
 
 <style>


### PR DESCRIPTION
## Summary

- Refactors the Generate CV page into a two-column split-screen layout — left panel has form/controls, right panel shows a live CV preview at all times
- Adds `POST /generate/cv/stream` SSE endpoint that emits the original profile immediately, then runs LLM enhancement in a thread pool, then emits the final result + saved DB id
- Right panel shows the current profile before generation and updates in-place with the enhanced result after — no more blank waiting state
- Adds blur overlay with "Enhancing with AI…" indicator on the preview during generation
- Fixes `datetime` JSON serialization error in the stream endpoint (`model_dump(mode="json")`)
- Adds `consumeStructuredStream` helper to `stream.ts` for typed SSE events
- Adds `generateCvStream` to `api.ts`

## Test plan

- [ ] Open `/generate` — right panel should immediately show your current profile as a CV preview
- [ ] Click Generate — right panel stays visible with blur overlay while AI enhances
- [ ] After completion — overlay disappears, preview updates to enhanced CV, enhancement badge appears
- [ ] Switch profiles — right panel updates immediately to new profile
- [ ] Download PDF still works after generation
- [ ] On mobile (< lg breakpoint) — single column, preview stacks below form