### PR TITLE
feat: add provider credential links

### DIFF
--- a/backend/app/llm/provider_credentials.py
+++ b/backend/app/llm/provider_credentials.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, HttpUrl, field_validator
+
+try:
+    from yaml import CSafeLoader as CredentialSafeLoader
+except ImportError:  # pragma: no cover - platform dependent
+    from yaml import SafeLoader as CredentialSafeLoader
+
+
+CREDENTIAL_LINKS_PATH = Path(__file__).with_name("provider_credentials.yaml")
+
+
+class ProviderCredentialLinks(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    providers: dict[str, HttpUrl]
+
+    @field_validator("providers")
+    @classmethod
+    def links_use_https(cls, providers: dict[str, HttpUrl]) -> dict[str, HttpUrl]:
+        for provider_id, url in providers.items():
+            if url.scheme != "https":
+                raise ValueError(f"credential URL for {provider_id} must use HTTPS")
+        return providers
+
+
+def load_provider_credential_links(
+    path: Path = CREDENTIAL_LINKS_PATH,
+) -> ProviderCredentialLinks:
+    with path.open("r", encoding="utf-8") as stream:
+        raw: Any = yaml.load(stream, Loader=CredentialSafeLoader)
+    if not isinstance(raw, dict):
+        raise ValueError("provider credential links root must be a mapping")
+    return ProviderCredentialLinks.model_validate(raw)
+
+
+CREDENTIAL_LINKS = load_provider_credential_links()
+
+
+def credential_url_for_provider(provider_id: str) -> str | None:
+    url = CREDENTIAL_LINKS.providers.get(provider_id)
+    return str(url) if url else None

--- a/backend/app/llm/provider_credentials.yaml
+++ b/backend/app/llm/provider_credentials.yaml
@@ -1,0 +1,10 @@
+providers:
+  anthropic: https://console.anthropic.com/settings/keys
+  deepseek: https://platform.deepseek.com/api_keys
+  gemini: https://aistudio.google.com/app/apikey
+  groq: https://console.groq.com/keys
+  huggingface: https://huggingface.co/settings/tokens
+  mistral: https://console.mistral.ai/api-keys
+  openai: https://platform.openai.com/api-keys
+  openrouter: https://openrouter.ai/settings/keys
+  xai: https://console.x.ai/

--- a/backend/app/llm/schemas.py
+++ b/backend/app/llm/schemas.py
@@ -17,6 +17,7 @@ class ProviderInfo(BaseModel):
     label: str
     auth_type: Literal["api_key", "token", "none"]
     local: bool
+    credential_url: str | None
     models: list[ModelOption]
     requires_api_key: bool
 

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.exceptions import ProviderNotFoundError
 from app.llm.catalog import CATALOG, get_provider
+from app.llm.provider_credentials import credential_url_for_provider
 from app.llm.schemas import ModelOption, ModelsResponse, ProviderInfo
 from app.public_errors import PROVIDER_CONNECTION_ERROR_MESSAGE
 from app.schemas import (
@@ -66,7 +67,6 @@ def get_integrations(db: Session = Depends(get_db)):
         api_key = ""
         if provider_requires_api_key(provider.id):
             api_key = get_provider_api_key(db, provider.id) or ""
-            # Legacy fallback for the active provider
             if not api_key and provider.id == active_provider:
                 api_key = get_setting(db, "llm_api_key") or ""
 
@@ -94,8 +94,6 @@ def get_integrations(db: Session = Depends(get_db)):
 def update_settings(req: UpdateSettingsRequest, db: Session = Depends(get_db)):
     migrate_legacy_api_key(db)
 
-    # An omitted or blank key means "keep the existing secret". Providers that do
-    # not require a key never persist placeholders or submitted secret values.
     provider_id = provider_from_model(req.model)
     api_key = req.api_key.strip() if req.api_key else ""
     if provider_id:
@@ -204,6 +202,7 @@ def get_models():
                 label=provider.label,
                 auth_type=provider.auth_type.value,
                 local=provider.local,
+                credential_url=credential_url_for_provider(provider.id),
                 requires_api_key=provider_requires_api_key(provider.id),
                 models=[
                     ModelOption(

--- a/backend/tests/test_provider_credentials.py
+++ b/backend/tests/test_provider_credentials.py
@@ -1,0 +1,23 @@
+from app.llm.catalog import CATALOG
+from app.llm.provider_credentials import (
+    CREDENTIAL_LINKS,
+    credential_url_for_provider,
+)
+
+
+def test_every_remote_provider_has_an_https_credential_url() -> None:
+    remote_provider_ids = {
+        provider.id for provider in CATALOG.providers if provider.auth_type != "none"
+    }
+
+    assert set(CREDENTIAL_LINKS.providers) == remote_provider_ids
+    for provider_id in remote_provider_ids:
+        assert credential_url_for_provider(provider_id).startswith("https://")
+
+
+def test_local_provider_has_no_credential_url() -> None:
+    assert credential_url_for_provider("ollama") is None
+
+
+def test_unknown_provider_has_no_credential_url() -> None:
+    assert credential_url_for_provider("unknown") is None

--- a/frontend/src/lib/components/SettingsModal.svelte
+++ b/frontend/src/lib/components/SettingsModal.svelte
@@ -2,11 +2,11 @@
   import { goto, invalidateAll } from '$app/navigation';
   import { page } from '$app/state';
   import { getModels, getSettings, testConnection, updateSettings } from '$lib/api';
-  import type { CatalogProviderInfo } from '$lib/llm-catalog';
+  import { credentialActionLabel, type CatalogProviderInfo } from '$lib/llm-catalog';
   import { toastState } from '$lib/toast.svelte';
   import type { TestConnectionResponse } from '$lib/types';
   import { errorMessage } from '$lib/utils';
-  import { CheckCircle, CircleAlert, Eye, EyeOff, Loader2, XCircle } from '@lucide/svelte';
+  import { CheckCircle, CircleAlert, ExternalLink, Eye, EyeOff, Loader2, XCircle } from '@lucide/svelte';
   import ModelSelector from '$lib/components/ModelSelector.svelte';
 
   let { open = $bindable(false), initialProviderId = '', initialModel = '', initialApiKeyConfigured = false }: {
@@ -222,7 +222,20 @@
 
         {#if selectedProvider?.requires_api_key}
           <div class="space-y-1.5">
-            <label for="api-key-input" class="text-sm font-medium">{selectedProvider.auth_type === 'token' ? 'Access Token' : 'API Key'}</label>
+            <div class="flex items-center justify-between gap-3">
+              <label for="api-key-input" class="text-sm font-medium">{selectedProvider.auth_type === 'token' ? 'Access Token' : 'API Key'}</label>
+              {#if selectedProvider.credential_url}
+                <a
+                  href={selectedProvider.credential_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+                >
+                  {credentialActionLabel(selectedProvider.auth_type)}
+                  <ExternalLink class="h-3 w-3" />
+                </a>
+              {/if}
+            </div>
             <div class="relative">
               <input
                 id="api-key-input"

--- a/frontend/src/lib/llm-catalog.test.ts
+++ b/frontend/src/lib/llm-catalog.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 
-import { filterCatalogModels, type CatalogModelFilters, type CatalogModelOption } from '$lib/llm-catalog';
+import {
+  credentialActionLabel,
+  filterCatalogModels,
+  type CatalogModelFilters,
+  type CatalogModelOption,
+} from '$lib/llm-catalog';
 
 const models: CatalogModelOption[] = [
   {
@@ -35,6 +40,13 @@ const noFilters: CatalogModelFilters = {
   reasoning: false,
   structuredOutput: false,
 };
+
+describe('credentialActionLabel', () => {
+  test('uses token-specific copy only for token providers', () => {
+    expect(credentialActionLabel('token')).toBe('Get access token');
+    expect(credentialActionLabel('api_key')).toBe('Get API key');
+  });
+});
 
 describe('filterCatalogModels', () => {
   test('searches case-insensitively by label and model ID', () => {

--- a/frontend/src/lib/llm-catalog.ts
+++ b/frontend/src/lib/llm-catalog.ts
@@ -13,6 +13,7 @@ export interface CatalogModelOption extends ModelOption {
 export interface CatalogProviderInfo extends Omit<ProviderInfo, 'models'> {
   auth_type: ProviderAuthType;
   local: boolean;
+  credential_url: string | null;
   models: CatalogModelOption[];
 }
 
@@ -21,6 +22,10 @@ export interface CatalogModelFilters {
   freeTier: boolean;
   reasoning: boolean;
   structuredOutput: boolean;
+}
+
+export function credentialActionLabel(authType: ProviderAuthType): string {
+  return authType === 'token' ? 'Get access token' : 'Get API key';
 }
 
 export function filterCatalogModels(


### PR DESCRIPTION
## Summary
- add release-managed official credential URLs for every remote LLM provider
- validate credential links through Pydantic and PyYAML using HTTPS-only URLs
- expose `credential_url` through the settings model catalog API
- show `Get API key` or `Get access token` beside the credential input
- open provider consoles in a new tab with safe link attributes
- add backend coverage for provider completeness and frontend coverage for credential copy

## Notes
- Ollama remains keyless and has no credential link
- no secrets are exposed or sent to external pages
- provider URLs are maintained in `backend/app/llm/provider_credentials.yaml`

Merge only after Backend CI and Frontend CI are green. No tag or release is included.