### PR TITLE
feat: add curated LLM provider catalog

### DIFF
--- a/backend/app/llm/README.md
+++ b/backend/app/llm/README.md
@@ -1,0 +1,5 @@
+# LLM catalog
+
+`catalog.yaml` is the release-managed source of truth for supported providers and active text/chat models. The catalog is loaded with PyYAML's safe loader and validated by immutable Pydantic models at backend startup.
+
+OpenRouter and Hugging Face intentionally contain a smaller curated selection to keep the Settings UI usable. Update this catalog as part of an ApplyKit release when providers add, preview, or deprecate models.

--- a/backend/app/llm/__init__.py
+++ b/backend/app/llm/__init__.py
@@ -1,0 +1,1 @@
+"""Validated LLM provider and model catalog."""

--- a/backend/app/llm/catalog.py
+++ b/backend/app/llm/catalog.py
@@ -1,0 +1,76 @@
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from app.llm.models import CatalogDefinition, ProviderDefinition
+
+try:
+    from yaml import CSafeLoader as CatalogSafeLoader
+except ImportError:  # pragma: no cover - depends on platform wheel availability
+    from yaml import SafeLoader as CatalogSafeLoader
+
+
+CATALOG_PATH = Path(__file__).with_name("catalog.yaml")
+
+
+def load_catalog(path: Path = CATALOG_PATH) -> CatalogDefinition:
+    with path.open("r", encoding="utf-8") as stream:
+        raw: Any = yaml.load(stream, Loader=CatalogSafeLoader)
+    if not isinstance(raw, dict):
+        raise ValueError("LLM catalog root must be a mapping")
+    return CatalogDefinition.model_validate(raw)
+
+
+CATALOG = load_catalog()
+
+
+@lru_cache(maxsize=1)
+def provider_index() -> dict[str, ProviderDefinition]:
+    return {provider.id: provider for provider in CATALOG.providers}
+
+
+@lru_cache(maxsize=1)
+def model_index() -> dict[str, str]:
+    return {
+        model.id: provider.id
+        for provider in CATALOG.providers
+        for model in provider.models
+    }
+
+
+def get_provider(provider_id: str | None) -> ProviderDefinition | None:
+    if not provider_id:
+        return None
+    return provider_index().get(provider_id)
+
+
+def get_provider_models(provider_id: str) -> tuple[str, ...]:
+    provider = get_provider(provider_id)
+    if not provider:
+        return ()
+    return tuple(model.id for model in provider.models)
+
+
+def provider_from_model(model_id: str) -> str | None:
+    if not model_id:
+        return None
+
+    known_provider = model_index().get(model_id)
+    if known_provider:
+        return known_provider
+
+    # Keep persisted models from older ApplyKit releases attributable to their
+    # provider, even when they are no longer offered in the active catalog.
+    for provider in CATALOG.providers:
+        if model_id == provider.model_prefix or model_id.startswith(
+            f"{provider.model_prefix}/"
+        ):
+            return provider.id
+    return None
+
+
+def provider_requires_api_key(provider_id: str | None) -> bool:
+    provider = get_provider(provider_id)
+    return provider is None or provider.auth_type != "none"

