### PR TITLE
fix: reuse HTTP client across application requests

### DIFF
--- a/backend/app/http_client.py
+++ b/backend/app/http_client.py
@@ -1,15 +1,36 @@
-"""Shared HTTP client via async context manager."""
-
-from collections.abc import AsyncGenerator
+"""Application-scoped HTTP client lifecycle."""
 
 import httpx
 
+_client: httpx.AsyncClient | None = None
 
-async def get_http_client() -> AsyncGenerator[httpx.AsyncClient, None]:
-    """FastAPI dependency — yields async context manager."""
-    async with httpx.AsyncClient(
+
+def _create_http_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
         timeout=httpx.Timeout(15.0, connect=5.0),
         follow_redirects=True,
         limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
-    ) as client:
-        yield client
+    )
+
+
+async def start_http_client() -> httpx.AsyncClient:
+    """Create the shared client once when the application starts."""
+    global _client
+    if _client is None or _client.is_closed:
+        _client = _create_http_client()
+    return _client
+
+
+async def stop_http_client() -> None:
+    """Close and clear the shared client during application shutdown."""
+    global _client
+    if _client is not None and not _client.is_closed:
+        await _client.aclose()
+    _client = None
+
+
+def get_http_client() -> httpx.AsyncClient:
+    """FastAPI dependency returning the application-scoped client."""
+    if _client is None or _client.is_closed:
+        raise RuntimeError("HTTP client is not initialized")
+    return _client

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ from app.exceptions import (
     BaseCustomException,
     error_response,
 )
+from app.http_client import start_http_client, stop_http_client
 from app.routes import (
     analyze,
     applications,
@@ -29,7 +30,11 @@ _settings = get_settings()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    yield
+    await start_http_client()
+    try:
+        yield
+    finally:
+        await stop_http_client()
 
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:

--- a/backend/tests/test_http_client.py
+++ b/backend/tests/test_http_client.py
@@ -1,0 +1,25 @@
+import asyncio
+
+import pytest
+
+from app import http_client
+
+
+def test_http_client_is_reused_until_shutdown():
+    first = asyncio.run(http_client.start_http_client())
+    second = http_client.get_http_client()
+
+    try:
+        assert second is first
+        assert first.is_closed is False
+    finally:
+        asyncio.run(http_client.stop_http_client())
+
+    assert first.is_closed is True
+
+
+def test_http_client_dependency_requires_started_lifespan():
+    asyncio.run(http_client.stop_http_client())
+
+    with pytest.raises(RuntimeError, match="HTTP client is not initialized"):
+        http_client.get_http_client()


### PR DESCRIPTION
## Summary

- create one shared `httpx.AsyncClient` during application startup
- reuse its connection pool for scraper requests throughout the app lifespan
- close and clear the client during shutdown
- add regression coverage for reuse, closure, and uninitialized access

## Verification

- TDD RED: both Python jobs failed before lifecycle functions existed
- Backend CI: passed on Python 3.12 and 3.13
- timeout, redirect, and connection-limit settings remain unchanged

## Impact

Repeated scraper requests now benefit from connection pooling instead of creating and closing a new client for every request.