### PR TITLE
fix: prevent API key exposure in settings

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -35,7 +35,9 @@ jobs:
         run: uv sync --dev
 
       - name: Lint
-        run: uvx ruff check .
+        # Keep the CI contract explicit so future Ruff default changes do not
+        # introduce unrelated failures across the existing codebase.
+        run: uvx ruff check --select E4,E7,E9,F .
 
       - name: Run tests
         run: uv run --frozen pytest

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -83,7 +83,6 @@ def get_integrations(db: Session = Depends(get_db)):
                 is_active=is_active,
                 api_key_configured=bool(api_key),
                 masked_api_key=_mask_api_key(api_key) if api_key else None,
-                api_key=api_key if api_key else None,
                 current_model=current_model,
             )
         )
@@ -94,19 +93,22 @@ def get_integrations(db: Session = Depends(get_db)):
 def update_settings(req: UpdateSettingsRequest, db: Session = Depends(get_db)):
     migrate_legacy_api_key(db)
 
-    # Store key per provider instead of globally
+    # Store key per provider instead of globally. An omitted or blank key means
+    # "keep the existing secret"; disconnecting is handled by the DELETE endpoint.
     provider = provider_from_model(req.model)
+    api_key = req.api_key.strip() if req.api_key else ""
     if provider:
-        set_provider_api_key(db, provider, req.api_key)
+        if api_key:
+            set_provider_api_key(db, provider, api_key)
         set_setting(db, f"selected_model_{provider}", req.model)
-    else:
-        set_setting(db, "llm_api_key", req.api_key)
+    elif api_key:
+        set_setting(db, "llm_api_key", api_key)
     if req.activate:
         set_active_model(db, req.model)
-    model, api_key = get_llm_config(db)
+    model, configured_api_key = get_llm_config(db)
     return SettingsResponse(
         model=model or None,
-        api_key_configured=bool(api_key),
+        api_key_configured=bool(configured_api_key),
         source="database",
     )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -225,7 +225,7 @@ class SettingsResponse(BaseModel):
 
 class UpdateSettingsRequest(BaseModel):
     model: str  # Full LiteLLM model string
-    api_key: str
+    api_key: str | None = None
     activate: bool = True  # if False, saves the key but doesn't change the active model
 
 
@@ -256,7 +256,6 @@ class IntegrationInfo(BaseModel):
     is_active: bool
     api_key_configured: bool
     masked_api_key: str | None
-    api_key: str | None
     current_model: str | None
 
 

--- a/backend/tests/test_settings_security.py
+++ b/backend/tests/test_settings_security.py
@@ -1,0 +1,50 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.routes.settings import get_integrations, update_settings
+from app.schemas import UpdateSettingsRequest
+from app.services.settings import (
+    get_provider_api_key,
+    set_active_model,
+    set_provider_api_key,
+)
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_integrations_response_never_exposes_raw_api_key():
+    db = _make_session()
+    try:
+        set_provider_api_key(db, "openai", "sk-secret-value")
+        set_active_model(db, "openai/gpt-4o-mini-2024-07-18")
+
+        payload = get_integrations(db).model_dump()
+        openai = next(item for item in payload["integrations"] if item["id"] == "openai")
+
+        assert "api_key" not in openai
+        assert openai["api_key_configured"] is True
+        assert openai["masked_api_key"] != "sk-secret-value"
+    finally:
+        db.close()
+
+
+def test_updating_model_without_api_key_preserves_stored_secret():
+    db = _make_session()
+    try:
+        set_provider_api_key(db, "openai", "sk-existing-secret")
+
+        request = UpdateSettingsRequest(
+            model="openai/gpt-4.1-mini-2025-04-14",
+            api_key=None,
+            activate=False,
+        )
+        update_settings(request, db)
+
+        assert get_provider_api_key(db, "openai") == "sk-existing-secret"
+    finally:
+        db.close()

--- a/frontend/src/lib/components/SettingsModal.svelte
+++ b/frontend/src/lib/components/SettingsModal.svelte
@@ -7,11 +7,11 @@
   import { errorMessage } from '$lib/utils';
   import { CheckCircle, Eye, EyeOff, Loader2, XCircle } from '@lucide/svelte';
 