--- a/backend/app/llm/catalog.yaml
+++ b/backend/app/llm/catalog.yaml
@@ -1,0 +1,383 @@
+providers:
+  - id: anthropic
+    label: Anthropic Claude
+    model_prefix: anthropic
+    auth_type: api_key
+    models:
+      - id: anthropic/claude-haiku-4-5-20251001
+        label: Claude Haiku 4.5
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, low_cost]
+      - id: anthropic/claude-opus-4-6
+        label: Claude Opus 4.6
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+      - id: anthropic/claude-sonnet-4-6
+        label: Claude Sonnet 4.6
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+
+  - id: deepseek
+    label: DeepSeek
+    model_prefix: deepseek
+    auth_type: api_key
+    models:
+      - id: deepseek/deepseek-v4-flash
+        label: DeepSeek V4 Flash
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, low_cost, reasoning]
+      - id: deepseek/deepseek-v4-pro
+        label: DeepSeek V4 Pro
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+
+  - id: gemini
+    label: Google Gemini
+    model_prefix: gemini
+    auth_type: api_key
+    models:
+      - id: gemini/gemini-2.5-flash
+        label: Gemini 2.5 Flash
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, low_cost, reasoning]
+        free_tier: true
+      - id: gemini/gemini-2.5-flash-lite
+        label: Gemini 2.5 Flash Lite
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, low_cost]
+        free_tier: true
+      - id: gemini/gemini-2.5-pro
+        label: Gemini 2.5 Pro
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+        free_tier: true
+      - id: gemini/gemini-3-flash-preview
+        label: Gemini 3 Flash Preview
+        status: preview
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, reasoning]
+        free_tier: true
+      - id: gemini/gemini-3.1-flash-lite-preview
+        label: Gemini 3.1 Flash Lite Preview
+        status: preview
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, low_cost]
+        free_tier: true
+      - id: gemini/gemini-3.1-pro-preview
+        label: Gemini 3.1 Pro Preview
+        status: preview
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+        free_tier: true
+
+  - id: groq
+    label: Groq
+    model_prefix: groq
+    auth_type: api_key
+    models:
+      - id: groq/groq/compound
+        label: Compound
+        capabilities: [text, streaming]
+        traits: [fast]
+        free_tier: true
+      - id: groq/groq/compound-mini
+        label: Compound Mini
+        capabilities: [text, streaming]
+        traits: [fast, low_cost]
+        free_tier: true
+      - id: groq/openai/gpt-oss-120b
+        label: GPT-OSS 120B
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+        free_tier: true
+      - id: groq/openai/gpt-oss-20b
+        label: GPT-OSS 20B
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, low_cost, reasoning]
+        free_tier: true
+      - id: groq/minimaxai/minimax-m2.7
+        label: MiniMax M2.7 Preview
+        status: preview
+        capabilities: [text, streaming]
+        traits: [reasoning]
+      - id: groq/qwen/qwen3.6-27b
+        label: Qwen 3.6 27B Preview
+        status: preview
+        capabilities: [text, streaming]
+        traits: [fast, reasoning]
+
+  - id: huggingface
+    label: Hugging Face
+    model_prefix: huggingface
+    auth_type: token
+    models:
+      - id: huggingface/deepseek-ai/DeepSeek-R1
+        label: DeepSeek R1
+        capabilities: [text, streaming]
+        traits: [reasoning]
+        free_tier: true
+      - id: huggingface/google/gemma-3-27b-it
+        label: Gemma 3 27B Instruct
+        capabilities: [text, streaming]
+        traits: [high_quality]
+        free_tier: true
+      - id: huggingface/openai/gpt-oss-120b
+        label: GPT-OSS 120B
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+        free_tier: true
+      - id: huggingface/openai/gpt-oss-20b
+        label: GPT-OSS 20B
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, low_cost, reasoning]
+        free_tier: true
+      - id: huggingface/zai-org/GLM-4.5
+        label: GLM 4.5
+        capabilities: [text, streaming]
+        traits: [high_quality, reasoning]
+        free_tier: true
+      - id: huggingface/meta-llama/Llama-3.3-70B-Instruct
+        label: Llama 3.3 70B Instruct
+        capabilities: [text, streaming]
+        traits: [high_quality]
+        free_tier: true
+      - id: huggingface/mistralai/Mistral-Small-3.1-24B-Instruct-2503
+        label: Mistral Small 3.1 24B Instruct
+        capabilities: [text, streaming]
+        traits: [fast, low_cost]
+        free_tier: true
+      - id: huggingface/Qwen/Qwen2.5-7B-Instruct-1M
+        label: Qwen 2.5 7B Instruct 1M
+        capabilities: [text, streaming]
+        traits: [low_cost]
+        free_tier: true
+      - id: huggingface/Qwen/Qwen2.5-Coder-32B-Instruct
+        label: Qwen 2.5 Coder 32B Instruct
+        capabilities: [text, streaming]
+        traits: [high_quality]
+        free_tier: true
+      - id: huggingface/Qwen/Qwen3-4B-Thinking-2507
+        label: Qwen 3 4B Thinking
+        capabilities: [text, streaming]
+        traits: [low_cost, reasoning]
+        free_tier: true
+      - id: huggingface/Qwen/Qwen3-Coder-480B-A35B-Instruct
+        label: Qwen 3 Coder 480B A35B Instruct
+        capabilities: [text, streaming]
+        traits: [high_quality, reasoning]
+        free_tier: true
+      - id: huggingface/zai-org/GLM-4.5-Air
+        label: Z.ai GLM 4.5 Air
+        capabilities: [text, streaming]
+        traits: [fast, low_cost]
+        free_tier: true
+
+  - id: mistral
+    label: Mistral AI
+    model_prefix: mistral
+    auth_type: api_key
+    models:
+      - id: mistral/codestral-latest
+        label: Codestral Latest
+        capabilities: [text, streaming]
+        traits: [high_quality]
+      - id: mistral/magistral-medium-latest
+        label: Magistral Medium Latest
+        capabilities: [text, streaming]
+        traits: [high_quality, reasoning]
+      - id: mistral/magistral-small-latest
+        label: Magistral Small Latest
+        capabilities: [text, streaming]
+        traits: [low_cost, reasoning]
+      - id: mistral/ministral-3b-latest
+        label: Ministral 3B Latest
+        capabilities: [text, streaming]
+        traits: [fast, low_cost]
+      - id: mistral/ministral-8b-latest
+        label: Ministral 8B Latest
+        capabilities: [text, streaming]
+        traits: [fast, low_cost]
+      - id: mistral/mistral-large-latest
+        label: Mistral Large Latest
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality]
+      - id: mistral/mistral-medium-latest
+        label: Mistral Medium Latest
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality]
+      - id: mistral/mistral-small-latest
+        label: Mistral Small Latest
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, low_cost]
+        free_tier: true
+
+  - id: ollama
+    label: Ollama
+    model_prefix: ollama
+    auth_type: none
+    local: true
+    models:
+      - id: ollama/glm-4.7-flash
+        label: GLM 4.7 Flash
+        capabilities: [text, streaming]
+        traits: [fast, local]
+      - id: ollama/glm-5
+        label: GLM 5
+        capabilities: [text, streaming]
+        traits: [high_quality, local]
+      - id: ollama/llama3
+        label: Llama 3
+        capabilities: [text, streaming]
+        traits: [local]
+      - id: ollama/llama3.1
+        label: Llama 3.1
+        capabilities: [text, streaming]
+        traits: [local]
+      - id: ollama/llama3.2
+        label: Llama 3.2
+        capabilities: [text, streaming]
+        traits: [local]
+      - id: ollama/llama4
+        label: Llama 4
+        capabilities: [text, streaming]
+        traits: [high_quality, local]
+      - id: ollama/qwen3-next
+        label: Qwen 3 Next
+        capabilities: [text, streaming]
+        traits: [local, reasoning]
+      - id: ollama/qwen3.5
+        label: Qwen 3.5
+        capabilities: [text, streaming]
+        traits: [local, reasoning]
+
+  - id: openai
+    label: OpenAI
+    model_prefix: openai
+    auth_type: api_key
+    models:
+      - id: openai/gpt-4.1
+        label: GPT-4.1
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality]
+      - id: openai/gpt-4.1-mini
+        label: GPT-4.1 Mini
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, low_cost]
+      - id: openai/gpt-4.1-nano
+        label: GPT-4.1 Nano
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, low_cost]
+      - id: openai/gpt-5
+        label: GPT-5
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+      - id: openai/gpt-5-mini
+        label: GPT-5 Mini
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, low_cost, reasoning]
+      - id: openai/gpt-5-nano
+        label: GPT-5 Nano
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, low_cost, reasoning]
+      - id: openai/gpt-5-pro
+        label: GPT-5 Pro
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+      - id: openai/gpt-5.1
+        label: GPT-5.1
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+      - id: openai/gpt-5.2
+        label: GPT-5.2
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+      - id: openai/o3
+        label: o3
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+      - id: openai/o4-mini
+        label: o4-mini
+        capabilities: [text, streaming, structured_output]
+        traits: [low_cost, reasoning]
+
+  - id: openrouter
+    label: OpenRouter
+    model_prefix: openrouter
+    auth_type: api_key
+    models:
+      - id: openrouter/anthropic/claude-opus-4.6
+        label: Claude Opus 4.6
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+      - id: openrouter/anthropic/claude-sonnet-4.6
+        label: Claude Sonnet 4.6
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+      - id: openrouter/deepseek/deepseek-r1
+        label: DeepSeek R1
+        capabilities: [text, streaming]
+        traits: [reasoning]
+      - id: openrouter/free
+        label: Free Models Router
+        capabilities: [text, streaming]
+        traits: [low_cost]
+        free_tier: true
+      - id: openrouter/google/gemini-2.5-flash
+        label: Gemini 2.5 Flash
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, low_cost, reasoning]
+      - id: openrouter/google/gemini-2.5-pro
+        label: Gemini 2.5 Pro
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+      - id: openrouter/openai/gpt-oss-120b
+        label: GPT-OSS 120B
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+      - id: openrouter/openai/gpt-5.2
+        label: GPT-5.2
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+      - id: openrouter/meta-llama/llama-4-maverick
+        label: Llama 4 Maverick
+        capabilities: [text, streaming]
+        traits: [high_quality]
+      - id: openrouter/minimax/minimax-m2.1
+        label: MiniMax M2.1
+        capabilities: [text, streaming]
+        traits: [reasoning]
+      - id: openrouter/mistralai/mistral-large
+        label: Mistral Large
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality]
+      - id: openrouter/qwen/qwen3-235b-a22b
+        label: Qwen 3 235B A22B
+        capabilities: [text, streaming]
+        traits: [high_quality, reasoning]
+      - id: openrouter/x-ai/grok-4.5
+        label: xAI Grok 4.5
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+      - id: openrouter/z-ai/glm-4.5
+        label: Z.ai GLM 4.5
+        capabilities: [text, streaming]
+        traits: [high_quality, reasoning]
+
+  - id: xai
+    label: xAI
+    model_prefix: xai
+    auth_type: api_key
+    models:
+      - id: xai/grok-4.3
+        label: Grok 4.3
+        capabilities: [text, streaming, structured_output]
+        traits: [fast, high_quality, reasoning]
+      - id: xai/grok-4.5
+        label: Grok 4.5
+        capabilities: [text, streaming, structured_output]
+        traits: [high_quality, reasoning]
+      - id: xai/grok-build-0.1
+        label: Grok Build 0.1
+        status: preview
+        capabilities: [text, streaming]
+        traits: [fast]

