### PR TITLE
refactor: complete typed exception migration

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,33 +1,27 @@
 """Shared FastAPI dependencies to reduce boilerplate across routes."""
 
-from fastapi import Depends, HTTPException
+from fastapi import Depends
 from sqlalchemy.orm import Session
 
 from app.database import get_db
+from app.exceptions import APIKeyNotConfiguredError, ProfileNotFoundError
 from app.models import Profile
 from app.services.settings import get_llm_config, is_llm_configured
 
 
 def get_profile_or_404(profile_id: int, db: Session = Depends(get_db)) -> Profile:
-    """Fetch a Profile by ID or raise 404. Use as a FastAPI dependency."""
+    """Fetch a Profile by ID or raise a typed 404 error."""
     profile = db.query(Profile).filter_by(id=profile_id).first()
     if not profile:
-        raise HTTPException(
-            status_code=404,
-            detail={"detail": "Profile not found.", "code": "PROFILE_NOT_FOUND"},
-        )
+        raise ProfileNotFoundError(profile_id)
     return profile
 
 
 def require_llm_config(db: Session = Depends(get_db)) -> tuple[str, str]:
-    """Return (model_string, api_key) or raise 400 if LLM is not configured."""
+    """Return (model_string, api_key) or raise when LLM is not configured."""
     model, api_key = get_llm_config(db)
     if not is_llm_configured(model, api_key):
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "detail": "LLM not configured. Select a model and add an API key when required.",
-                "code": "API_KEY_NOT_CONFIGURED",
-            },
+        raise APIKeyNotConfiguredError(
+            "LLM not configured. Select a model and add an API key when required."
         )
     return model, api_key

--- a/backend/app/exceptions/__init__.py
+++ b/backend/app/exceptions/__init__.py
@@ -1,41 +1,54 @@
-from app.exceptions.base import (
-    AppError,
-    BaseCustomException,
-    ErrorBody,
-    ErrorCode,
-    ErrorEnvelope,
-    error_response,
-    not_found_404,
-)
+from app.exceptions.base import AppError, ErrorBody, ErrorCode, ErrorEnvelope
 from app.exceptions.infrastructure import (
-    AIProcessingError,
     InternalApplicationError,
-    InternalServerError,
+    PDFRenderFailedError,
     RateLimitError,
-    StorageError,
+    ScrapeFailedError,
 )
-from app.exceptions.llm import APIKeyNotConfiguredError, LLMCallError, LLMOutputError
-from app.exceptions.request import ValidationAppError, ValidationError
-from app.exceptions.resource import ConflictError, NotFoundError
+from app.exceptions.llm import (
+    APIKeyNotConfiguredError,
+    CVImportOutputError,
+    LLMCallError,
+    LLMOutputError,
+)
+from app.exceptions.request import (
+    FileParseError,
+    FileTooLargeError,
+    InvalidRequestError,
+    ScrapeValueError,
+    UnsupportedFileTypeError,
+    ValidationAppError,
+)
+from app.exceptions.resource import (
+    ApplicationNotFoundError,
+    HistoryEntryNotFoundError,
+    ProfileNotFoundError,
+    ProviderNotFoundError,
+)
+from app.exceptions.stream import stream_error_event
 
 __all__ = [
     "AppError",
-    "BaseCustomException",
     "ErrorCode",
     "ErrorBody",
     "ErrorEnvelope",
-    "NotFoundError",
+    "ProfileNotFoundError",
+    "ApplicationNotFoundError",
+    "HistoryEntryNotFoundError",
+    "ProviderNotFoundError",
     "ValidationAppError",
-    "ValidationError",
-    "ConflictError",
+    "InvalidRequestError",
+    "ScrapeValueError",
+    "FileTooLargeError",
+    "UnsupportedFileTypeError",
+    "FileParseError",
     "InternalApplicationError",
-    "InternalServerError",
-    "AIProcessingError",
     "RateLimitError",
-    "StorageError",
+    "ScrapeFailedError",
+    "PDFRenderFailedError",
     "APIKeyNotConfiguredError",
     "LLMCallError",
     "LLMOutputError",
-    "error_response",
-    "not_found_404",
+    "CVImportOutputError",
+    "stream_error_event",
 ]

--- a/backend/app/exceptions/base.py
+++ b/backend/app/exceptions/base.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 from enum import StrEnum
 from typing import Any, ClassVar
 
-from fastapi import HTTPException
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -13,27 +12,27 @@ class ErrorCode(StrEnum):
 
     VALIDATION_ERROR = "VALIDATION_ERROR"
     HTTP_ERROR = "HTTP_ERROR"
+    ROUTE_NOT_FOUND = "ROUTE_NOT_FOUND"
+    METHOD_NOT_ALLOWED = "METHOD_NOT_ALLOWED"
     INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR"
-    RESOURCE_NOT_FOUND = "RESOURCE_NOT_FOUND"
-    RESOURCE_CONFLICT = "RESOURCE_CONFLICT"
-    AI_PROCESSING_ERROR = "AI_PROCESSING_ERROR"
-    RATE_LIMIT_EXCEEDED = "RATE_LIMIT_EXCEEDED"
-    STORAGE_ERROR = "STORAGE_ERROR"
-    API_KEY_NOT_CONFIGURED = "API_KEY_NOT_CONFIGURED"
-    LLM_CALL_FAILED = "LLM_CALL_FAILED"
-    LLM_OUTPUT_INVALID = "LLM_OUTPUT_INVALID"
 
-    # Legacy route codes retained during incremental migration.
     PROFILE_NOT_FOUND = "PROFILE_NOT_FOUND"
     APPLICATION_NOT_FOUND = "APPLICATION_NOT_FOUND"
-    NOT_FOUND = "NOT_FOUND"
+    HISTORY_ENTRY_NOT_FOUND = "HISTORY_ENTRY_NOT_FOUND"
+    PROVIDER_NOT_FOUND = "PROVIDER_NOT_FOUND"
+
+    INVALID_REQUEST = "INVALID_REQUEST"
     SCRAPE_VALUE_ERROR = "SCRAPE_VALUE_ERROR"
     SCRAPE_FAILED = "SCRAPE_FAILED"
-    INVALID_REQUEST = "INVALID_REQUEST"
     FILE_TOO_LARGE = "FILE_TOO_LARGE"
     FILE_TYPE_UNSUPPORTED = "FILE_TYPE_UNSUPPORTED"
     FILE_PARSE_FAILED = "FILE_PARSE_FAILED"
     PDF_RENDER_FAILED = "PDF_RENDER_FAILED"
