### PR TITLE
fix: correct usage query date and totals

### DIFF
--- a/backend/app/routes/usage.py
+++ b/backend/app/routes/usage.py
@@ -1,6 +1,7 @@
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, date, datetime, time, timedelta
+from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -18,8 +19,8 @@ def get_llm_usage(
     date_from: date | None = None,
     date_to: date | None = None,
     success: bool | None = None,
-    limit: int = 100,
-    offset: int = 0,
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+    offset: Annotated[int, Query(ge=0)] = 0,
     db: Session = Depends(get_db),
 ):
     """Get LLM usage logs with optional filters."""
@@ -30,22 +31,20 @@ def get_llm_usage(
     if profile_id:
         query = query.filter(LlmUsageLog.profile_id == profile_id)
     if date_from:
-        query = query.filter(LlmUsageLog.created_at >= date_from)
+        query = query.filter(
+            LlmUsageLog.created_at >= datetime.combine(date_from, time.min)
+        )
     if date_to:
-        query = query.filter(LlmUsageLog.created_at <= date_to)
+        next_day = datetime.combine(date_to + timedelta(days=1), time.min)
+        query = query.filter(LlmUsageLog.created_at < next_day)
     if success is not None:
         query = query.filter(LlmUsageLog.success == success)
 
     total = query.count()
-
-    totals = (
-        db.query(
-            func.sum(LlmUsageLog.total_tokens).label("total_tokens"),
-            func.sum(LlmUsageLog.cost).label("total_cost"),
-        )
-        .filter(LlmUsageLog.id.in_(query.limit(10000).with_entities(LlmUsageLog.id)))
-        .first()
-    )
+    totals = query.with_entities(
+        func.sum(LlmUsageLog.total_tokens).label("total_tokens"),
+        func.sum(LlmUsageLog.cost).label("total_cost"),
+    ).first()
 
     items = (
         query.order_by(LlmUsageLog.created_at.desc()).offset(offset).limit(limit).all()

--- a/backend/tests/test_usage_routes.py
+++ b/backend/tests/test_usage_routes.py
@@ -1,0 +1,60 @@
+from datetime import date, datetime
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base, LlmUsageLog
+from app.routes.usage import get_llm_usage
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _usage(created_at: datetime, total_tokens: int = 1) -> LlmUsageLog:
+    return LlmUsageLog(
+        created_at=created_at,
+        operation="cv_generation",
+        provider="openai",
+        model="gpt-4.1-mini",
+        total_tokens=total_tokens,
+        success=True,
+    )
+
+
+def test_date_to_includes_the_entire_selected_day():
+    db = _make_session()
+    try:
+        db.add_all(
+            [
+                _usage(datetime(2026, 7, 30, 23, 59, 59)),
+                _usage(datetime(2026, 7, 31, 0, 0, 0)),
+            ]
+        )
+        db.commit()
+
+        response = get_llm_usage(date_to=date(2026, 7, 30), db=db)
+
+        assert response.total == 1
+        assert response.items[0].created_at == datetime(2026, 7, 30, 23, 59, 59)
+    finally:
+        db.close()
+
+
+def test_usage_totals_include_more_than_ten_thousand_rows():
+    db = _make_session()
+    try:
+        db.bulk_save_objects(
+            [_usage(datetime(2026, 7, 30, 12, 0, 0)) for _ in range(10_001)]
+        )
+        db.commit()
+
+        response = get_llm_usage(limit=1, db=db)
+
+        assert response.total == 10_001
+        assert response.total_tokens == 10_001
+        assert len(response.items) == 1
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary

- make `date_to` include the entire selected calendar day
- calculate token and cost totals across every matching row instead of capping at 10,000
- keep aggregate totals independent from response pagination
- validate `limit` between 1–500 and require a non-negative offset

## Verification

- TDD RED: both Python jobs failed on the midnight cutoff and total truncation
- Backend CI: passed on Python 3.12 and 3.13
- regression suite verifies 10,001 matching usage rows while returning one paginated item

## Impact

Usage analytics now report complete date ranges and accurate totals for larger local histories.