### PR TITLE
fix: bind Docker services to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   backend:
     build: ./backend
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     volumes:
       - applykit-data:/data
     environment:
@@ -19,7 +19,7 @@ services:
         # For a remote server: change to your domain, e.g. https://applykit.example.com/api
         VITE_API_BASE_URL: http://localhost:8000/api
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     depends_on:
       - backend
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- bind the backend port to `127.0.0.1:8000`
- bind the frontend port to `127.0.0.1:3000`
- keep existing container networking and browser URLs unchanged

## Security impact

ApplyKit has no built-in authentication. The default Compose configuration now prevents the services from listening on every host network interface.

## Verification

- parsed the modified Compose YAML successfully
- asserted both published ports use the loopback interface

No GitHub workflow currently targets changes limited to `docker-compose.yml`.