+
+    RATE_LIMIT_EXCEEDED = "RATE_LIMIT_EXCEEDED"
+    API_KEY_NOT_CONFIGURED = "API_KEY_NOT_CONFIGURED"
+    LLM_CALL_FAILED = "LLM_CALL_FAILED"
+    LLM_OUTPUT_INVALID = "LLM_OUTPUT_INVALID"
 
 
 class ErrorBody(BaseModel):
@@ -107,40 +106,3 @@ class AppError(Exception):
                 details=deepcopy(self.details),
             )
         )
-
-
-# Transitional compatibility name for existing imports. New code should use AppError.
-BaseCustomException = AppError
-
-
-def error_response(
-    message: str | list[str],
-    status_code: int,
-    error_code: str | None = None,
-    details: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Build the new envelope for callers using the legacy helper."""
-    del status_code
-    try:
-        code = ErrorCode(error_code) if error_code else ErrorCode.HTTP_ERROR
-    except ValueError:
-        code = ErrorCode.HTTP_ERROR
-    public_message = message if isinstance(message, str) else "; ".join(message)
-    return ErrorEnvelope(
-        error=ErrorBody(
-            code=code,
-            message=public_message,
-            details=deepcopy(details) if details is not None else {},
-        )
-    ).model_dump(mode="json")
-
-
-def not_found_404(resource: str = "Resource") -> HTTPException:
-    """Create a legacy 404 response that the global adapter can normalize."""
-    return HTTPException(
-        status_code=404,
-        detail={
-            "detail": f"{resource} not found",
-            "code": ErrorCode.RESOURCE_NOT_FOUND.value,
-        },
-    )

--- a/backend/app/exceptions/handlers.py
+++ b/backend/app/exceptions/handlers.py
@@ -1,23 +1,17 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
-from fastapi import HTTPException, Request
+from fastapi import Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from app.exceptions.base import AppError, ErrorCode, ErrorBody, ErrorEnvelope
+from app.exceptions.base import AppError, ErrorBody, ErrorCode, ErrorEnvelope
 from app.exceptions.infrastructure import InternalApplicationError
 from app.exceptions.request import ValidationAppError
 
 logger = logging.getLogger(__name__)
-
-_LEGACY_PUBLIC_MESSAGES = {
-    ErrorCode.INTERNAL_SERVER_ERROR: "An unexpected error occurred",
-    ErrorCode.LLM_CALL_FAILED: "The AI provider request failed. Check your settings and try again.",
-    ErrorCode.PDF_RENDER_FAILED: "Could not generate the PDF. Please try again.",
-}
 
 
 def _response_for(exc: AppError) -> JSONResponse:
@@ -33,47 +27,41 @@ async def app_exception_handler(request: Request, exc: AppError) -> JSONResponse
     return _response_for(exc)
 
 
-def _legacy_code(value: Any) -> ErrorCode:
-    if not isinstance(value, str):
-        return ErrorCode.HTTP_ERROR
-    try:
-        return ErrorCode(value)
-    except ValueError:
-        return ErrorCode.HTTP_ERROR
+def _framework_error_envelope(exc: StarletteHTTPException) -> ErrorEnvelope:
+    if exc.status_code == 404:
+        return ErrorEnvelope(
+            error=ErrorBody(
+                code=ErrorCode.ROUTE_NOT_FOUND,
+                message="Route was not found.",
+            )
+        )
+    if exc.status_code == 405:
+        return ErrorEnvelope(
+            error=ErrorBody(
+                code=ErrorCode.METHOD_NOT_ALLOWED,
+                message="Method is not allowed for this route.",
+            )
+        )
+    if exc.status_code >= 500:
+        return InternalApplicationError().to_envelope()
 
-
-def _legacy_message(detail: Any, code: ErrorCode) -> str:
-    if code in _LEGACY_PUBLIC_MESSAGES:
-        return _LEGACY_PUBLIC_MESSAGES[code]
-
-    candidate: Any = detail
-    if isinstance(detail, dict):
-        candidate = detail.get("detail", detail.get("message"))
-    if isinstance(candidate, str) and candidate.strip():
-        return candidate
-    return "Request failed."
-
-
-async def http_exception_handler(
-    request: Request, exc: HTTPException
-) -> JSONResponse:
-    del request
-    raw_code = None
-    if isinstance(exc.detail, dict):
-        raw_code = exc.detail.get("code", exc.detail.get("error_code"))
-    code = _legacy_code(raw_code)
-    if exc.status_code >= 500 and code not in _LEGACY_PUBLIC_MESSAGES:
-        code = ErrorCode.INTERNAL_SERVER_ERROR
-    envelope = ErrorEnvelope(
+    message = exc.detail if isinstance(exc.detail, str) and exc.detail.strip() else None
+    return ErrorEnvelope(
         error=ErrorBody(
-            code=code,
-            message=_legacy_message(exc.detail, code),
-            details={},
+            code=ErrorCode.HTTP_ERROR,
+            message=message or "Request failed.",
         )
     )
+
+
+async def framework_http_exception_handler(
+    request: Request,
+    exc: StarletteHTTPException,
+) -> JSONResponse:
+    del request
     return JSONResponse(
         status_code=exc.status_code,
-        content=envelope.model_dump(mode="json"),
+        content=_framework_error_envelope(exc).model_dump(mode="json"),
         headers=exc.headers,
     )
 
@@ -111,7 +99,7 @@ async def generic_exception_handler(
 
 exception_handlers = {
     AppError: app_exception_handler,
-    HTTPException: http_exception_handler,
+    StarletteHTTPException: framework_http_exception_handler,
     RequestValidationError: validation_exception_handler,
     Exception: generic_exception_handler,
 }

--- a/backend/app/exceptions/infrastructure.py
+++ b/backend/app/exceptions/infrastructure.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from app.exceptions.base import AppError, ErrorCode
 from app.public_errors import UNEXPECTED_ERROR_MESSAGE
 
@@ -8,33 +6,6 @@ class InternalApplicationError(AppError):
     code = ErrorCode.INTERNAL_SERVER_ERROR
     status_code = 500
     default_message = UNEXPECTED_ERROR_MESSAGE
-
-
-class InternalServerError(InternalApplicationError):
-    """Compatibility wrapper for the previous public exception API."""
-
-    default_message = "An internal server error occurred"
-
-    def __init__(
-        self,
-        message: str | None = None,
-        details: dict[str, Any] | None = None,
-    ) -> None:
-        super().__init__(message, details=details)
-
-
-class AIProcessingError(AppError):
-    code = ErrorCode.AI_PROCESSING_ERROR
-    status_code = 500
-    default_message = "AI processing failed"
-
-    def __init__(
-        self,
-        message: str | None = None,
-        model: str | None = None,
-    ) -> None:
-        details = {"model": model} if model else {}
-        super().__init__(message, details=details)
 
 
 class RateLimitError(AppError):
@@ -54,15 +25,15 @@ class RateLimitError(AppError):
         super().__init__(message, details=details, headers=headers)
 
 
-class StorageError(AppError):
-    code = ErrorCode.STORAGE_ERROR
-    status_code = 500
-    default_message = "Storage operation failed"
+class ScrapeFailedError(AppError):
+    code = ErrorCode.SCRAPE_FAILED
+    status_code = 422
+    default_message = (
+        "Could not extract job posting. Please paste the text manually."
+    )
 
-    def __init__(
-        self,
-        message: str | None = None,
-        operation: str | None = None,
-    ) -> None:
-        details = {"operation": operation} if operation else {}
-        super().__init__(message, details=details)
+
+class PDFRenderFailedError(AppError):
+    code = ErrorCode.PDF_RENDER_FAILED
+    status_code = 502
+    default_message = "Could not generate the PDF. Please try again."

--- a/backend/app/exceptions/llm.py
+++ b/backend/app/exceptions/llm.py
@@ -21,3 +21,9 @@ class LLMOutputError(AppError):
     default_message = (
         "The AI provider returned an invalid structured response. Please try again."
     )
+
+
+class CVImportOutputError(AppError):
+    code = ErrorCode.LLM_OUTPUT_INVALID
+    status_code = 422
+    default_message = "Could not parse CV into profile fields. Try editing manually."

--- a/backend/app/exceptions/request.py
+++ b/backend/app/exceptions/request.py
@@ -7,14 +7,37 @@ class ValidationAppError(AppError):
     default_message = "Validation error."
 
 
-class ValidationError(ValidationAppError):
-    """Compatibility wrapper for the previous public exception API."""
+class InvalidRequestError(AppError):
+    code = ErrorCode.INVALID_REQUEST
+    status_code = 400
+    default_message = "Invalid request."
 
-    def __init__(
-        self,
-        message: str | list[str],
-        field: str | None = None,
-    ) -> None:
-        public_message = message if isinstance(message, str) else "; ".join(message)
-        details = {"field": field} if field else {}
-        super().__init__(public_message, details=details)
+
+class ScrapeValueError(AppError):
+    code = ErrorCode.SCRAPE_VALUE_ERROR
+    status_code = 422
+    default_message = "The job posting input is invalid."
+
+
+class FileTooLargeError(AppError):
+    code = ErrorCode.FILE_TOO_LARGE
+    status_code = 413
+    default_message = "File is too large."
+
+    def __init__(self, max_size_mb: int) -> None:
+        super().__init__(
+            f"File too large. Maximum size is {max_size_mb}MB.",
+            details={"max_size_mb": max_size_mb},
+        )
+
+
+class UnsupportedFileTypeError(AppError):
+    code = ErrorCode.FILE_TYPE_UNSUPPORTED
+    status_code = 422
+    default_message = "Unsupported file type. Use PDF, DOCX, or plain text."
+
+
+class FileParseError(AppError):
+    code = ErrorCode.FILE_PARSE_FAILED
+    status_code = 422
+    default_message = "Could not extract text from file."

--- a/backend/app/exceptions/resource.py
+++ b/backend/app/exceptions/resource.py
@@ -1,30 +1,40 @@
 from app.exceptions.base import AppError, ErrorCode
 
 
-class NotFoundError(AppError):
-    code = ErrorCode.RESOURCE_NOT_FOUND
+class ProfileNotFoundError(AppError):
+    code = ErrorCode.PROFILE_NOT_FOUND
     status_code = 404
-    default_message = "Resource was not found."
+    default_message = "Profile was not found."
 
-    def __init__(self, resource: str, identifier: str | int) -> None:
+    def __init__(self, profile_id: int) -> None:
+        super().__init__(details={"profile_id": profile_id})
+
+
+class ApplicationNotFoundError(AppError):
+    code = ErrorCode.APPLICATION_NOT_FOUND
+    status_code = 404
+    default_message = "Application was not found."
+
+    def __init__(self, application_id: int) -> None:
+        super().__init__(details={"application_id": application_id})
+
+
+class HistoryEntryNotFoundError(AppError):
+    code = ErrorCode.HISTORY_ENTRY_NOT_FOUND
+    status_code = 404
+    default_message = "History entry was not found."
+
+    def __init__(self, resource: str, entry_id: int) -> None:
         super().__init__(
-            f"{resource} with identifier '{identifier}' not found",
-            details={"resource": resource, "identifier": identifier},
+            f"{resource} was not found.",
+            details={"resource": resource, "entry_id": entry_id},
         )
 
 
-class ConflictError(AppError):
-    code = ErrorCode.RESOURCE_CONFLICT
-    status_code = 409
-    default_message = "Resource state conflicts with the request."
+class ProviderNotFoundError(AppError):
+    code = ErrorCode.PROVIDER_NOT_FOUND
+    status_code = 404
+    default_message = "Provider was not found."
 
-    def __init__(
-        self,
-        resource: str,
-        identifier: str | int,
-        message: str | None = None,
-    ) -> None:
-        super().__init__(
-            message or f"{resource} with identifier '{identifier}' already exists",
-            details={"resource": resource, "identifier": identifier},
-        )
+    def __init__(self, provider_id: str) -> None:
+        super().__init__(details={"provider_id": provider_id})

--- a/backend/app/exceptions/stream.py
+++ b/backend/app/exceptions/stream.py
@@ -25,6 +25,6 @@ def stream_error_event(exc: Exception) -> ServerSentEvent:
         event = "error"
 
     return ServerSentEvent(
-        data=public_error.to_envelope().model_dump_json(),
+        data=public_error.to_envelope().model_dump(mode="json"),
         event=event,
     )

--- a/backend/app/exceptions/stream.py
+++ b/backend/app/exceptions/stream.py
@@ -1,0 +1,30 @@
+import logging
+
+from fastapi.sse import ServerSentEvent
+
+from app.exceptions.base import AppError
+from app.exceptions.infrastructure import InternalApplicationError, RateLimitError
+
+logger = logging.getLogger(__name__)
+
+
+def stream_error_event(exc: Exception) -> ServerSentEvent:
+    """Convert a streaming exception into the public error envelope."""
+    if isinstance(exc, RateLimitError):
+        public_error: AppError = exc
+        event = "rate_limit"
+    elif isinstance(exc, AppError):
+        public_error = exc
+        event = "error"
+    else:
+        logger.error(
+            "Unhandled streaming exception",
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+        public_error = InternalApplicationError()
+        event = "error"
+
+    return ServerSentEvent(
+        data=public_error.to_envelope().model_dump_json(),
+        event=event,
+    )

--- a/backend/app/routes/applications.py
+++ b/backend/app/routes/applications.py
@@ -1,9 +1,10 @@
 from datetime import UTC, date, datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.database import get_db
+from app.exceptions import ApplicationNotFoundError
 from app.models import Application, GeneratedCoverLetter, GeneratedCV
 from app.schemas import (
     ApplicationEntry,
@@ -14,6 +15,13 @@ from app.schemas import (
 from app.utils import batch_load_profiles
 
 router = APIRouter()
+
+
+def _get_application_or_404(db: Session, application_id: int) -> Application:
+    application = db.query(Application).filter_by(id=application_id).first()
+    if not application:
+        raise ApplicationNotFoundError(application_id)
+    return application
 
 
 def _enrich_app(app: Application, profiles: dict) -> dict:
@@ -178,23 +186,14 @@ def list_applications(
 
 @router.get("/applications/{app_id}", response_model=ApplicationEntry)
 def get_application(app_id: int, db: Session = Depends(get_db)):
-    app = db.query(Application).filter_by(id=app_id).first()
-    if not app:
-        raise HTTPException(
-            status_code=404, detail={"detail": "Not found", "code": "NOT_FOUND"}
-        )
-    return _build_app_entry(app, db)
+    return _build_app_entry(_get_application_or_404(db, app_id), db)
 
 
 @router.patch("/applications/{app_id}", response_model=ApplicationEntry)
 def update_application(
     app_id: int, body: UpdateApplicationRequest, db: Session = Depends(get_db)
 ):
-    app = db.query(Application).filter_by(id=app_id).first()
-    if not app:
-        raise HTTPException(
-            status_code=404, detail={"detail": "Not found", "code": "NOT_FOUND"}
-        )
+    app = _get_application_or_404(db, app_id)
     for field, value in body.model_dump(exclude_unset=True).items():
         if field == "status" and value is not None:
             value = value if isinstance(value, str) else value.value
@@ -207,11 +206,7 @@ def update_application(
 
 @router.delete("/applications/{app_id}")
 def delete_application(app_id: int, db: Session = Depends(get_db)):
-    app = db.query(Application).filter_by(id=app_id).first()
-    if not app:
-        raise HTTPException(
-            status_code=404, detail={"detail": "Not found", "code": "NOT_FOUND"}
-        )
+    app = _get_application_or_404(db, app_id)
     # Nullify FKs on linked documents before deleting
     db.query(GeneratedCoverLetter).filter_by(application_id=app_id).update(
         {"application_id": None}

--- a/backend/app/routes/generate.py
+++ b/backend/app/routes/generate.py
@@ -3,14 +3,14 @@ import json
 import logging
 from collections.abc import AsyncIterable
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from fastapi.responses import Response
 from fastapi.sse import EventSourceResponse, ServerSentEvent
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.dependencies import get_profile_or_404, require_llm_config
-from app.exceptions import RateLimitError
+from app.exceptions import PDFRenderFailedError, RateLimitError, stream_error_event
 from app.models import GeneratedCoverLetter, GeneratedCV
 from app.schemas import (
     ATSEnhancement,
@@ -64,10 +64,7 @@ def _render_cv_pdf(profile_data: dict) -> Response:
         html = render_cv_template(profile_data)
         pdf_bytes = html_to_pdf(html)
     except PDFRenderError as exc:
-        raise HTTPException(
-            status_code=502,
-            detail={"detail": str(exc), "code": "PDF_RENDER_FAILED"},
-        ) from exc
+        raise PDFRenderFailedError() from exc
     return Response(
         content=pdf_bytes,
         media_type="application/pdf",
@@ -80,21 +77,12 @@ def _render_cover_letter_pdf(letter_data: dict) -> Response:
         html = render_cover_letter_template(letter_data)
         pdf_bytes = html_to_pdf(html)
     except PDFRenderError as exc:
-        raise HTTPException(
-            status_code=502,
-            detail={"detail": str(exc), "code": "PDF_RENDER_FAILED"},
-        ) from exc
+        raise PDFRenderFailedError() from exc
     return Response(
         content=pdf_bytes,
         media_type="application/pdf",
         headers={"Content-Disposition": "attachment; filename=cover-letter.pdf"},
     )
-
-
-def _handle_stream_error(exc: Exception) -> ServerSentEvent:
-    if isinstance(exc, RateLimitError):
-        return ServerSentEvent(data=str(exc), event="rate_limit")
-    return ServerSentEvent(data=str(exc), event="error")
 
 
 # ---------------------------------------------------------------------------
@@ -238,7 +226,7 @@ async def generate_cv_stream(req: GenerateCvRequest, db: Session = Depends(get_d
             )
             enhanced = True
         except RateLimitError as exc:
-            yield ServerSentEvent(data=str(exc), event="rate_limit")
+            yield stream_error_event(exc)
             return
         except Exception as exc:
             logger.warning(
@@ -294,7 +282,7 @@ async def generate_cover_letter(
             accumulated.append(chunk)
             yield ServerSentEvent(data=str(chunk), event="token")
     except Exception as exc:
-        yield _handle_stream_error(exc)
+        yield stream_error_event(exc)
         return
 
     full_text = "".join(accumulated)
@@ -351,7 +339,7 @@ async def generate_summary(
         ):
             yield ServerSentEvent(data=str(chunk), event="token")
     except Exception as exc:
-        yield _handle_stream_error(exc)
+        yield stream_error_event(exc)
         return
     yield ServerSentEvent(data="[DONE]", event="done")
 
@@ -402,7 +390,7 @@ async def generate_bullets(
         ):
             yield ServerSentEvent(data=str(chunk), event="token")
     except Exception as exc:
-        yield _handle_stream_error(exc)
+        yield stream_error_event(exc)
         return
 
     yield ServerSentEvent(data="[DONE]", event="done")

--- a/backend/app/routes/history.py
+++ b/backend/app/routes/history.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.exceptions import not_found_404
+from app.exceptions import HistoryEntryNotFoundError
 from app.models import Application, GeneratedCoverLetter, GeneratedCV
 from app.schemas import (
     BulkDeleteRequest,
@@ -116,7 +116,7 @@ def list_cv_history(
 def get_cv_history_entry(entry_id: int, db: Session = Depends(get_db)):
     entry = db.query(GeneratedCV).filter_by(id=entry_id).first()
     if not entry:
-        raise not_found_404("CV entry")
+        raise HistoryEntryNotFoundError("CV entry", entry_id)
     return _enrich_cv(entry, batch_load_profiles([entry], db))
 
 
@@ -124,7 +124,7 @@ def get_cv_history_entry(entry_id: int, db: Session = Depends(get_db)):
 def delete_cv_history_entry(entry_id: int, db: Session = Depends(get_db)):
     entry = db.query(GeneratedCV).filter_by(id=entry_id).first()
     if not entry:
-        raise not_found_404("CV entry")
+        raise HistoryEntryNotFoundError("CV entry", entry_id)
     db.delete(entry)
     db.commit()
 
@@ -135,7 +135,7 @@ def update_cv_status(
 ):
     entry = db.query(GeneratedCV).filter_by(id=entry_id).first()
     if not entry:
-        raise not_found_404("CV entry")
+        raise HistoryEntryNotFoundError("CV entry", entry_id)
     entry.application_status = body.status
     db.commit()
     return _enrich_cv(entry, batch_load_profiles([entry], db))
@@ -193,7 +193,7 @@ def list_cover_letter_history(
 def get_cover_letter_history_entry(entry_id: int, db: Session = Depends(get_db)):
     entry = db.query(GeneratedCoverLetter).filter_by(id=entry_id).first()
     if not entry:
-        raise not_found_404("Cover letter")
+        raise HistoryEntryNotFoundError("Cover letter", entry_id)
     return _enrich_cl(entry, batch_load_profiles([entry], db))
 
 
@@ -201,7 +201,7 @@ def get_cover_letter_history_entry(entry_id: int, db: Session = Depends(get_db))
 def delete_cover_letter_history_entry(entry_id: int, db: Session = Depends(get_db)):
     entry = db.query(GeneratedCoverLetter).filter_by(id=entry_id).first()
     if not entry:
-        raise not_found_404("Cover letter")
+        raise HistoryEntryNotFoundError("Cover letter", entry_id)
     db.delete(entry)
     db.commit()
 
@@ -214,7 +214,7 @@ def update_cover_letter_status(
 ):
     entry = db.query(GeneratedCoverLetter).filter_by(id=entry_id).first()
     if not entry:
-        raise not_found_404("Cover letter")
+        raise HistoryEntryNotFoundError("Cover letter", entry_id)
     entry.application_status = body.status
     if body.status:
         if entry.application_id:

--- a/backend/app/routes/import_cv.py
+++ b/backend/app/routes/import_cv.py
@@ -1,11 +1,17 @@
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, UploadFile
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.dependencies import require_llm_config
+from app.exceptions import (
+    CVImportOutputError,
+    FileParseError,
+    FileTooLargeError,
+    UnsupportedFileTypeError,
+)
 from app.exceptions.llm import LLMOutputError
 from app.schemas import ProfileData
 from app.services.llm import call_llm, parse_structured_output
@@ -21,6 +27,7 @@ ALLOWED_MIME_TYPES = {
 }
 ALLOWED_EXTENSIONS = {"pdf", "docx"}
 MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB
+MAX_FILE_SIZE_MB = 5
 
 
 def _clean_cv_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -46,48 +53,24 @@ async def import_cv(
     if file is not None:
         content = await file.read()
         if len(content) > MAX_FILE_SIZE:
-            raise HTTPException(
-                status_code=413,
-                detail={
-                    "detail": "File too large. Maximum size is 5MB.",
-                    "code": "FILE_TOO_LARGE",
-                },
-            )
+            raise FileTooLargeError(max_size_mb=MAX_FILE_SIZE_MB)
         ext = (file.filename or "").lower().rsplit(".", 1)[-1]
         mime = file.content_type or ""
         if ext not in ALLOWED_EXTENSIONS or mime not in ALLOWED_MIME_TYPES:
-            raise HTTPException(
-                status_code=422,
-                detail={
-                    "detail": "Unsupported file type. Use PDF, DOCX, or plain text.",
-                    "code": "FILE_TYPE_UNSUPPORTED",
-                },
-            )
+            raise UnsupportedFileTypeError()
         try:
             raw_text = extract_text(file_content=content, filename=file.filename)
         except Exception as exc:
-            raise HTTPException(
-                status_code=422,
-                detail={
-                    "detail": "Could not extract text from file.",
-                    "code": "FILE_PARSE_FAILED",
-                },
-            ) from exc
+            raise FileParseError() from exc
     elif text:
         raw_text = text.strip()
     else:
-        raise HTTPException(
-            status_code=422,
-            detail={"detail": "Provide a file or text.", "code": "FILE_PARSE_FAILED"},
-        )
+        raise FileParseError("Provide a file or text.")
 
     try:
         validate_extracted_text(raw_text)
     except ValueError as exc:
-        raise HTTPException(
-            status_code=422,
-            detail={"detail": str(exc), "code": "FILE_PARSE_FAILED"},
-        ) from exc
+        raise FileParseError(str(exc)) from exc
 
     # Truncate to avoid exceeding LLM context windows (CVs rarely need more than this)
     max_text_chars = 15_000
@@ -110,10 +93,4 @@ async def import_cv(
         )
     except LLMOutputError:
         logger.warning("CV import returned invalid structured output")
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "detail": "Could not parse CV into profile fields. Try editing manually.",
-                "code": "LLM_OUTPUT_INVALID",
-            },
-        ) from None
+        raise CVImportOutputError() from None

--- a/backend/app/routes/scrape.py
+++ b/backend/app/routes/scrape.py
@@ -1,9 +1,10 @@
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.dependencies import require_llm_config
+from app.exceptions import InvalidRequestError, ScrapeFailedError, ScrapeValueError
 from app.http_client import get_http_client
 from app.schemas import (
     ParseJobDescriptionRequest,
@@ -25,19 +26,10 @@ async def scrape_job(
 ):
     try:
         result = await scrape_job_url(body.url, client)
-    except ValueError as e:
-        raise HTTPException(
-            status_code=422,
-            detail={"detail": str(e), "code": "SCRAPE_VALUE_ERROR"},
-        ) from e
+    except ValueError as exc:
+        raise ScrapeValueError(str(exc)) from exc
     except Exception:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "detail": "Could not extract job posting. Please paste the text manually.",
-                "code": "SCRAPE_FAILED",
-            },
-        ) from None
+        raise ScrapeFailedError() from None
     return ScrapeJobResponse(
         job_description=result.job_description,
         company_name=result.company_name,
@@ -63,13 +55,7 @@ async def scrape_analyze(
     client: httpx.AsyncClient = Depends(get_http_client),
 ):
     if not body.url and not body.text:
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "detail": "Either url or text must be provided",
-                "code": "INVALID_REQUEST",
-            },
-        )
+        raise InvalidRequestError("Either url or text must be provided")
 
     provider, api_key = require_llm_config(db)
 
@@ -94,8 +80,5 @@ async def scrape_analyze(
             job_description=job_description,
             source=source,
         )
-    except ValueError as e:
-        raise HTTPException(
-            status_code=422,
-            detail={"detail": str(e), "code": "SCRAPE_VALUE_ERROR"},
-        )
+    except ValueError as exc:
+        raise ScrapeValueError(str(exc)) from exc

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -1,9 +1,10 @@
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from app.database import get_db
+from app.exceptions import ProviderNotFoundError
 from app.public_errors import PROVIDER_CONNECTION_ERROR_MESSAGE
 from app.schemas import (
     ActivateProviderRequest,
@@ -189,7 +190,7 @@ def test_connection(req: UpdateSettingsRequest):
 def disconnect_provider(provider_id: str, db: Session = Depends(get_db)):
     """Remove the stored API key for a provider. If it was active, clear the active model."""
     if provider_id not in KNOWN_MODELS:
-        raise HTTPException(status_code=404, detail="Unknown provider")
+        raise ProviderNotFoundError(provider_id)
 
     clear_provider_api_key(db, provider_id)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import get_settings
-from app.exceptions import handlers as exception_handler_module
+from app.exceptions.handlers import exception_handlers
 from app.http_client import start_http_client, stop_http_client
 from app.routes import (
     analyze,
@@ -22,13 +22,6 @@ from app.routes import (
 from app.services.usage_logging import stop_usage_logger
 
 _settings = get_settings()
-
-# Transitional module-level aliases retained for existing imports and tests.
-app_exception_handler = exception_handler_module.app_exception_handler
-http_exception_handler = exception_handler_module.http_exception_handler
-validation_exception_handler = exception_handler_module.validation_exception_handler
-generic_exception_handler = exception_handler_module.generic_exception_handler
-exception_handlers = exception_handler_module.exception_handlers
 
 
 @asynccontextmanager

--- a/backend/tests/test_error_sanitization.py
+++ b/backend/tests/test_error_sanitization.py
@@ -4,7 +4,7 @@ import json
 import litellm
 import pytest
 
-import main
+from app.exceptions.handlers import generic_exception_handler
 from app.exceptions.llm import LLMCallError
 from app.routes.settings import test_connection as check_connection
 from app.schemas import UpdateSettingsRequest
@@ -14,7 +14,7 @@ _RAW_ERROR = "provider failed api_key=sk-secret-value https://internal.example/d
 
 
 def test_generic_exception_response_does_not_expose_raw_error():
-    response = asyncio.run(main.generic_exception_handler(None, RuntimeError(_RAW_ERROR)))
+    response = asyncio.run(generic_exception_handler(None, RuntimeError(_RAW_ERROR)))
     payload = json.loads(response.body)
 
     assert response.status_code == 500

--- a/backend/tests/test_exception_framework.py
+++ b/backend/tests/test_exception_framework.py
@@ -4,14 +4,14 @@ import logging
 from types import SimpleNamespace
 
 import pytest
-from fastapi import HTTPException
 from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.exceptions import AppError, ErrorCode
 from app.exceptions.handlers import (
     app_exception_handler,
+    framework_http_exception_handler,
     generic_exception_handler,
-    http_exception_handler,
     validation_exception_handler,
 )
 
@@ -88,38 +88,17 @@ def test_app_exception_handler_uses_status_envelope_and_headers():
     }
 
 
-def test_http_exception_handler_normalizes_known_legacy_payload():
-    exc = HTTPException(
+def test_framework_http_exception_handler_normalizes_string_detail():
+    exc = StarletteHTTPException(
         status_code=400,
-        detail={
-            "detail": "LLM not configured.",
-            "code": "API_KEY_NOT_CONFIGURED",
-        },
+        detail="Request rejected.",
+        headers={"X-Reason": "invalid"},
     )
 
-    response = asyncio.run(http_exception_handler(_request(), exc))
+    response = asyncio.run(framework_http_exception_handler(_request(), exc))
 
     assert response.status_code == 400
-    assert _payload(response) == {
-        "error": {
-            "code": "API_KEY_NOT_CONFIGURED",
-            "message": "LLM not configured.",
-            "details": {},
-        }
-    }
-
-
-def test_http_exception_handler_uses_safe_code_for_unknown_legacy_code():
-    exc = HTTPException(
-        status_code=418,
-        detail={"detail": "Request rejected.", "code": "RUNTIME_CODE"},
-        headers={"X-Reason": "teapot"},
-    )
-
-    response = asyncio.run(http_exception_handler(_request(), exc))
-
-    assert response.status_code == 418
-    assert response.headers["x-reason"] == "teapot"
+    assert response.headers["x-reason"] == "invalid"
     assert _payload(response) == {
         "error": {
             "code": "HTTP_ERROR",
@@ -129,24 +108,24 @@ def test_http_exception_handler_uses_safe_code_for_unknown_legacy_code():
     }
 
 
-def test_http_exception_handler_does_not_reflect_nested_detail_objects():
+def test_framework_http_exception_handler_does_not_reflect_nested_details():
     secret = "sk-secret-value"
-    exc = HTTPException(
+    exc = StarletteHTTPException(
         status_code=400,
-        detail={"detail": {"api_key": secret}, "code": "UNKNOWN"},
+        detail={"api_key": secret},
     )
 
-    response = asyncio.run(http_exception_handler(_request(), exc))
+    response = asyncio.run(framework_http_exception_handler(_request(), exc))
 
     assert _payload(response)["error"]["message"] == "Request failed."
     assert secret not in response.body.decode()
 
 
-def test_http_exception_handler_sanitizes_unknown_server_errors():
+def test_framework_http_exception_handler_sanitizes_server_errors():
     secret = "database failed password=secret https://internal.example/debug"
-    exc = HTTPException(status_code=503, detail=secret)
+    exc = StarletteHTTPException(status_code=503, detail=secret)
 
-    response = asyncio.run(http_exception_handler(_request(), exc))
+    response = asyncio.run(framework_http_exception_handler(_request(), exc))
 
     assert response.status_code == 503
     assert _payload(response) == {

--- a/backend/tests/test_exception_migration.py
+++ b/backend/tests/test_exception_migration.py
@@ -1,0 +1,217 @@
+import ast
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import app.exceptions as exceptions
+from app.exceptions import (
+    ApplicationNotFoundError,
+    FileParseError,
+    FileTooLargeError,
+    HistoryEntryNotFoundError,
+    InvalidRequestError,
+    PDFRenderFailedError,
+    ProfileNotFoundError,
+    ProviderNotFoundError,
+    ScrapeFailedError,
+    ScrapeValueError,
+    UnsupportedFileTypeError,
+)
+from app.exceptions.handlers import framework_http_exception_handler
+from app.exceptions.infrastructure import InternalApplicationError, RateLimitError
+from app.exceptions.stream import stream_error_event
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = BACKEND_ROOT / "app"
+
+
+def _request(path: str = "/example", method: str = "GET") -> SimpleNamespace:
+    return SimpleNamespace(method=method, url=SimpleNamespace(path=path))
+
+
+def _payload(response) -> dict:
+    return json.loads(response.body)
+
+
+def test_domain_errors_expose_stable_codes_statuses_and_details():
+    cases = [
+        (
+            ProfileNotFoundError(12),
+            404,
+            "PROFILE_NOT_FOUND",
+            "Profile was not found.",
+            {"profile_id": 12},
+        ),
+        (
+            ApplicationNotFoundError(8),
+            404,
+            "APPLICATION_NOT_FOUND",
+            "Application was not found.",
+            {"application_id": 8},
+        ),
+        (
+            HistoryEntryNotFoundError("CV entry", 5),
+            404,
+            "HISTORY_ENTRY_NOT_FOUND",
+            "CV entry was not found.",
+            {"resource": "CV entry", "entry_id": 5},
+        ),
+        (
+            ProviderNotFoundError("unknown"),
+            404,
+            "PROVIDER_NOT_FOUND",
+            "Provider was not found.",
+            {"provider_id": "unknown"},
+        ),
+        (
+            InvalidRequestError("Either url or text must be provided"),
+            400,
+            "INVALID_REQUEST",
+            "Either url or text must be provided",
+            {},
+        ),
+        (
+            ScrapeValueError("URL is invalid"),
+            422,
+            "SCRAPE_VALUE_ERROR",
+            "URL is invalid",
+            {},
+        ),
+        (
+            ScrapeFailedError(),
+            422,
+            "SCRAPE_FAILED",
+            "Could not extract job posting. Please paste the text manually.",
+            {},
+        ),
+        (
+            FileTooLargeError(max_size_mb=5),
+            413,
+            "FILE_TOO_LARGE",
+            "File too large. Maximum size is 5MB.",
+            {"max_size_mb": 5},
+        ),
+        (
+            UnsupportedFileTypeError(),
+            422,
+            "FILE_TYPE_UNSUPPORTED",
+            "Unsupported file type. Use PDF, DOCX, or plain text.",
+            {},
+        ),
+        (
+            FileParseError(),
+            422,
+            "FILE_PARSE_FAILED",
+            "Could not extract text from file.",
+            {},
+        ),
+        (
+            PDFRenderFailedError(),
+            502,
+            "PDF_RENDER_FAILED",
+            "Could not generate the PDF. Please try again.",
+            {},
+        ),
+    ]
+
+    for exc, status, code, message, details in cases:
+        assert exc.status_code == status
+        assert exc.to_envelope().model_dump(mode="json") == {
+            "error": {"code": code, "message": message, "details": details}
+        }
+
+
+def test_framework_http_exception_handler_normalizes_route_not_found():
+    response = asyncio.run(
+        framework_http_exception_handler(
+            _request(path="/missing"),
+            StarletteHTTPException(status_code=404, detail="Not Found"),
+        )
+    )
+
+    assert response.status_code == 404
+    assert _payload(response) == {
+        "error": {
+            "code": "ROUTE_NOT_FOUND",
+            "message": "Route was not found.",
+            "details": {},
+        }
+    }
+
+
+def test_framework_http_exception_handler_sanitizes_server_errors():
+    secret = "database password=secret https://internal.example/debug"
+    response = asyncio.run(
+        framework_http_exception_handler(
+            _request(path="/broken"),
+            StarletteHTTPException(status_code=503, detail=secret),
+        )
+    )
+
+    assert response.status_code == 503
+    assert _payload(response) == InternalApplicationError().to_envelope().model_dump(
+        mode="json"
+    )
+    assert secret not in response.body.decode()
+
+
+def test_stream_error_event_uses_public_envelope_for_rate_limits():
+    event = stream_error_event(RateLimitError(retry_after=3))
+
+    assert event.event == "rate_limit"
+    assert json.loads(event.data) == {
+        "error": {
+            "code": "RATE_LIMIT_EXCEEDED",
+            "message": "Rate limit exceeded. Please retry later.",
+            "details": {"retry_after": 3},
+        }
+    }
+
+
+def test_stream_error_event_sanitizes_unexpected_exceptions():
+    secret = "provider api_key=sk-secret https://internal.example"
+    event = stream_error_event(RuntimeError(secret))
+
+    assert event.event == "error"
+    assert json.loads(event.data) == InternalApplicationError().to_envelope().model_dump(
+        mode="json"
+    )
+    assert secret not in event.data
+
+
+def test_routes_and_dependencies_do_not_use_http_exception():
+    candidates = [APP_ROOT / "dependencies.py", *sorted((APP_ROOT / "routes").glob("*.py"))]
+    offenders: list[str] = []
+
+    for path in candidates:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module in {
+                "fastapi",
+                "starlette.exceptions",
+            }:
+                if any(alias.name == "HTTPException" for alias in node.names):
+                    offenders.append(f"{path.relative_to(BACKEND_ROOT)}:{node.lineno}")
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "HTTPException"
+            ):
+                offenders.append(f"{path.relative_to(BACKEND_ROOT)}:{node.lineno}")
+
+    assert offenders == []
+
+
+def test_legacy_exception_compatibility_exports_are_removed():
+    legacy_names = {
+        "BaseCustomException",
+        "ValidationError",
+        "InternalServerError",
+        "error_response",
+        "not_found_404",
+    }
+
+    assert {name for name in legacy_names if hasattr(exceptions, name)} == set()

--- a/backend/tests/test_exception_migration.py
+++ b/backend/tests/test_exception_migration.py
@@ -158,11 +158,11 @@ def test_framework_http_exception_handler_sanitizes_server_errors():
     assert secret not in response.body.decode()
 
 
-def test_stream_error_event_uses_public_envelope_for_rate_limits():
+def test_stream_error_event_uses_native_public_envelope_for_rate_limits():
     event = stream_error_event(RateLimitError(retry_after=3))
 
     assert event.event == "rate_limit"
-    assert json.loads(event.data) == {
+    assert event.data == {
         "error": {
             "code": "RATE_LIMIT_EXCEEDED",
             "message": "Rate limit exceeded. Please retry later.",
@@ -176,14 +176,16 @@ def test_stream_error_event_sanitizes_unexpected_exceptions():
     event = stream_error_event(RuntimeError(secret))
 
     assert event.event == "error"
-    assert json.loads(event.data) == InternalApplicationError().to_envelope().model_dump(
-        mode="json"
-    )
-    assert secret not in event.data
+    assert event.data == InternalApplicationError().to_envelope().model_dump(mode="json")
+    assert secret not in json.dumps(event.data)
 
 
-def test_routes_and_dependencies_do_not_use_http_exception():
-    candidates = [APP_ROOT / "dependencies.py", *sorted((APP_ROOT / "routes").glob("*.py"))]
+def test_application_code_does_not_use_http_exception():
+    candidates = [
+        path
+        for path in sorted(APP_ROOT.rglob("*.py"))
+        if path != APP_ROOT / "exceptions" / "handlers.py"
+    ]
     offenders: list[str] = []
 
     for path in candidates:

--- a/frontend/src/lib/stream.test.ts
+++ b/frontend/src/lib/stream.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+
+import { consumeStream, consumeStructuredStream } from './stream';
+
+
+function sseResponse(payload: string): Response {
+    const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+            controller.enqueue(new TextEncoder().encode(payload));
+            controller.close();
+        },
+    });
+    return new Response(body);
+}
+
+
+describe('SSE error envelopes', () => {
+    test('consumeStream extracts the public message from an error envelope', async () => {
+        let message: string | undefined;
+        const response = sseResponse(
+            'event: error\n' +
+            'data: {"error":{"code":"LLM_CALL_FAILED","message":"Provider request failed.","details":{}}}\n\n'
+        );
+
+        await consumeStream(response, {
+            onError(value) {
+                message = value;
+            },
+        });
+
+        expect(message).toBe('Provider request failed.');
+    });
+
+    test('consumeStructuredStream routes error events through onError', async () => {
+        let message: string | undefined;
+        const events: string[] = [];
+        const response = sseResponse(
+            'event: error\n' +
+            'data: {"error":{"code":"INTERNAL_SERVER_ERROR","message":"An unexpected error occurred","details":{}}}\n\n'
+        );
+
+        await consumeStructuredStream(response, {
+            onEvent(event) {
+                events.push(event);
+            },
+            onError(value) {
+                message = value;
+            },
+        });
+
+        expect(message).toBe('An unexpected error occurred');
+        expect(events).toEqual([]);
+    });
+
+    test('consumeStructuredStream keeps rate limit envelopes as typed events', async () => {
+        let received: unknown;
+        const response = sseResponse(
+            'event: rate_limit\n' +
+            'data: {"error":{"code":"RATE_LIMIT_EXCEEDED","message":"Rate limit exceeded.","details":{"retry_after":3}}}\n\n'
+        );
+
+        await consumeStructuredStream(response, {
+            onEvent(event, data) {
+                if (event === 'rate_limit') received = data;
+            },
+        });
+
+        expect(received).toEqual({
+            error: {
+                code: 'RATE_LIMIT_EXCEEDED',
+                message: 'Rate limit exceeded.',
+                details: { retry_after: 3 },
+            },
+        });
+    });
+});

--- a/frontend/src/lib/stream.ts
+++ b/frontend/src/lib/stream.ts
@@ -1,8 +1,26 @@
+import { parseApiError } from './api-error';
+
+
 export interface StreamOptions {
   onChunk?: (text: string) => void;
   onDone?: () => void;
   onError?: (msg: string) => void;
   transformChunk?: (chunk: string) => string;
+}
+
+function streamErrorMessage(payload: unknown, fallback = 'Request failed.'): string | undefined {
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    return undefined;
+  }
+
+  const record = payload as Record<string, unknown>;
+  if (typeof record.error === 'string' && record.error.trim()) {
+    return record.error;
+  }
+  if (typeof record.error === 'object' && record.error !== null) {
+    return parseApiError(payload, fallback).message;
+  }
+  return undefined;
 }
 
 export async function consumeStream(response: Response, options: StreamOptions = {}): Promise<void> {
@@ -48,8 +66,9 @@ export async function consumeStream(response: Response, options: StreamOptions =
               onDone?.();
               return;
             }
-            if (parsed.error) {
-              onError?.(parsed.error);
+            const errorMessage = streamErrorMessage(parsed);
+            if (errorMessage) {
+              onError?.(errorMessage);
               return;
             }
             if (parsed.chunk !== undefined) {
@@ -110,6 +129,13 @@ export async function consumeStructuredStream(
           try {
             const parsed = JSON.parse(raw);
             const data = typeof parsed === 'string' ? JSON.parse(parsed) : parsed;
+            if (currentEvent === 'error') {
+              options.onError?.(
+                streamErrorMessage(data, 'Streaming request failed.')
+                ?? 'Streaming request failed.'
+              );
+              return;
+            }
             options.onEvent(currentEvent, data);
           } catch {
             options.onError?.(raw);


### PR DESCRIPTION
## Summary

- replace every application-level `HTTPException` with typed `AppError` subclasses across profiles, applications, history, settings, scraper, CV import, PDF generation, and LLM dependencies
- add stable domain error codes and consistent `{ "error": { "code", "message", "details" } }` responses
- retain only a framework-level Starlette HTTP adapter for router-generated 404/405 and other framework failures
- remove transitional aliases and helpers including `BaseCustomException`, legacy wrappers, `error_response`, and `not_found_404`
- standardize SSE failures on the same public envelope and keep unknown exception details server-side
- update frontend stream consumers for typed error and rate-limit events
- add a full application AST audit preventing `HTTPException` from returning outside the framework handler

## Security

- unknown HTTP 5xx and streaming failures return only the safe internal-error envelope
- PDF rendering failures no longer expose renderer exception text
- request validation continues to omit raw input values
- SSE payloads use native JSON objects, avoiding double-encoded envelopes

## Verification

- TDD RED: backend and frontend initially failed because domain errors and stream parsing were absent
- review regression RED: both backend matrices failed when SSE envelopes were still emitted as pre-serialized strings
- Backend CI passed on Python 3.12 and 3.13 with lint and 62 tests
- Frontend CI passed unit tests, Svelte/TypeScript checks, and production build
- no unresolved review threads

No design specification or implementation plan is included in the repository.