--- a/backend/app/llm/models.py
+++ b/backend/app/llm/models.py
@@ -74,11 +74,8 @@ class ProviderDefinition(BaseModel):
 
     @field_validator("models")
     @classmethod
-    def models_are_sorted(cls, models: tuple[ModelDefinition, ...]):
-        labels = [model.label.casefold() for model in models]
-        if labels != sorted(labels):
-            raise ValueError("provider models must be sorted alphabetically")
-        return models
+    def sort_models(cls, models: tuple[ModelDefinition, ...]):
+        return tuple(sorted(models, key=lambda model: model.label.casefold()))
 
     @model_validator(mode="after")
     def validate_provider_semantics(self):
@@ -109,11 +106,8 @@ class CatalogDefinition(BaseModel):
 
     @field_validator("providers")
     @classmethod
-    def providers_are_sorted(cls, providers: tuple[ProviderDefinition, ...]):
-        labels = [provider.label.casefold() for provider in providers]
-        if labels != sorted(labels):
-            raise ValueError("providers must be sorted alphabetically")
-        return providers
+    def sort_providers(cls, providers: tuple[ProviderDefinition, ...]):
+        return tuple(sorted(providers, key=lambda provider: provider.label.casefold()))
 
     @model_validator(mode="after")
     def validate_uniqueness(self):