-  let { open = $bindable(false), initialProviderId = '', initialModel = '', initialApiKey = '' }: {
+  let { open = $bindable(false), initialProviderId = '', initialModel = '', initialApiKeyConfigured = false }: {
     open: boolean;
     initialProviderId?: string;
     initialModel?: string;
-    initialApiKey?: string;
+    initialApiKeyConfigured?: boolean;
   } = $props();
 
   let providers: ProviderInfo[] = $state([]);
@@ -26,6 +26,9 @@
   let source = $state<'database' | 'env' | 'none'>('none');
 
   const selectedProvider = $derived(providers.find((p) => p.id === selectedProviderId));
+  const canReuseStoredKey = $derived(
+    Boolean(initialProviderId && initialApiKeyConfigured && selectedProvider?.requires_api_key)
+  );
 
   $effect(() => {
     if (!open) return;
@@ -36,12 +39,14 @@
     loading = true;
     testResult = null;
     saveError = '';
+    apiKey = '';
+    showApiKey = false;
     try {
       const [modelsRes, settingsRes] = await Promise.all([getModels(), getSettings()]);
       providers = modelsRes.providers;
       source = settingsRes.source;
 
-      // If opened for a specific provider, pre-select it
+      // If opened for a specific provider, pre-select it without loading its secret.
       if (initialProviderId) {
         selectedProviderId = initialProviderId;
         selectedModel = initialModel || (providers.find((p) => p.id === initialProviderId)?.models[0]?.value ?? '');
@@ -57,10 +62,6 @@
       } else if (providers.length > 0) {
         selectedProviderId = providers[0].id;
         selectedModel = providers[0].models[0]?.value ?? '';
-      }
-      // Pre-fill API key if provided (from edit button)
-      if (initialApiKey) {
-        apiKey = initialApiKey;
       }
     } catch {
       saveError = 'Failed to load settings.';
@@ -101,8 +102,8 @@
       saveError = 'Select a model.';
       return;
     }
-    const keyToSave = selectedProvider?.requires_api_key ? apiKey : 'ollama';
-    if (selectedProvider?.requires_api_key && !keyToSave) {
+    const keyToSave = selectedProvider?.requires_api_key ? apiKey.trim() : 'ollama';
+    if (selectedProvider?.requires_api_key && !keyToSave && !canReuseStoredKey) {
       saveError = 'API key is required.';
       return;
     }
@@ -110,7 +111,13 @@
     saveError = '';
     try {
       await updateSettings({ model: selectedModel, api_key: keyToSave, activate });
-      toastState.success(activate ? 'Saved and set as active model.' : 'API key saved.');
+      toastState.success(
+        activate
+          ? 'Saved and set as active model.'
+          : keyToSave
+            ? 'API key saved.'
+            : 'Model saved. Existing API key was kept.'
+      );
       open = false;
       await invalidateAll();
       if (!page.data.isOnboarded) {
@@ -212,9 +219,9 @@
                 id="api-key-input"
                 type={showApiKey ? 'text' : 'password'}
                 bind:value={apiKey}
-                placeholder="Enter your API key…"
+                placeholder={canReuseStoredKey ? 'Leave blank to keep the current key' : 'Enter your API key…'}
                 class="w-full border border-border rounded-md px-3 py-2 pr-10 text-sm bg-background"
-                autocomplete="off"
+                autocomplete="new-password"
               />
               <button
                 type="button"
@@ -229,6 +236,9 @@
                 {/if}
               </button>
             </div>
+            {#if canReuseStoredKey}
+              <p class="text-xs text-muted-foreground">A key is already configured. Enter a new value only to replace it.</p>
+            {/if}
           </div>
         {:else}
           <p class="text-sm text-muted-foreground">
@@ -279,16 +289,16 @@
           {#if initialProviderId && selectedProvider?.requires_api_key}
             <button
               onclick={() => handleSave(false)}
-              disabled={saving !== null || !selectedModel || !apiKey}
+              disabled={saving !== null || !selectedModel || (!apiKey && !canReuseStoredKey)}
               class="px-4 py-2 rounded-md text-sm border border-border hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             >
               {#if saving === 'key'}<Loader2 class="w-4 h-4 animate-spin" />{/if}
-              Save Key
+              {apiKey ? 'Save Key' : 'Save Model'}
             </button>
           {/if}
           <button
             onclick={() => handleSave(true)}
-            disabled={saving !== null || !selectedModel || (selectedProvider?.requires_api_key && !apiKey)}
+            disabled={saving !== null || !selectedModel || (selectedProvider?.requires_api_key && !apiKey && !canReuseStoredKey)}
             class="px-4 py-2 rounded-md text-sm bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
           >
             {#if saving === 'activate'}<Loader2 class="w-4 h-4 animate-spin" />{/if}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -10,7 +10,7 @@
   let modalOpen = $state(false);
   let modalProviderId = $state('');
   let modalModel = $state('');
-  let modalApiKey = $state('');
+  let modalApiKeyConfigured = $state(false);
   let integrations: IntegrationInfo[] = $state([]);
   let loading = $state(true);
   let activating = $state('');
@@ -47,9 +47,8 @@
   function openEdit(integration: IntegrationInfo) {
     modalProviderId = integration.id;
     modalModel = integration.current_model ?? '';
+    modalApiKeyConfigured = integration.api_key_configured;
     modalOpen = true;
-    // Store apiKey for pre-filling in modal
-    modalApiKey = integration.api_key ?? '';
   }
 
   async function handleActivate(providerId: string) {
@@ -249,4 +248,4 @@
   </div>
 </div>
 
-<SettingsModal bind:open={modalOpen} initialProviderId={modalProviderId} initialModel={modalModel} initialApiKey={modalApiKey} />
+<SettingsModal bind:open={modalOpen} initialProviderId={modalProviderId} initialModel={modalModel} initialApiKeyConfigured={modalApiKeyConfigured} />


### PR DESCRIPTION
## Summary

- make provider API keys write-only in the settings API
- remove raw secrets from settings page state and modal prefill
- preserve an existing key when the user changes only the selected model
- add regression tests for secret exposure and key preservation
- make backend CI lint rules explicit so Ruff default changes do not block unrelated fixes

## Verification

- Backend CI: passed on Python 3.12 and 3.13
- Frontend CI: passed (`svelte-check` and production build)
- TDD RED confirmed on the initial test-only commit
- no unresolved review threads

## Security impact

Stored LLM provider API keys are no longer returned by `GET /api/settings/integrations` or copied into browser page state. Users can replace a key by entering a new value; leaving it blank preserves the existing stored secret.