### PR TITLE
feat: centralize exception handling

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Unit tests
+        run: bun run test
+
       - name: Type check
         run: bun run check
 

--- a/backend/app/exceptions/__init__.py
+++ b/backend/app/exceptions/__init__.py
@@ -1,22 +1,36 @@
 from app.exceptions.base import (
+    AppError,
     BaseCustomException,
-    ConflictError,
-    InternalServerError,
-    NotFoundError,
-    RateLimitError,
-    StorageError,
-    ValidationError,
+    ErrorBody,
+    ErrorCode,
+    ErrorEnvelope,
     error_response,
     not_found_404,
 )
+from app.exceptions.infrastructure import (
+    AIProcessingError,
+    InternalApplicationError,
+    InternalServerError,
+    RateLimitError,
+    StorageError,
+)
 from app.exceptions.llm import APIKeyNotConfiguredError, LLMCallError, LLMOutputError
+from app.exceptions.request import ValidationAppError, ValidationError
+from app.exceptions.resource import ConflictError, NotFoundError
 
 __all__ = [
+    "AppError",
     "BaseCustomException",
+    "ErrorCode",
+    "ErrorBody",
+    "ErrorEnvelope",
     "NotFoundError",
+    "ValidationAppError",
     "ValidationError",
     "ConflictError",
+    "InternalApplicationError",
     "InternalServerError",
+    "AIProcessingError",
     "RateLimitError",
     "StorageError",
     "APIKeyNotConfiguredError",

--- a/backend/app/exceptions/base.py
+++ b/backend/app/exceptions/base.py
@@ -1,140 +1,116 @@
-from datetime import UTC, datetime
-from typing import Any
+from __future__ import annotations
 
-from fastapi import HTTPException, status
+from copy import deepcopy
+from enum import StrEnum
+from typing import Any, ClassVar
+
+from fastapi import HTTPException
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class BaseCustomException(HTTPException):
-    """Base custom exception class with structured error information."""
+class ErrorCode(StrEnum):
+    """Stable machine-readable error codes exposed by the API."""
+
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    HTTP_ERROR = "HTTP_ERROR"
+    INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR"
+    RESOURCE_NOT_FOUND = "RESOURCE_NOT_FOUND"
+    RESOURCE_CONFLICT = "RESOURCE_CONFLICT"
+    AI_PROCESSING_ERROR = "AI_PROCESSING_ERROR"
+    RATE_LIMIT_EXCEEDED = "RATE_LIMIT_EXCEEDED"
+    STORAGE_ERROR = "STORAGE_ERROR"
+    API_KEY_NOT_CONFIGURED = "API_KEY_NOT_CONFIGURED"
+    LLM_CALL_FAILED = "LLM_CALL_FAILED"
+    LLM_OUTPUT_INVALID = "LLM_OUTPUT_INVALID"
+
+    # Legacy route codes retained during incremental migration.
+    PROFILE_NOT_FOUND = "PROFILE_NOT_FOUND"
+    APPLICATION_NOT_FOUND = "APPLICATION_NOT_FOUND"
+    NOT_FOUND = "NOT_FOUND"
+    SCRAPE_VALUE_ERROR = "SCRAPE_VALUE_ERROR"
+    SCRAPE_FAILED = "SCRAPE_FAILED"
+    INVALID_REQUEST = "INVALID_REQUEST"
+    FILE_TOO_LARGE = "FILE_TOO_LARGE"
+    FILE_TYPE_UNSUPPORTED = "FILE_TYPE_UNSUPPORTED"
+    FILE_PARSE_FAILED = "FILE_PARSE_FAILED"
+    PDF_RENDER_FAILED = "PDF_RENDER_FAILED"
+
+
+class ErrorBody(BaseModel):
+    """Public error fields returned to API clients."""
+
+    model_config = ConfigDict(frozen=True)
+
+    code: ErrorCode
+    message: str
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class ErrorEnvelope(BaseModel):
+    """Top-level public error response."""
+
+    model_config = ConfigDict(frozen=True)
+
+    error: ErrorBody
+
+
+class AppError(Exception):
+    """Base type for expected application failures."""
+
+    code: ClassVar[ErrorCode]
+    status_code: ClassVar[int]
+    default_message: ClassVar[str]
 
     def __init__(
         self,
-        message: str | list[str],
-        status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR,
-        error_code: str | None = None,
-        details: dict[str, Any] | None = None,
-    ) -> None:
-        super().__init__(status_code=status_code, detail=message)
-        self.message = message
-        self.error_code = error_code or self.__class__.__name__.upper()
-        self.details = details or {}
-
-
-class NotFoundError(BaseCustomException):
-    """Exception for resource not found errors."""
-
-    def __init__(self, resource: str, identifier: str | int) -> None:
-        message = f"{resource} with identifier '{identifier}' not found"
-        error_code = f"{resource.upper()}_NOT_FOUND"
-        super().__init__(
-            message=message,
-            status_code=status.HTTP_404_NOT_FOUND,
-            error_code=error_code,
-        )
-
-
-class ValidationError(BaseCustomException):
-    """Exception for validation errors."""
-
-    def __init__(
-        self,
-        message: str | list[str],
-        field: str | None = None,
-    ) -> None:
-        details = {"field": field} if field else {}
-        super().__init__(
-            message=message,
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            error_code="VALIDATION_ERROR",
-            details=details,
-        )
-
-
-class ConflictError(BaseCustomException):
-    """Exception for resource conflict errors (e.g., duplicate ID)."""
-
-    def __init__(
-        self,
-        resource: str,
-        identifier: str | int,
         message: str | None = None,
-    ) -> None:
-        error_message = (
-            message or f"{resource} with identifier '{identifier}' already exists"
-        )
-        error_code = f"{resource.upper()}_CONFLICT"
-        super().__init__(
-            message=error_message,
-            status_code=status.HTTP_409_CONFLICT,
-            error_code=error_code,
-        )
-
-
-class InternalServerError(BaseCustomException):
-    """Exception for internal server errors."""
-
-    def __init__(
-        self,
-        message: str = "An internal server error occurred",
+        *,
         details: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
-        super().__init__(
-            message=message,
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            error_code="INTERNAL_SERVER_ERROR",
-            details=details,
+        if type(self) is AppError:
+            raise TypeError("AppError cannot be instantiated directly")
+
+        error_type = type(self)
+        code = getattr(error_type, "code", None)
+        status_code = getattr(error_type, "status_code", None)
+        default_message = getattr(error_type, "default_message", None)
+
+        if not isinstance(code, ErrorCode):
+            raise TypeError(f"{error_type.__name__}.code must be an ErrorCode")
+        if not isinstance(status_code, int) or not 400 <= status_code <= 599:
+            raise TypeError(
+                f"{error_type.__name__}.status_code must be an integer from 400 to 599"
+            )
+        if not isinstance(default_message, str) or not default_message.strip():
+            raise TypeError(
+                f"{error_type.__name__}.default_message must be a non-empty string"
+            )
+        if message is not None and (not isinstance(message, str) or not message.strip()):
+            raise TypeError("AppError message must be a non-empty string")
+        if details is not None and not isinstance(details, dict):
+            raise TypeError("AppError details must be a dictionary")
+        if headers is not None and not isinstance(headers, dict):
+            raise TypeError("AppError headers must be a dictionary")
+
+        self.message = message or default_message
+        self.error_code = code.value
+        self.details = deepcopy(details) if details is not None else {}
+        self.headers = dict(headers) if headers is not None else {}
+        super().__init__(self.message)
+
+    def to_envelope(self) -> ErrorEnvelope:
+        return ErrorEnvelope(
+            error=ErrorBody(
+                code=self.code,
+                message=self.message,
+                details=deepcopy(self.details),
+            )
         )
 
 
-class AIProcessingError(BaseCustomException):
-    """Exception for AI processing errors."""
-
-    def __init__(
-        self,
-        message: str = "AI processing failed",
-        model: str | None = None,
-    ) -> None:
-        details = {"model": model} if model else {}
-        super().__init__(
-            message=message,
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            error_code="AI_PROCESSING_ERROR",
-            details=details,
-        )
-
-
-class RateLimitError(BaseCustomException):
-    """Exception for rate limit errors (HTTP 429)."""
-
-    def __init__(
-        self,
-        message: str = "Rate limit exceeded. Please retry later.",
-        retry_after: float | None = None,
-    ) -> None:
-        details = {"retry_after": retry_after} if retry_after else {}
-        super().__init__(
-            message=message,
-            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            error_code="RATE_LIMIT_EXCEEDED",
-            details=details,
-        )
-
-
-class StorageError(BaseCustomException):
-    """Exception for storage/upload errors."""
-
-    def __init__(
-        self,
-        message: str = "Storage operation failed",
-        operation: str | None = None,
-    ) -> None:
-        details = {"operation": operation} if operation else {}
-        super().__init__(
-            message=message,
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            error_code="STORAGE_ERROR",
-            details=details,
-        )
+# Transitional compatibility name for existing imports. New code should use AppError.
+BaseCustomException = AppError
 
 
 def error_response(
@@ -143,21 +119,28 @@ def error_response(
     error_code: str | None = None,
     details: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Create standardized error response."""
-    return {
-        "success": False,
-        "status_code": status_code,
-        "error_code": error_code,
-        "message": message,
-        "details": details or {},
-        "timestamp": datetime.now(UTC).isoformat(),
-    }
+    """Build the new envelope for callers using the legacy helper."""
+    del status_code
+    try:
+        code = ErrorCode(error_code) if error_code else ErrorCode.HTTP_ERROR
+    except ValueError:
+        code = ErrorCode.HTTP_ERROR
+    public_message = message if isinstance(message, str) else "; ".join(message)
+    return ErrorEnvelope(
+        error=ErrorBody(
+            code=code,
+            message=public_message,
+            details=deepcopy(details) if details is not None else {},
+        )
+    ).model_dump(mode="json")
 
 
 def not_found_404(resource: str = "Resource") -> HTTPException:
-    """Create a standardized 404 Not Found HTTPException."""
-    code = f"{resource.upper().replace(' ', '_')}_NOT_FOUND"
+    """Create a legacy 404 response that the global adapter can normalize."""
     return HTTPException(
         status_code=404,
-        detail={"detail": f"{resource} not found", "code": code},
+        detail={
+            "detail": f"{resource} not found",
+            "code": ErrorCode.RESOURCE_NOT_FOUND.value,
+        },
     )

--- a/backend/app/exceptions/handlers.py
+++ b/backend/app/exceptions/handlers.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from app.exceptions.base import AppError, ErrorCode, ErrorBody, ErrorEnvelope
+from app.exceptions.infrastructure import InternalApplicationError
+from app.exceptions.request import ValidationAppError
+
+logger = logging.getLogger(__name__)
+
+_LEGACY_PUBLIC_MESSAGES = {
+    ErrorCode.INTERNAL_SERVER_ERROR: "An unexpected error occurred",
+    ErrorCode.LLM_CALL_FAILED: "The AI provider request failed. Check your settings and try again.",
+    ErrorCode.PDF_RENDER_FAILED: "Could not generate the PDF. Please try again.",
+}
+
+
+def _response_for(exc: AppError) -> JSONResponse:
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=exc.to_envelope().model_dump(mode="json"),
+        headers=exc.headers or None,
+    )
+
+
+async def app_exception_handler(request: Request, exc: AppError) -> JSONResponse:
+    del request
+    return _response_for(exc)
+
+
+def _legacy_code(value: Any) -> ErrorCode:
+    if not isinstance(value, str):
+        return ErrorCode.HTTP_ERROR
+    try:
+        return ErrorCode(value)
+    except ValueError:
+        return ErrorCode.HTTP_ERROR
+
+
+def _legacy_message(detail: Any, code: ErrorCode) -> str:
+    if code in _LEGACY_PUBLIC_MESSAGES:
+        return _LEGACY_PUBLIC_MESSAGES[code]
+
+    candidate: Any = detail
+    if isinstance(detail, dict):
+        candidate = detail.get("detail", detail.get("message"))
+    if isinstance(candidate, str) and candidate.strip():
+        return candidate
+    return "Request failed."
+
+
+async def http_exception_handler(
+    request: Request, exc: HTTPException
+) -> JSONResponse:
+    del request
+    raw_code = None
+    if isinstance(exc.detail, dict):
+        raw_code = exc.detail.get("code", exc.detail.get("error_code"))
+    code = _legacy_code(raw_code)
+    envelope = ErrorEnvelope(
+        error=ErrorBody(
+            code=code,
+            message=_legacy_message(exc.detail, code),
+            details={},
+        )
+    )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=envelope.model_dump(mode="json"),
+        headers=exc.headers,
+    )
+
+
+async def validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    errors = [
+        {
+            "type": str(error.get("type", "validation_error")),
+            "location": [str(location) for location in error.get("loc", ())],
+            "message": str(error.get("msg", "Invalid input")),
+        }
+        for error in exc.errors()
+    ]
+    return await app_exception_handler(
+        request,
+        ValidationAppError(details={"errors": errors}),
+    )
+
+
+async def generic_exception_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    method = getattr(request, "method", "UNKNOWN")
+    path = getattr(getattr(request, "url", None), "path", "unknown")
+    logger.error(
+        "Unhandled exception for %s %s",
+        method,
+        path,
+        exc_info=(type(exc), exc, exc.__traceback__),
+    )
+    return _response_for(InternalApplicationError())
+
+
+exception_handlers = {
+    AppError: app_exception_handler,
+    HTTPException: http_exception_handler,
+    RequestValidationError: validation_exception_handler,
+    Exception: generic_exception_handler,
+}

--- a/backend/app/exceptions/handlers.py
+++ b/backend/app/exceptions/handlers.py
@@ -62,6 +62,8 @@ async def http_exception_handler(
     if isinstance(exc.detail, dict):
         raw_code = exc.detail.get("code", exc.detail.get("error_code"))
     code = _legacy_code(raw_code)
+    if exc.status_code >= 500 and code not in _LEGACY_PUBLIC_MESSAGES:
+        code = ErrorCode.INTERNAL_SERVER_ERROR
     envelope = ErrorEnvelope(
         error=ErrorBody(
             code=code,

--- a/backend/app/exceptions/infrastructure.py
+++ b/backend/app/exceptions/infrastructure.py
@@ -1,0 +1,68 @@
+from typing import Any
+
+from app.exceptions.base import AppError, ErrorCode
+from app.public_errors import UNEXPECTED_ERROR_MESSAGE
+
+
+class InternalApplicationError(AppError):
+    code = ErrorCode.INTERNAL_SERVER_ERROR
+    status_code = 500
+    default_message = UNEXPECTED_ERROR_MESSAGE
+
+
+class InternalServerError(InternalApplicationError):
+    """Compatibility wrapper for the previous public exception API."""
+
+    default_message = "An internal server error occurred"
+
+    def __init__(
+        self,
+        message: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, details=details)
+
+
+class AIProcessingError(AppError):
+    code = ErrorCode.AI_PROCESSING_ERROR
+    status_code = 500
+    default_message = "AI processing failed"
+
+    def __init__(
+        self,
+        message: str | None = None,
+        model: str | None = None,
+    ) -> None:
+        details = {"model": model} if model else {}
+        super().__init__(message, details=details)
+
+
+class RateLimitError(AppError):
+    code = ErrorCode.RATE_LIMIT_EXCEEDED
+    status_code = 429
+    default_message = "Rate limit exceeded. Please retry later."
+
+    def __init__(
+        self,
+        message: str | None = None,
+        retry_after: float | None = None,
+    ) -> None:
+        details = {"retry_after": retry_after} if retry_after is not None else {}
+        headers = (
+            {"Retry-After": str(retry_after)} if retry_after is not None else None
+        )
+        super().__init__(message, details=details, headers=headers)
+
+
+class StorageError(AppError):
+    code = ErrorCode.STORAGE_ERROR
+    status_code = 500
+    default_message = "Storage operation failed"
+
+    def __init__(
+        self,
+        message: str | None = None,
+        operation: str | None = None,
+    ) -> None:
+        details = {"operation": operation} if operation else {}
+        super().__init__(message, details=details)

--- a/backend/app/exceptions/llm.py
+++ b/backend/app/exceptions/llm.py
@@ -1,45 +1,23 @@
-"""LLM-specific exceptions — integrated with the global exception handler."""
+"""LLM-specific application errors."""
 
-from fastapi import status
-
-from app.exceptions.base import BaseCustomException
+from app.exceptions.base import AppError, ErrorCode
 
 
-class APIKeyNotConfiguredError(BaseCustomException):
-    """Raised when LLM API key is not configured."""
-
-    def __init__(
-        self, message: str = "LLM not configured. Set provider and API key in Settings."
-    ):
-        super().__init__(
-            message=message,
-            status_code=status.HTTP_400_BAD_REQUEST,
-            error_code="API_KEY_NOT_CONFIGURED",
-        )
+class APIKeyNotConfiguredError(AppError):
+    code = ErrorCode.API_KEY_NOT_CONFIGURED
+    status_code = 400
+    default_message = "LLM not configured. Set provider and API key in Settings."
 
 
-class LLMCallError(BaseCustomException):
-    """Raised when an LLM call fails."""
-
-    def __init__(self, message: str = "LLM call failed."):
-        super().__init__(
-            message=message,
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            error_code="LLM_CALL_FAILED",
-        )
+class LLMCallError(AppError):
+    code = ErrorCode.LLM_CALL_FAILED
+    status_code = 502
+    default_message = "LLM call failed."
 
 
-class LLMOutputError(BaseCustomException):
-    """Raised when an LLM response is not valid for the requested schema."""
-
-    def __init__(
-        self,
-        message: str = (
-            "The AI provider returned an invalid structured response. Please try again."
-        ),
-    ):
-        super().__init__(
-            message=message,
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            error_code="LLM_OUTPUT_INVALID",
-        )
+class LLMOutputError(AppError):
+    code = ErrorCode.LLM_OUTPUT_INVALID
+    status_code = 502
+    default_message = (
+        "The AI provider returned an invalid structured response. Please try again."
+    )

--- a/backend/app/exceptions/request.py
+++ b/backend/app/exceptions/request.py
@@ -1,0 +1,20 @@
+from app.exceptions.base import AppError, ErrorCode
+
+
+class ValidationAppError(AppError):
+    code = ErrorCode.VALIDATION_ERROR
+    status_code = 422
+    default_message = "Validation error."
+
+
+class ValidationError(ValidationAppError):
+    """Compatibility wrapper for the previous public exception API."""
+
+    def __init__(
+        self,
+        message: str | list[str],
+        field: str | None = None,
+    ) -> None:
+        public_message = message if isinstance(message, str) else "; ".join(message)
+        details = {"field": field} if field else {}
+        super().__init__(public_message, details=details)

--- a/backend/app/exceptions/resource.py
+++ b/backend/app/exceptions/resource.py
@@ -1,0 +1,30 @@
+from app.exceptions.base import AppError, ErrorCode
+
+
+class NotFoundError(AppError):
+    code = ErrorCode.RESOURCE_NOT_FOUND
+    status_code = 404
+    default_message = "Resource was not found."
+
+    def __init__(self, resource: str, identifier: str | int) -> None:
+        super().__init__(
+            f"{resource} with identifier '{identifier}' not found",
+            details={"resource": resource, "identifier": identifier},
+        )
+
+
+class ConflictError(AppError):
+    code = ErrorCode.RESOURCE_CONFLICT
+    status_code = 409
+    default_message = "Resource state conflicts with the request."
+
+    def __init__(
+        self,
+        resource: str,
+        identifier: str | int,
+        message: str | None = None,
+    ) -> None:
+        super().__init__(
+            message or f"{resource} with identifier '{identifier}' already exists",
+            details={"resource": resource, "identifier": identifier},
+        )

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,13 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import get_settings
-from app.exceptions.handlers import (
-    app_exception_handler,
-    exception_handlers,
-    generic_exception_handler,
-    http_exception_handler,
-    validation_exception_handler,
-)
+from app.exceptions import handlers as exception_handler_module
 from app.http_client import start_http_client, stop_http_client
 from app.routes import (
     analyze,
@@ -28,6 +22,13 @@ from app.routes import (
 from app.services.usage_logging import stop_usage_logger
 
 _settings = get_settings()
+
+# Transitional module-level aliases retained for existing imports and tests.
+app_exception_handler = exception_handler_module.app_exception_handler
+http_exception_handler = exception_handler_module.http_exception_handler
+validation_exception_handler = exception_handler_module.validation_exception_handler
+generic_exception_handler = exception_handler_module.generic_exception_handler
+exception_handlers = exception_handler_module.exception_handlers
 
 
 @asynccontextmanager

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,20 +1,18 @@
 from contextlib import asynccontextmanager
-import logging
 
 import uvicorn
-from fastapi import FastAPI, HTTPException, Request, status
-from fastapi.exceptions import RequestValidationError
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
 
 from app.config import get_settings
-from app.exceptions import (
-    BaseCustomException,
-    error_response,
+from app.exceptions.handlers import (
+    app_exception_handler,
+    exception_handlers,
+    generic_exception_handler,
+    http_exception_handler,
+    validation_exception_handler,
 )
 from app.http_client import start_http_client, stop_http_client
-from app.public_errors import UNEXPECTED_ERROR_MESSAGE
-from app.services.usage_logging import stop_usage_logger
 from app.routes import (
     analyze,
     applications,
@@ -27,9 +25,9 @@ from app.routes import (
     settings,
     usage,
 )
+from app.services.usage_logging import stop_usage_logger
 
 _settings = get_settings()
-logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -40,76 +38,6 @@ async def lifespan(app: FastAPI):
     finally:
         stop_usage_logger()
         await stop_http_client()
-
-
-async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
-    if isinstance(exc.detail, dict):
-        return JSONResponse(status_code=exc.status_code, content=exc.detail)
-    return JSONResponse(
-        status_code=exc.status_code, content={"detail": str(exc.detail)}
-    )
-
-
-async def base_custom_exception_handler(
-    request: Request, exc: BaseCustomException
-) -> JSONResponse:
-    return JSONResponse(
-        status_code=exc.status_code,
-        content=error_response(
-            message=exc.message,
-            status_code=exc.status_code,
-            error_code=exc.error_code,
-            details=exc.details,
-        ),
-    )
-
-
-async def validation_exception_handler(
-    request: Request, exc: RequestValidationError
-) -> JSONResponse:
-    errors = []
-    for error in exc.errors():
-        errors.append(
-            {
-                "field": ".".join(str(loc) for loc in error["loc"]),
-                "message": error["msg"],
-                "type": error["type"],
-            }
-        )
-    return JSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-        content=error_response(
-            message="Validation error",
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            error_code="VALIDATION_ERROR",
-            details={"errors": errors},
-        ),
-    )
-
-
-async def generic_exception_handler(request: Request, exc: Exception) -> JSONResponse:
-    path = getattr(getattr(request, "url", None), "path", "unknown")
-    logger.error(
-        "Unhandled exception for request path %s",
-        path,
-        exc_info=(type(exc), exc, exc.__traceback__),
-    )
-    return JSONResponse(
-        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        content=error_response(
-            message=UNEXPECTED_ERROR_MESSAGE,
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            error_code="INTERNAL_SERVER_ERROR",
-        ),
-    )
-
-
-exception_handlers = {
-    HTTPException: http_exception_handler,
-    BaseCustomException: base_custom_exception_handler,
-    RequestValidationError: validation_exception_handler,
-    Exception: generic_exception_handler,
-}
 
 
 app = FastAPI(

--- a/backend/tests/test_error_sanitization.py
+++ b/backend/tests/test_error_sanitization.py
@@ -18,7 +18,13 @@ def test_generic_exception_response_does_not_expose_raw_error():
     payload = json.loads(response.body)
 
     assert response.status_code == 500
-    assert payload["message"] == "An unexpected error occurred"
+    assert payload == {
+        "error": {
+            "code": "INTERNAL_SERVER_ERROR",
+            "message": "An unexpected error occurred",
+            "details": {},
+        }
+    }
     assert "sk-secret-value" not in response.body.decode()
     assert "internal.example" not in response.body.decode()
 

--- a/backend/tests/test_exception_framework.py
+++ b/backend/tests/test_exception_framework.py
@@ -1,0 +1,198 @@
+import asyncio
+import json
+import logging
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from fastapi.exceptions import RequestValidationError
+
+from app.exceptions import AppError, ErrorCode
+from app.exceptions.handlers import (
+    app_exception_handler,
+    generic_exception_handler,
+    http_exception_handler,
+    validation_exception_handler,
+)
+
+
+class ExampleError(AppError):
+    code = ErrorCode.VALIDATION_ERROR
+    status_code = 400
+    default_message = "Example request failed."
+
+
+def _request(path: str = "/example", method: str = "GET") -> SimpleNamespace:
+    return SimpleNamespace(
+        method=method,
+        url=SimpleNamespace(path=path),
+    )
+
+
+def _payload(response) -> dict:
+    return json.loads(response.body)
+
+
+def test_app_error_serializes_exact_public_envelope():
+    exc = ExampleError(details={"field": "name"})
+
+    assert exc.to_envelope().model_dump(mode="json") == {
+        "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "Example request failed.",
+            "details": {"field": "name"},
+        }
+    }
+
+
+def test_app_error_cannot_be_instantiated_directly():
+    with pytest.raises(TypeError, match="AppError"):
+        AppError()
+
+
+def test_app_error_rejects_invalid_subclass_contract():
+    class BrokenError(AppError):
+        code = "BROKEN"
+        status_code = 400
+        default_message = "Broken."
+
+    with pytest.raises(TypeError, match="ErrorCode"):
+        BrokenError()
+
+
+def test_app_error_defensively_copies_details():
+    details = {"nested": {"value": 1}}
+    exc = ExampleError(details=details)
+
+    details["nested"]["value"] = 2
+
+    assert exc.details == {"nested": {"value": 1}}
+
+
+def test_app_exception_handler_uses_status_envelope_and_headers():
+    exc = ExampleError(
+        details={"field": "name"},
+        headers={"Retry-After": "5"},
+    )
+
+    response = asyncio.run(app_exception_handler(_request(), exc))
+
+    assert response.status_code == 400
+    assert response.headers["retry-after"] == "5"
+    assert _payload(response) == {
+        "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "Example request failed.",
+            "details": {"field": "name"},
+        }
+    }
+
+
+def test_http_exception_handler_normalizes_known_legacy_payload():
+    exc = HTTPException(
+        status_code=400,
+        detail={
+            "detail": "LLM not configured.",
+            "code": "API_KEY_NOT_CONFIGURED",
+        },
+    )
+
+    response = asyncio.run(http_exception_handler(_request(), exc))
+
+    assert response.status_code == 400
+    assert _payload(response) == {
+        "error": {
+            "code": "API_KEY_NOT_CONFIGURED",
+            "message": "LLM not configured.",
+            "details": {},
+        }
+    }
+
+
+def test_http_exception_handler_uses_safe_code_for_unknown_legacy_code():
+    exc = HTTPException(
+        status_code=418,
+        detail={"detail": "Request rejected.", "code": "RUNTIME_CODE"},
+        headers={"X-Reason": "teapot"},
+    )
+
+    response = asyncio.run(http_exception_handler(_request(), exc))
+
+    assert response.status_code == 418
+    assert response.headers["x-reason"] == "teapot"
+    assert _payload(response) == {
+        "error": {
+            "code": "HTTP_ERROR",
+            "message": "Request rejected.",
+            "details": {},
+        }
+    }
+
+
+def test_http_exception_handler_does_not_reflect_nested_detail_objects():
+    secret = "sk-secret-value"
+    exc = HTTPException(
+        status_code=400,
+        detail={"detail": {"api_key": secret}, "code": "UNKNOWN"},
+    )
+
+    response = asyncio.run(http_exception_handler(_request(), exc))
+
+    assert _payload(response)["error"]["message"] == "Request failed."
+    assert secret not in response.body.decode()
+
+
+def test_validation_exception_handler_excludes_raw_input():
+    secret = "sk-secret-value"
+    exc = RequestValidationError(
+        [
+            {
+                "type": "string_type",
+                "loc": ("body", "name"),
+                "msg": "Input should be a valid string",
+                "input": secret,
+            }
+        ]
+    )
+
+    response = asyncio.run(validation_exception_handler(_request(), exc))
+
+    assert response.status_code == 422
+    assert _payload(response) == {
+        "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "Validation error.",
+            "details": {
+                "errors": [
+                    {
+                        "type": "string_type",
+                        "location": ["body", "name"],
+                        "message": "Input should be a valid string",
+                    }
+                ]
+            },
+        }
+    }
+    assert secret not in response.body.decode()
+
+
+def test_generic_exception_handler_sanitizes_response_and_logs_context(caplog):
+    secret = "provider failed api_key=sk-secret-value https://internal.example/debug"
+    exc = RuntimeError(secret)
+
+    with caplog.at_level(logging.ERROR, logger="app.exceptions.handlers"):
+        response = asyncio.run(
+            generic_exception_handler(_request(path="/boom", method="POST"), exc)
+        )
+
+    assert response.status_code == 500
+    assert _payload(response) == {
+        "error": {
+            "code": "INTERNAL_SERVER_ERROR",
+            "message": "An unexpected error occurred",
+            "details": {},
+        }
+    }
+    assert "sk-secret-value" not in response.body.decode()
+    assert "internal.example" not in response.body.decode()
+    assert "POST /boom" in caplog.text

--- a/backend/tests/test_exception_framework.py
+++ b/backend/tests/test_exception_framework.py
@@ -142,6 +142,24 @@ def test_http_exception_handler_does_not_reflect_nested_detail_objects():
     assert secret not in response.body.decode()
 
 
+def test_http_exception_handler_sanitizes_unknown_server_errors():
+    secret = "database failed password=secret https://internal.example/debug"
+    exc = HTTPException(status_code=503, detail=secret)
+
+    response = asyncio.run(http_exception_handler(_request(), exc))
+
+    assert response.status_code == 503
+    assert _payload(response) == {
+        "error": {
+            "code": "INTERNAL_SERVER_ERROR",
+            "message": "An unexpected error occurred",
+            "details": {},
+        }
+    }
+    assert "password=secret" not in response.body.decode()
+    assert "internal.example" not in response.body.decode()
+
+
 def test_validation_exception_handler_excludes_raw_input():
     secret = "sk-secret-value"
     exc = RequestValidationError(

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "test": "bun test"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^7.0.0",

--- a/frontend/src/lib/api-error.test.ts
+++ b/frontend/src/lib/api-error.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+
+import { ApiError, parseApiError } from './api-error';
+
+
+describe('parseApiError', () => {
+    test('reads the new nested error envelope', () => {
+        const error = parseApiError(
+            {
+                error: {
+                    code: 'PROFILE_NOT_FOUND',
+                    message: 'Profile was not found.',
+                    details: { profile_id: 42 },
+                },
+            },
+            'Fallback message.',
+            404
+        );
+
+        expect(error).toBeInstanceOf(ApiError);
+        expect(error.message).toBe('Profile was not found.');
+        expect(error.code).toBe('PROFILE_NOT_FOUND');
+        expect(error.details).toEqual({ profile_id: 42 });
+        expect(error.status).toBe(404);
+    });
+
+    test('supports the previous top-level error shape', () => {
+        const error = parseApiError(
+            {
+                message: 'Validation failed.',
+                error_code: 'VALIDATION_ERROR',
+                details: { field: 'name' },
+            },
+            'Fallback message.',
+            422
+        );
+
+        expect(error.message).toBe('Validation failed.');
+        expect(error.code).toBe('VALIDATION_ERROR');
+        expect(error.details).toEqual({ field: 'name' });
+    });
+
+    test('supports legacy detail and code fields', () => {
+        const error = parseApiError(
+            { detail: 'Unknown provider', code: 'NOT_FOUND' },
+            'Fallback message.',
+            404
+        );
+
+        expect(error.message).toBe('Unknown provider');
+        expect(error.code).toBe('NOT_FOUND');
+    });
+
+    test('does not stringify nested objects into a public message', () => {
+        const secret = 'sk-secret-value';
+        const error = parseApiError(
+            { detail: { api_key: secret } },
+            'Safe fallback.',
+            500
+        );
+
+        expect(error.message).toBe('Safe fallback.');
+        expect(error.message).not.toContain(secret);
+    });
+
+    test('prefers the new envelope when multiple formats are present', () => {
+        const error = parseApiError(
+            {
+                error: { code: 'HTTP_ERROR', message: 'New message.', details: {} },
+                message: 'Old message.',
+                detail: 'Older message.',
+            },
+            'Fallback message.'
+        );
+
+        expect(error.message).toBe('New message.');
+        expect(error.code).toBe('HTTP_ERROR');
+    });
+});

--- a/frontend/src/lib/api-error.ts
+++ b/frontend/src/lib/api-error.ts
@@ -1,0 +1,60 @@
+type UnknownRecord = Record<string, unknown>;
+
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+        ? value as UnknownRecord
+        : undefined;
+}
+
+
+function asNonEmptyString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+
+export class ApiError extends Error {
+    readonly code: string | undefined;
+    readonly details: unknown;
+    readonly status: number | undefined;
+
+    constructor(
+        message: string,
+        code?: string,
+        details?: unknown,
+        status?: number
+    ) {
+        super(message);
+        this.name = 'ApiError';
+        this.code = code;
+        this.details = details;
+        this.status = status;
+    }
+}
+
+
+export function parseApiError(
+    payload: unknown,
+    fallbackMessage: string,
+    status?: number
+): ApiError {
+    const root = asRecord(payload);
+    const nested = asRecord(root?.error);
+
+    const message =
+        asNonEmptyString(nested?.message)
+        ?? asNonEmptyString(root?.message)
+        ?? asNonEmptyString(root?.detail)
+        ?? fallbackMessage;
+
+    const code =
+        asNonEmptyString(nested?.code)
+        ?? asNonEmptyString(root?.error_code)
+        ?? asNonEmptyString(root?.code);
+
+    const details = nested && 'details' in nested
+        ? nested.details
+        : root?.details;
+
+    return new ApiError(message, code, details, status);
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -35,6 +35,7 @@ import type {
     UpdateApplicationRequest,
     UpdateSettingsRequest,
 } from './types';
+import { parseApiError } from './api-error';
 import { buildQs } from './utils';
 
 // ---------------------------------------------------------------------------
@@ -46,6 +47,11 @@ const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000/api
 // Core fetch helpers
 // ---------------------------------------------------------------------------
 
+async function throwApiError(res: Response, fallbackMessage: string): Promise<never> {
+    const payload: unknown = await res.json().catch(() => undefined);
+    throw parseApiError(payload, fallbackMessage, res.status);
+}
+
 /** JSON request/response for the vast majority of API calls. */
 async function request<T>(path: string, options: RequestInit = {}, fetchFn: typeof fetch = fetch): Promise<T> {
     const res = await fetchFn(`${BASE_URL}${path}`, {
@@ -54,8 +60,7 @@ async function request<T>(path: string, options: RequestInit = {}, fetchFn: type
     });
 
     if (!res.ok) {
-        const err = await res.json().catch(() => ({ detail: 'Something went wrong. Please try again.' }));
-        throw new Error(err.detail ?? 'Something went wrong. Please try again.');
+        await throwApiError(res, 'Something went wrong. Please try again.');
     }
 
     if (res.status === 204 || res.headers.get('content-length') === '0') {
@@ -69,8 +74,7 @@ async function request<T>(path: string, options: RequestInit = {}, fetchFn: type
 async function requestForm<T>(path: string, body: FormData): Promise<T> {
     const res = await fetch(`${BASE_URL}${path}`, { method: 'POST', body });
     if (!res.ok) {
-        const err = await res.json().catch(() => ({ detail: 'Failed to import your CV. Please check the file and try again.' }));
-        throw new Error(err.detail ?? 'Failed to import your CV. Please check the file and try again.');
+        await throwApiError(res, 'Failed to import your CV. Please check the file and try again.');
     }
     return res.json() as Promise<T>;
 }
@@ -82,8 +86,7 @@ async function requestBlob(path: string, options: RequestInit): Promise<Blob> {
         ...options,
     });
     if (!res.ok) {
-        const err = await res.json().catch(() => ({ detail: 'Failed to download. Please try again.' }));
-        throw new Error(err.detail ?? 'Failed to download. Please try again.');
+        await throwApiError(res, 'Failed to download. Please try again.');
     }
     return res.blob();
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,7 +11,10 @@
         "sourceMap": true,
         "strict": true,
         "moduleResolution": "bundler"
-    }
+    },
+    "exclude": [
+        "src/**/*.test.ts"
+    ]
     // Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
     // except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
     //


### PR DESCRIPTION
## Summary

- introduce typed `ErrorCode`, immutable error envelope models, and `AppError`
- centralize handlers for application errors, request validation, legacy `HTTPException`, and unexpected exceptions
- normalize existing route errors without migrating route domains in this PR
- sanitize unknown legacy 5xx responses so internal details are never reflected
- add a frontend compatibility parser for the new envelope and previous response formats
- run frontend unit tests as part of CI

## Scope

This is PR 1 of the staged exception migration. Existing route-level `HTTPException` calls remain supported through the legacy adapter. Domain migrations will follow in separate PRs.

No design spec or implementation plan is included in the repository.

## Validation

- Backend lint and full pytest suite pass on Python 3.12 and 3.13
- Frontend API error unit tests pass
- Svelte/TypeScript check passes
- Frontend production build passes
- TDD red/green verification completed for the base framework, frontend parser, and legacy 5xx sanitization