--- a/backend/app/llm/models.py
+++ b/backend/app/llm/models.py
@@ -1,0 +1,131 @@
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+
+class ModelStatus(StrEnum):
+    STABLE = "stable"
+    PREVIEW = "preview"
+    EXPERIMENTAL = "experimental"
+
+
+class AuthType(StrEnum):
+    API_KEY = "api_key"
+    TOKEN = "token"
+    NONE = "none"
+
+
+class Capability(StrEnum):
+    TEXT = "text"
+    STREAMING = "streaming"
+    STRUCTURED_OUTPUT = "structured_output"
+
+
+class ModelTrait(StrEnum):
+    FAST = "fast"
+    LOW_COST = "low_cost"
+    HIGH_QUALITY = "high_quality"
+    LOCAL = "local"
+    REASONING = "reasoning"
+
+
+class ModelDefinition(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    label: str
+    status: ModelStatus = ModelStatus.STABLE
+    capabilities: frozenset[Capability]
+    traits: frozenset[ModelTrait] = frozenset()
+    free_tier: bool = False
+
+    @field_validator("id", "label")
+    @classmethod
+    def non_empty_string(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("must not be empty")
+        return value
+
+    @model_validator(mode="after")
+    def requires_text_capability(self):
+        if Capability.TEXT not in self.capabilities:
+            raise ValueError("catalog models must support text")
+        return self
+
+
+class ProviderDefinition(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    label: str
+    model_prefix: str
+    auth_type: AuthType
+    local: bool = False
+    models: tuple[ModelDefinition, ...]
+
+    @field_validator("id", "label", "model_prefix")
+    @classmethod
+    def non_empty_string(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("must not be empty")
+        return value
+
+    @field_validator("models")
+    @classmethod
+    def models_are_sorted(cls, models: tuple[ModelDefinition, ...]):
+        labels = [model.label.casefold() for model in models]
+        if labels != sorted(labels):
+            raise ValueError("provider models must be sorted alphabetically")
+        return models
+
+    @model_validator(mode="after")
+    def validate_provider_semantics(self):
+        if not self.models:
+            raise ValueError("provider must define at least one model")
+        if self.auth_type == AuthType.NONE and not self.local:
+            raise ValueError("keyless providers must be local")
+        if self.local and self.auth_type != AuthType.NONE:
+            raise ValueError("local providers must be keyless")
+
+        expected_prefix = f"{self.model_prefix}/"
+        for model in self.models:
+            if not model.id.startswith(expected_prefix):
+                raise ValueError(
+                    f"model {model.id!r} must start with {expected_prefix!r}"
+                )
+            if self.local and ModelTrait.LOCAL not in model.traits:
+                raise ValueError("local provider models must have the local trait")
+            if not self.local and ModelTrait.LOCAL in model.traits:
+                raise ValueError("remote provider models cannot have the local trait")
+        return self
+
+
+class CatalogDefinition(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    providers: tuple[ProviderDefinition, ...]
+
+    @field_validator("providers")
+    @classmethod
+    def providers_are_sorted(cls, providers: tuple[ProviderDefinition, ...]):
+        labels = [provider.label.casefold() for provider in providers]
+        if labels != sorted(labels):
+            raise ValueError("providers must be sorted alphabetically")
+        return providers
+
+    @model_validator(mode="after")
+    def validate_uniqueness(self):
+        provider_ids = [provider.id for provider in self.providers]
+        if len(provider_ids) != len(set(provider_ids)):
+            raise ValueError("provider IDs must be unique")
+
+        model_ids = [
+            model.id
+            for provider in self.providers
+            for model in provider.models
+        ]
+        if len(model_ids) != len(set(model_ids)):
+            raise ValueError("model IDs must be globally unique")
+        return self

--- a/backend/app/llm/schemas.py
+++ b/backend/app/llm/schemas.py
@@ -1,0 +1,25 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class ModelOption(BaseModel):
+    value: str
+    label: str
+    status: Literal["stable", "preview", "experimental"]
+    capabilities: list[str]
+    traits: list[str]
+    free_tier: bool
+
+
+class ProviderInfo(BaseModel):
+    id: str
+    label: str
+    auth_type: Literal["api_key", "token", "none"]
+    local: bool
+    models: list[ModelOption]
+    requires_api_key: bool
+
+
+class ModelsResponse(BaseModel):
+    providers: list[ProviderInfo]

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -5,20 +5,18 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.exceptions import ProviderNotFoundError
+from app.llm.catalog import CATALOG, get_provider
+from app.llm.schemas import ModelOption, ModelsResponse, ProviderInfo
 from app.public_errors import PROVIDER_CONNECTION_ERROR_MESSAGE
 from app.schemas import (
     ActivateProviderRequest,
     IntegrationInfo,
     IntegrationsResponse,
-    ModelOption,
-    ModelsResponse,
-    ProviderInfo,
     SettingsResponse,
     TestConnectionResponse,
     UpdateSettingsRequest,
 )
 from app.services.settings import (
-    KNOWN_MODELS,
     clear_provider_api_key,
     get_llm_config,
     get_provider_api_key,
@@ -34,13 +32,6 @@ from app.services.settings import (
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-
-PROVIDER_LABELS = {
-    "gemini": "Google Gemini",
-    "anthropic": "Anthropic Claude",
-    "openai": "OpenAI",
-    "ollama": "Ollama (local)",
-}
 
 
 def _mask_api_key(key: str) -> str | None:
@@ -71,25 +62,25 @@ def get_integrations(db: Session = Depends(get_db)):
     active_provider = provider_from_model(active_model)
 
     integrations = []
-    for provider_id, models in KNOWN_MODELS.items():
+    for provider in CATALOG.providers:
         api_key = ""
-        if provider_requires_api_key(provider_id):
-            api_key = get_provider_api_key(db, provider_id) or ""
+        if provider_requires_api_key(provider.id):
+            api_key = get_provider_api_key(db, provider.id) or ""
             # Legacy fallback for the active provider
-            if not api_key and provider_id == active_provider:
+            if not api_key and provider.id == active_provider:
                 api_key = get_setting(db, "llm_api_key") or ""
 
-        is_active = provider_id == active_provider
+        is_active = provider.id == active_provider
         current_model = (
             active_model
             if is_active
-            else get_setting(db, f"selected_model_{provider_id}")
+            else get_setting(db, f"selected_model_{provider.id}")
         )
 
         integrations.append(
             IntegrationInfo(
-                id=provider_id,
-                label=PROVIDER_LABELS.get(provider_id, provider_id),
+                id=provider.id,
+                label=provider.label,
                 is_active=is_active,
                 api_key_configured=bool(api_key),
                 masked_api_key=_mask_api_key(api_key) if api_key else None,
@@ -133,11 +124,13 @@ def activate_provider(req: ActivateProviderRequest, db: Session = Depends(get_db
     """Switch active provider without changing any stored API key."""
     migrate_legacy_api_key(db)
 
-    provider_id = req.provider_id
-    saved_model = get_setting(db, f"selected_model_{provider_id}")
+    provider = get_provider(req.provider_id)
+    if provider is None:
+        raise ProviderNotFoundError(req.provider_id)
+
+    saved_model = get_setting(db, f"selected_model_{provider.id}")
     if not saved_model:
-        models = KNOWN_MODELS.get(provider_id, [])
-        saved_model = models[0] if models else provider_id
+        saved_model = provider.models[0].id
     set_active_model(db, saved_model)
     model, api_key = get_llm_config(db)
     return SettingsResponse(
@@ -189,7 +182,7 @@ def test_connection(req: UpdateSettingsRequest):
 @router.delete("/settings/integrations/{provider_id}", response_model=IntegrationsResponse)
 def disconnect_provider(provider_id: str, db: Session = Depends(get_db)):
     """Remove the stored API key for a provider. If it was active, clear the active model."""
-    if provider_id not in KNOWN_MODELS:
+    if get_provider(provider_id) is None:
         raise ProviderNotFoundError(provider_id)
 
     clear_provider_api_key(db, provider_id)
@@ -207,11 +200,23 @@ def get_models():
     return ModelsResponse(
         providers=[
             ProviderInfo(
-                id=provider_id,
-                label=PROVIDER_LABELS.get(provider_id, provider_id),
-                models=[ModelOption(value=model, label=model) for model in models],
-                requires_api_key=provider_requires_api_key(provider_id),
+                id=provider.id,
+                label=provider.label,
+                auth_type=provider.auth_type.value,
+                local=provider.local,
+                requires_api_key=provider_requires_api_key(provider.id),
+                models=[
+                    ModelOption(
+                        value=model.id,
+                        label=model.label,
+                        status=model.status.value,
+                        capabilities=sorted(capability.value for capability in model.capabilities),
+                        traits=sorted(trait.value for trait in model.traits),
+                        free_tier=model.free_tier,
+                    )
+                    for model in provider.models
+                ],
             )
-            for provider_id, models in KNOWN_MODELS.items()
+            for provider in CATALOG.providers
         ]
     )

--- a/backend/app/services/settings.py
+++ b/backend/app/services/settings.py
@@ -1,59 +1,18 @@
 from sqlalchemy.orm import Session
 
+from app.llm.catalog import (
+    CATALOG,
+    get_provider_models,
+    provider_from_model,
+    provider_requires_api_key,
+)
 from app.models import AppSetting
 
-# Full LiteLLM model strings, grouped by provider family.
-# Used by GET /api/settings/models and the Settings UI.
+# Backward-compatible projection for callers that still need provider -> model IDs.
 KNOWN_MODELS: dict[str, list[str]] = {
-    "gemini": [
-        "gemini/gemini-2.5-flash",
-        "gemini/gemini-2.5-pro",
-        "gemini/gemini-2.5-flash-lite",
-        "gemini/gemini-3.1-flash-lite-preview",
-        "gemini/gemini-3-flash-preview",
-        "gemini/gemini-3.1-pro-preview",
-    ],
-    "anthropic": [
-        "anthropic/claude-haiku-4-5-20251001",
-        "anthropic/claude-sonnet-4-6",
-        "anthropic/claude-opus-4-6",
-    ],
-    "openai": [
-        "openai/gpt-4o-mini-2024-07-18",
-        "openai/gpt-4o-2024-08-06",
-        "openai/gpt-4.1-2025-04-14",
-        "openai/gpt-4.1-mini-2025-04-14",
-        "openai/o4-mini-2025-04-16",
-        "openai/o3-2025-04-16",
-    ],
-    "ollama": [
-        "ollama/llama4",
-        "ollama/llama3.2",
-        "ollama/llama3.1",
-        "ollama/llama3",
-        "ollama/qwen3.5",
-        "ollama/qwen3-next",
-        "ollama/glm-5",
-        "ollama/glm-4.7-flash",
-    ],
+    provider.id: list(get_provider_models(provider.id))
+    for provider in CATALOG.providers
 }
-
-KEYLESS_PROVIDERS = frozenset({"ollama"})
-
-
-def provider_from_model(model: str) -> str | None:
-    """Extract provider id from a LiteLLM model string like 'gemini/gemini-2.5-flash'."""
-    if not model:
-        return None
-    for provider_id in KNOWN_MODELS:
-        if model.startswith(provider_id + "/") or model == provider_id:
-            return provider_id
-    return None
-
-
-def provider_requires_api_key(provider_id: str | None) -> bool:
-    """Return whether a provider requires a stored secret to be usable."""
-    return provider_id not in KEYLESS_PROVIDERS
 
 
 def is_llm_configured(model: str, api_key: str | None) -> bool:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "litellm<=1.82.6",
     "pdfplumber>=0.11.9",
     "pydantic[email]>=2.12.5",
-    "pyyaml>=6.0.3",
     "python-docx>=1.2.0",
     "python-dotenv>=1.2.2",
     "python-multipart>=0.0.22",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "litellm<=1.82.6",
     "pdfplumber>=0.11.9",
     "pydantic[email]>=2.12.5",
+    "pyyaml>=6.0.3",
     "python-docx>=1.2.0",
     "python-dotenv>=1.2.2",
     "python-multipart>=0.0.22",

--- a/backend/tests/test_llm_catalog.py
+++ b/backend/tests/test_llm_catalog.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from app.llm.catalog import CATALOG, load_catalog
+from app.llm.models import CatalogDefinition
+
+
+def test_catalog_contains_expected_providers() -> None:
+    assert {provider.id for provider in CATALOG.providers} == {
+        "anthropic",
+        "deepseek",
+        "gemini",
+        "groq",
+        "huggingface",
+        "mistral",
+        "ollama",
+        "openai",
+        "openrouter",
+        "xai",
+    }
+
+
+def test_catalog_provider_and_model_labels_are_sorted() -> None:
+    provider_labels = [provider.label.casefold() for provider in CATALOG.providers]
+    assert provider_labels == sorted(provider_labels)
+
+    for provider in CATALOG.providers:
+        model_labels = [model.label.casefold() for model in provider.models]
+        assert model_labels == sorted(model_labels)
+
+
+def test_catalog_model_ids_are_globally_unique() -> None:
+    model_ids = [
+        model.id
+        for provider in CATALOG.providers
+        for model in provider.models
+    ]
+    assert len(model_ids) == len(set(model_ids))
+
+
+def test_every_catalog_model_supports_text() -> None:
+    for provider in CATALOG.providers:
+        for model in provider.models:
+            assert "text" in model.capabilities
+
+
+def test_only_ollama_is_keyless_and_local() -> None:
+    for provider in CATALOG.providers:
+        if provider.id == "ollama":
+            assert provider.auth_type == "none"
+            assert provider.local is True
+        else:
+            assert provider.auth_type in {"api_key", "token"}
+            assert provider.local is False
+
+
+def test_openrouter_and_huggingface_are_intentionally_curated() -> None:
+    providers = {provider.id: provider for provider in CATALOG.providers}
+    assert 10 <= len(providers["openrouter"].models) <= 15
+    assert 10 <= len(providers["huggingface"].models) <= 15
+
+
+def test_invalid_catalog_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        CatalogDefinition.model_validate(
+            {
+                "providers": [
+                    {
+                        "id": "ollama",
+                        "label": "Ollama",
+                        "model_prefix": "ollama",
+                        "auth_type": "none",
+                        "local": True,
+                        "models": [
+                            {
+                                "id": "wrong/model",
+                                "label": "Wrong Model",
+                                "status": "stable",
+                                "capabilities": ["text"],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+
+def test_load_catalog_rejects_non_mapping_yaml(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.yaml"
+    path.write_text("- invalid\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="root must be a mapping"):
+        load_catalog(path)

--- a/frontend/src/lib/components/SettingsModal.svelte
+++ b/frontend/src/lib/components/SettingsModal.svelte
@@ -2,10 +2,11 @@
   import { goto, invalidateAll } from '$app/navigation';
   import { page } from '$app/state';
   import { getModels, getSettings, testConnection, updateSettings } from '$lib/api';
+  import type { CatalogProviderInfo } from '$lib/llm-catalog';
   import { toastState } from '$lib/toast.svelte';
-  import type { ProviderInfo, TestConnectionResponse } from '$lib/types';
+  import type { TestConnectionResponse } from '$lib/types';
   import { errorMessage } from '$lib/utils';
-  import { CheckCircle, Eye, EyeOff, Loader2, XCircle } from '@lucide/svelte';
+  import { CheckCircle, CircleAlert, Eye, EyeOff, Loader2, XCircle } from '@lucide/svelte';
 
   let { open = $bindable(false), initialProviderId = '', initialModel = '', initialApiKeyConfigured = false }: {
     open: boolean;
@@ -14,7 +15,7 @@
     initialApiKeyConfigured?: boolean;
   } = $props();
 
-  let providers: ProviderInfo[] = $state([]);
+  let providers: CatalogProviderInfo[] = $state([]);
   let selectedProviderId = $state('gemini');
   let selectedModel = $state('');
   let apiKey = $state('');
@@ -26,6 +27,10 @@
   let source = $state<'database' | 'env' | 'none'>('none');
 
   const selectedProvider = $derived(providers.find((p) => p.id === selectedProviderId));
+  const selectedModelInfo = $derived(selectedProvider?.models.find((model) => model.value === selectedModel));
+  const unavailableCurrentModel = $derived(
+    Boolean(initialModel && selectedProvider && !selectedProvider.models.some((model) => model.value === initialModel))
+  );
   const canReuseStoredKey = $derived(
     Boolean(initialProviderId && initialApiKeyConfigured && selectedProvider?.requires_api_key)
   );
@@ -43,18 +48,16 @@
     showApiKey = false;
     try {
       const [modelsRes, settingsRes] = await Promise.all([getModels(), getSettings()]);
-      providers = modelsRes.providers;
+      providers = modelsRes.providers as CatalogProviderInfo[];
       source = settingsRes.source;
 
-      // If opened for a specific provider, pre-select it without loading its secret.
       if (initialProviderId) {
         selectedProviderId = initialProviderId;
         selectedModel = initialModel || (providers.find((p) => p.id === initialProviderId)?.models[0]?.value ?? '');
       } else if (settingsRes.model) {
-        // Find which provider owns this model string
-        for (const p of providers) {
-          if (p.models.some((m) => m.value === settingsRes.model)) {
-            selectedProviderId = p.id;
+        for (const provider of providers) {
+          if (provider.models.some((model) => model.value === settingsRes.model)) {
+            selectedProviderId = provider.id;
             selectedModel = settingsRes.model;
             break;
           }
@@ -72,8 +75,8 @@
 
   function onProviderChange(id: string) {
     selectedProviderId = id;
-    const prov = providers.find((p) => p.id === id);
-    selectedModel = prov?.models[0]?.value ?? '';
+    const provider = providers.find((item) => item.id === id);
+    selectedModel = provider?.models[0]?.value ?? '';
     apiKey = '';
     testResult = null;
   }
@@ -93,7 +96,6 @@
     }
   }
 
-  /** Union state — mutually exclusive, impossible to be both true at once. */
   let saving = $state<'activate' | 'key' | null>(null);
 
   async function handleSave(activate: boolean) {
@@ -122,15 +124,15 @@
       if (!page.data.isOnboarded) {
         await goto('/onboarding');
       }
-    } catch (e) {
-      saveError = errorMessage(e, 'Failed to save settings.');
+    } catch (error) {
+      saveError = errorMessage(error, 'Failed to save settings.');
     } finally {
       saving = null;
     }
   }
 
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') open = false;
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') open = false;
   }
 </script>
 
@@ -140,7 +142,7 @@
   <div
     class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4"
     onclick={() => (open = false)}
-    onkeydown={(e) => e.key === 'Escape' && (open = false)}
+    onkeydown={(event) => event.key === 'Escape' && (open = false)}
     role="dialog"
     tabindex="-1"
     aria-modal="true"
@@ -148,16 +150,12 @@
   >
     <div
       class="bg-background border border-border rounded-lg shadow-xl w-full max-w-md p-6 space-y-5"
-      onclick={(e) => e.stopPropagation()}
+      onclick={(event) => event.stopPropagation()}
       role="presentation"
     >
       <div class="flex items-center justify-between">
         <h2 class="text-lg font-semibold">{initialProviderId && selectedProvider ? selectedProvider.label : 'LLM Settings'}</h2>
-        <button
-          onclick={() => (open = false)}
-          class="text-muted-foreground hover:text-foreground text-lg leading-none"
-          aria-label="Close"
-        >✕</button>
+        <button onclick={() => (open = false)} class="text-muted-foreground hover:text-foreground text-lg leading-none" aria-label="Close">✕</button>
       </div>
 
       {#if loading}
@@ -172,119 +170,103 @@
           </p>
         {/if}
 
-        <!-- Provider tabs — hidden when opened for a specific provider -->
         {#if !initialProviderId}
           <div class="space-y-1.5">
             <p class="text-sm font-medium">Provider</p>
             <div class="flex flex-wrap gap-2">
-              {#each providers as p}
+              {#each providers as provider}
                 <button
-                  onclick={() => onProviderChange(p.id)}
-                  class="px-3 py-1.5 rounded-md text-sm border transition-colors {selectedProviderId === p.id
+                  onclick={() => onProviderChange(provider.id)}
+                  class="px-3 py-1.5 rounded-md text-sm border transition-colors {selectedProviderId === provider.id
                     ? 'bg-primary text-primary-foreground border-primary'
                     : 'border-border hover:bg-accent'}"
-                >
-                  {p.label}
-                </button>
+                >{provider.label}</button>
               {/each}
             </div>
           </div>
         {:else}
-          <div class="flex items-center gap-2">
-            <p class="text-sm font-medium">{selectedProvider?.label}</p>
-          </div>
+          <p class="text-sm font-medium">{selectedProvider?.label}</p>
         {/if}
 
-        <!-- Model dropdown -->
         <div class="space-y-1.5">
           <label for="model-select" class="text-sm font-medium">Model</label>
-          <select
-            id="model-select"
-            bind:value={selectedModel}
-            class="w-full border border-border rounded-md px-3 py-2 text-sm bg-background"
-          >
-            {#each selectedProvider?.models ?? [] as m}
-              <option value={m.value}>{m.label}</option>
+          <select id="model-select" bind:value={selectedModel} class="w-full border border-border rounded-md px-3 py-2 text-sm bg-background">
+            {#if unavailableCurrentModel}
+              <option value={initialModel}>{initialModel} — unavailable</option>
+            {/if}
+            {#each selectedProvider?.models ?? [] as model}
+              <option value={model.value}>{model.label}</option>
             {/each}
           </select>
+
+          {#if unavailableCurrentModel && selectedModel === initialModel}
+            <div class="flex items-start gap-2 rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-xs text-yellow-800 dark:border-yellow-900 dark:bg-yellow-950/30 dark:text-yellow-300">
+              <CircleAlert class="w-4 h-4 shrink-0" />
+              <span>This model is no longer included in this ApplyKit release. Select an active model to replace it.</span>
+            </div>
+          {:else if selectedModelInfo}
+            <div class="flex flex-wrap gap-1.5 pt-0.5">
+              {#if selectedModelInfo.status !== 'stable'}
+                <span class="rounded bg-yellow-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-yellow-800 dark:bg-yellow-950 dark:text-yellow-300">{selectedModelInfo.status}</span>
+              {/if}
+              {#if selectedModelInfo.free_tier}
+                <span class="rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-green-800 dark:bg-green-950 dark:text-green-300">Free tier</span>
+              {/if}
+              {#if selectedProvider?.local}
+                <span class="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-blue-800 dark:bg-blue-950 dark:text-blue-300">Local</span>
+              {/if}
+              {#each selectedModelInfo.traits as trait}
+                <span class="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">{trait.replaceAll('_', ' ')}</span>
+              {/each}
+            </div>
+          {/if}
         </div>
 
-        <!-- API key -->
         {#if selectedProvider?.requires_api_key}
           <div class="space-y-1.5">
-            <label for="api-key-input" class="text-sm font-medium">API Key</label>
+            <label for="api-key-input" class="text-sm font-medium">{selectedProvider.auth_type === 'token' ? 'Access Token' : 'API Key'}</label>
             <div class="relative">
               <input
                 id="api-key-input"
                 type={showApiKey ? 'text' : 'password'}
                 bind:value={apiKey}
-                placeholder={canReuseStoredKey ? 'Leave blank to keep the current key' : 'Enter your API key…'}
+                placeholder={canReuseStoredKey ? 'Leave blank to keep the current credential' : 'Enter your credential…'}
                 class="w-full border border-border rounded-md px-3 py-2 pr-10 text-sm bg-background"
                 autocomplete="new-password"
               />
-              <button
-                type="button"
-                onclick={() => (showApiKey = !showApiKey)}
-                class="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                aria-label={showApiKey ? 'Hide API key' : 'Show API key'}
-              >
-                {#if showApiKey}
-                  <EyeOff class="w-4 h-4" />
-                {:else}
-                  <Eye class="w-4 h-4" />
-                {/if}
+              <button type="button" onclick={() => (showApiKey = !showApiKey)} class="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground" aria-label={showApiKey ? 'Hide credential' : 'Show credential'}>
+                {#if showApiKey}<EyeOff class="w-4 h-4" />{:else}<Eye class="w-4 h-4" />{/if}
               </button>
             </div>
             {#if canReuseStoredKey}
-              <p class="text-xs text-muted-foreground">A key is already configured. Enter a new value only to replace it.</p>
+              <p class="text-xs text-muted-foreground">A credential is already configured. Enter a new value only to replace it.</p>
             {/if}
           </div>
         {:else}
-          <p class="text-sm text-muted-foreground">
-            Ollama runs locally — no API key required. Make sure Ollama is running on port 11434.
-          </p>
+          <p class="text-sm text-muted-foreground">This provider runs locally and does not require an API key.</p>
         {/if}
 
-        <!-- Test connection -->
         <div class="space-y-2">
           <button
             onclick={handleTest}
             disabled={testing || !selectedModel || (selectedProvider?.requires_api_key && !apiKey)}
             class="w-full px-4 py-2 rounded-md border border-border text-sm hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
           >
-            {#if testing}
-              <Loader2 class="w-4 h-4 animate-spin" />
-              Testing…
-            {:else}
-              Test Connection
-            {/if}
+            {#if testing}<Loader2 class="w-4 h-4 animate-spin" />Testing…{:else}Test Connection{/if}
           </button>
 
           {#if testResult}
             <div class="flex items-start gap-2 text-sm {testResult.ok ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}">
-              {#if testResult.ok}
-                <CheckCircle class="w-4 h-4 shrink-0 mt-0.5" />
-              {:else}
-                <XCircle class="w-4 h-4 shrink-0 mt-0.5" />
-              {/if}
+              {#if testResult.ok}<CheckCircle class="w-4 h-4 shrink-0 mt-0.5" />{:else}<XCircle class="w-4 h-4 shrink-0 mt-0.5" />{/if}
               <span>{testResult.message}</span>
             </div>
           {/if}
         </div>
 
-        {#if saveError}
-          <p class="text-sm text-red-600">{saveError}</p>
-        {/if}
+        {#if saveError}<p class="text-sm text-red-600">{saveError}</p>{/if}
 
-        <!-- Actions -->
         <div class="flex justify-end gap-2 pt-1 flex-wrap">
-          <button
-            onclick={() => (open = false)}
-            class="px-4 py-2 rounded-md text-sm border border-border hover:bg-accent"
-          >
-            Cancel
-          </button>
-          <!-- Save key only — shown only for API-key providers when editing a non-active one -->
+          <button onclick={() => (open = false)} class="px-4 py-2 rounded-md text-sm border border-border hover:bg-accent">Cancel</button>
           {#if initialProviderId && selectedProvider?.requires_api_key}
             <button
               onclick={() => handleSave(false)}
@@ -292,7 +274,7 @@
               class="px-4 py-2 rounded-md text-sm border border-border hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             >
               {#if saving === 'key'}<Loader2 class="w-4 h-4 animate-spin" />{/if}
-              {apiKey ? 'Save Key' : 'Save Model'}
+              {apiKey ? 'Save Credential' : 'Save Model'}
             </button>
           {/if}
           <button

--- a/frontend/src/lib/llm-catalog.ts
+++ b/frontend/src/lib/llm-catalog.ts
@@ -1,0 +1,17 @@
+import type { ModelOption, ProviderInfo } from '$lib/types';
+
+export type ModelStatus = 'stable' | 'preview' | 'experimental';
+export type ProviderAuthType = 'api_key' | 'token' | 'none';
+
+export interface CatalogModelOption extends ModelOption {
+  status: ModelStatus;
+  capabilities: string[];
+  traits: string[];
+  free_tier: boolean;
+}
+
+export interface CatalogProviderInfo extends Omit<ProviderInfo, 'models'> {
+  auth_type: ProviderAuthType;
+  local: boolean;
+  models: CatalogModelOption[];
+}


### PR DESCRIPTION
## Summary
- add a release-managed YAML catalog for trusted LLM providers and active text/chat models
- validate and normalize the catalog with immutable Pydantic models
- expand Settings API metadata for status, capabilities, traits, free tier, auth type, and local providers
- add OpenRouter, Groq, Mistral, DeepSeek, xAI, and Hugging Face alongside existing providers
- render preview, experimental, free-tier, local, and model-trait badges in Settings
- preserve legacy selected models with an unavailable-model warning
- add catalog contract tests

## Catalog policy
- mainstream providers list active, non-deprecated text/chat models
- OpenRouter and Hugging Face are intentionally curated to 10–15 popular models
- the catalog is updated through ApplyKit releases and does not call provider model-list APIs

## Verification
CI must pass before merge. No release tag is included.