### PR TITLE
feat: support custom model IDs

### DIFF
--- a/backend/app/llm/model_selection.py
+++ b/backend/app/llm/model_selection.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from app.llm.catalog import CATALOG, get_provider
+
+
+CUSTOM_MODEL_PROVIDERS = frozenset({"openrouter", "huggingface", "ollama"})
+MAX_MODEL_ID_LENGTH = 200
+
+_CATALOG_MODEL_IDS = frozenset(
+    model.id for provider in CATALOG.providers for model in provider.models
+)
+
+
+def supports_custom_models(provider_id: str) -> bool:
+    return provider_id in CUSTOM_MODEL_PROVIDERS
+
+
+def validate_model_id(model_id: str) -> str:
+    normalized = model_id.strip()
+    if not normalized:
+        raise ValueError("Model ID must not be empty.")
+    if len(normalized) > MAX_MODEL_ID_LENGTH:
+        raise ValueError(
+            f"Model ID must be at most {MAX_MODEL_ID_LENGTH} characters."
+        )
+    if any(character.isspace() for character in normalized):
+        raise ValueError("Model ID must not contain whitespace.")
+    if "/" not in normalized:
+        raise ValueError("Model ID must include a provider prefix.")
+
+    provider_id, model_name = normalized.split("/", 1)
+    provider = get_provider(provider_id)
+    if provider is None:
+        raise ValueError(f"Unknown provider: {provider_id}.")
+    if not model_name:
+        raise ValueError("Model ID must include a model name after the provider prefix.")
+
+    if normalized in _CATALOG_MODEL_IDS:
+        return normalized
+    if not supports_custom_models(provider_id):
+        raise ValueError(f"Provider {provider_id} does not allow custom model IDs.")
+
+    expected_prefix = f"{provider.model_prefix}/"
+    if not normalized.startswith(expected_prefix):
+        raise ValueError(f"Model ID must start with {expected_prefix}.")
+    return normalized

--- a/backend/app/llm/schemas.py
+++ b/backend/app/llm/schemas.py
@@ -18,6 +18,7 @@ class ProviderInfo(BaseModel):
     auth_type: Literal["api_key", "token", "none"]
     local: bool
     credential_url: str | None
+    supports_custom_models: bool
     models: list[ModelOption]
     requires_api_key: bool
 

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -1,11 +1,12 @@
 import logging
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.exceptions import ProviderNotFoundError
 from app.llm.catalog import CATALOG, get_provider
+from app.llm.model_selection import supports_custom_models, validate_model_id
 from app.llm.provider_credentials import credential_url_for_provider
 from app.llm.schemas import ModelOption, ModelsResponse, ProviderInfo
 from app.public_errors import PROVIDER_CONNECTION_ERROR_MESSAGE
@@ -42,6 +43,13 @@ def _mask_api_key(key: str) -> str | None:
     if len(key) <= 8:
         return "•" * len(key)
     return key[:4] + "•" * (len(key) - 8) + key[-4:]
+
+
+def _validate_model_or_422(model_id: str) -> str:
+    try:
+        return validate_model_id(model_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @router.get("/settings", response_model=SettingsResponse)
@@ -94,7 +102,8 @@ def get_integrations(db: Session = Depends(get_db)):
 def update_settings(req: UpdateSettingsRequest, db: Session = Depends(get_db)):
     migrate_legacy_api_key(db)
 
-    provider_id = provider_from_model(req.model)
+    model_id = _validate_model_or_422(req.model)
+    provider_id = provider_from_model(model_id)
     api_key = req.api_key.strip() if req.api_key else ""
     if provider_id:
         if provider_requires_api_key(provider_id):
@@ -102,12 +111,10 @@ def update_settings(req: UpdateSettingsRequest, db: Session = Depends(get_db)):
                 set_provider_api_key(db, provider_id, api_key)
         else:
             clear_provider_api_key(db, provider_id)
-        set_setting(db, f"selected_model_{provider_id}", req.model)
-    elif api_key:
-        set_setting(db, "llm_api_key", api_key)
+        set_setting(db, f"selected_model_{provider_id}", model_id)
 
     if req.activate:
-        set_active_model(db, req.model)
+        set_active_model(db, model_id)
 
     model, configured_api_key = get_llm_config(db)
     return SettingsResponse(
@@ -142,7 +149,8 @@ def activate_provider(req: ActivateProviderRequest, db: Session = Depends(get_db
 def test_connection(req: UpdateSettingsRequest):
     import litellm
 
-    provider_id = provider_from_model(req.model)
+    model_id = _validate_model_or_422(req.model)
+    provider_id = provider_from_model(model_id)
     api_key = req.api_key.strip() if req.api_key else ""
     if provider_requires_api_key(provider_id) and not api_key:
         return TestConnectionResponse(
@@ -151,7 +159,7 @@ def test_connection(req: UpdateSettingsRequest):
         )
 
     request_kwargs = {
-        "model": req.model,
+        "model": model_id,
         "messages": [{"role": "user", "content": "Reply with the single word: ok"}],
         "timeout": 15,
         "max_tokens": 5,
@@ -168,7 +176,7 @@ def test_connection(req: UpdateSettingsRequest):
     except Exception as exc:
         logger.warning(
             "LLM connection test failed for model %s",
-            req.model,
+            model_id,
             exc_info=(type(exc), exc, exc.__traceback__),
         )
         return TestConnectionResponse(
@@ -203,6 +211,7 @@ def get_models():
                 auth_type=provider.auth_type.value,
                 local=provider.local,
                 credential_url=credential_url_for_provider(provider.id),
+                supports_custom_models=supports_custom_models(provider.id),
                 requires_api_key=provider_requires_api_key(provider.id),
                 models=[
                     ModelOption(

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -1,10 +1,10 @@
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.exceptions import ProviderNotFoundError
+from app.exceptions import ProviderNotFoundError, ValidationAppError
 from app.llm.catalog import CATALOG, get_provider
 from app.llm.model_selection import supports_custom_models, validate_model_id
 from app.llm.provider_credentials import credential_url_for_provider
@@ -49,7 +49,7 @@ def _validate_model_or_422(model_id: str) -> str:
     try:
         return validate_model_id(model_id)
     except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise ValidationAppError(str(exc)) from exc
 
 
 @router.get("/settings", response_model=SettingsResponse)

--- a/backend/tests/test_custom_model_ids.py
+++ b/backend/tests/test_custom_model_ids.py
@@ -1,0 +1,43 @@
+import pytest
+
+from app.llm.model_selection import (
+    CUSTOM_MODEL_PROVIDERS,
+    validate_model_id,
+)
+
+
+def test_catalog_model_is_accepted() -> None:
+    assert validate_model_id("openai/gpt-5-mini") == "openai/gpt-5-mini"
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "openrouter/google/gemini-2.5-flash:free",
+        "huggingface/meta-llama/Llama-3.3-70B-Instruct",
+        "ollama/qwen3:14b",
+    ],
+)
+def test_supported_provider_custom_model_is_accepted(model_id: str) -> None:
+    assert validate_model_id(model_id) == model_id
+
+
+def test_custom_model_providers_are_explicit() -> None:
+    assert CUSTOM_MODEL_PROVIDERS == frozenset({"openrouter", "huggingface", "ollama"})
+
+
+@pytest.mark.parametrize(
+    ("model_id", "message"),
+    [
+        ("", "must not be empty"),
+        ("openrouter/model with spaces", "must not contain whitespace"),
+        ("openrouter/model\nnext", "must not contain whitespace"),
+        ("openai/not-in-catalog", "does not allow custom model IDs"),
+        ("unknown/model", "Unknown provider"),
+        ("openrouter", "must include a provider prefix"),
+        ("openrouter/" + "x" * 200, "must be at most 200 characters"),
+    ],
+)
+def test_invalid_custom_model_is_rejected(model_id: str, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        validate_model_id(model_id)

--- a/backend/tests/test_settings_security.py
+++ b/backend/tests/test_settings_security.py
@@ -39,7 +39,7 @@ def test_updating_model_without_api_key_preserves_stored_secret():
         set_provider_api_key(db, "openai", "sk-existing-secret")
 
         request = UpdateSettingsRequest(
-            model="openai/gpt-4.1-mini-2025-04-14",
+            model="openai/gpt-4.1-mini",
             api_key=None,
             activate=False,
         )

--- a/frontend/src/lib/components/SettingsModal.svelte
+++ b/frontend/src/lib/components/SettingsModal.svelte
@@ -2,7 +2,12 @@
   import { goto, invalidateAll } from '$app/navigation';
   import { page } from '$app/state';
   import { getModels, getSettings, testConnection, updateSettings } from '$lib/api';
-  import { credentialActionLabel, type CatalogProviderInfo } from '$lib/llm-catalog';
+  import {
+    credentialActionLabel,
+    customModelValidationError,
+    isCustomModel,
+    type CatalogProviderInfo,
+  } from '$lib/llm-catalog';
   import { toastState } from '$lib/toast.svelte';
   import type { TestConnectionResponse } from '$lib/types';
   import { errorMessage } from '$lib/utils';
@@ -19,6 +24,7 @@
   let providers: CatalogProviderInfo[] = $state([]);
   let selectedProviderId = $state('gemini');
   let selectedModel = $state('');
+  let customMode = $state(false);
   let apiKey = $state('');
   let showApiKey = $state(false);
   let loading = $state(true);
@@ -29,11 +35,21 @@
 
   const selectedProvider = $derived(providers.find((p) => p.id === selectedProviderId));
   const selectedModelInfo = $derived(selectedProvider?.models.find((model) => model.value === selectedModel));
+  const customModelError = $derived(
+    customMode && selectedProvider
+      ? customModelValidationError(selectedProvider.id, selectedModel)
+      : null,
+  );
   const unavailableCurrentModel = $derived(
-    Boolean(initialModel && selectedProvider && !selectedProvider.models.some((model) => model.value === initialModel))
+    Boolean(
+      initialModel &&
+        selectedProvider &&
+        !customMode &&
+        !selectedProvider.models.some((model) => model.value === initialModel),
+    ),
   );
   const canReuseStoredKey = $derived(
-    Boolean(initialProviderId && initialApiKeyConfigured && selectedProvider?.requires_api_key)
+    Boolean(initialProviderId && initialApiKeyConfigured && selectedProvider?.requires_api_key),
   );
 
   $effect(() => {
@@ -41,28 +57,48 @@
     loadData();
   });
 
+  function selectExistingModel(modelId: string): boolean {
+    for (const provider of providers) {
+      if (provider.models.some((model) => model.value === modelId)) {
+        selectedProviderId = provider.id;
+        selectedModel = modelId;
+        customMode = false;
+        return true;
+      }
+    }
+
+    const providerId = modelId.split('/', 1)[0];
+    const provider = providers.find(
+      (item) => item.id === providerId && item.supports_custom_models,
+    );
+    if (provider) {
+      selectedProviderId = provider.id;
+      selectedModel = modelId;
+      customMode = isCustomModel(provider, modelId);
+      return true;
+    }
+    return false;
+  }
+
   async function loadData() {
     loading = true;
     testResult = null;
     saveError = '';
     apiKey = '';
     showApiKey = false;
+    customMode = false;
     try {
       const [modelsRes, settingsRes] = await Promise.all([getModels(), getSettings()]);
       providers = modelsRes.providers as CatalogProviderInfo[];
       source = settingsRes.source;
 
       if (initialProviderId) {
+        const provider = providers.find((item) => item.id === initialProviderId);
         selectedProviderId = initialProviderId;
-        selectedModel = initialModel || (providers.find((p) => p.id === initialProviderId)?.models[0]?.value ?? '');
-      } else if (settingsRes.model) {
-        for (const provider of providers) {
-          if (provider.models.some((model) => model.value === settingsRes.model)) {
-            selectedProviderId = provider.id;
-            selectedModel = settingsRes.model;
-            break;
-          }
-        }
+        selectedModel = initialModel || provider?.models[0]?.value || '';
+        customMode = isCustomModel(provider, selectedModel);
+      } else if (settingsRes.model && selectExistingModel(settingsRes.model)) {
+        // Selection was restored from saved settings.
       } else if (providers.length > 0) {
         selectedProviderId = providers[0].id;
         selectedModel = providers[0].models[0]?.value ?? '';
@@ -78,18 +114,29 @@
     selectedProviderId = id;
     const provider = providers.find((item) => item.id === id);
     selectedModel = provider?.models[0]?.value ?? '';
+    customMode = false;
     apiKey = '';
     testResult = null;
   }
 
+  function toggleCustomMode() {
+    if (!selectedProvider?.supports_custom_models) return;
+    customMode = !customMode;
+    selectedModel = customMode
+      ? `${selectedProvider.id}/`
+      : selectedProvider.models[0]?.value ?? '';
+    testResult = null;
+    saveError = '';
+  }
+
   async function handleTest() {
-    if (!selectedModel) return;
+    if (!selectedModel || customModelError) return;
     const keyToTest = apiKey.trim() || null;
     if (selectedProvider?.requires_api_key && !keyToTest) return;
     testing = true;
     testResult = null;
     try {
-      testResult = await testConnection({ model: selectedModel, api_key: keyToTest });
+      testResult = await testConnection({ model: selectedModel.trim(), api_key: keyToTest });
     } catch {
       testResult = { ok: false, message: 'Request failed.' };
     } finally {
@@ -104,6 +151,10 @@
       saveError = 'Select a model.';
       return;
     }
+    if (customModelError) {
+      saveError = customModelError;
+      return;
+    }
     const keyToSave = apiKey.trim() || null;
     if (selectedProvider?.requires_api_key && !keyToSave && !canReuseStoredKey) {
       saveError = 'API key is required.';
@@ -112,13 +163,13 @@
     saving = activate ? 'activate' : 'key';
     saveError = '';
     try {
-      await updateSettings({ model: selectedModel, api_key: keyToSave, activate });
+      await updateSettings({ model: selectedModel.trim(), api_key: keyToSave, activate });
       toastState.success(
         activate
           ? 'Saved and set as active model.'
           : keyToSave
             ? 'API key saved.'
-            : 'Model saved. Existing API key was kept.'
+            : 'Model saved. Existing API key was kept.',
       );
       open = false;
       await invalidateAll();
@@ -190,12 +241,43 @@
         {/if}
 
         <div class="space-y-1.5">
-          <label class="text-sm font-medium">Model</label>
-          <ModelSelector
-            models={selectedProvider?.models ?? []}
-            bind:value={selectedModel}
-            unavailableValue={unavailableCurrentModel ? initialModel : ''}
-          />
+          <div class="flex items-center justify-between gap-3">
+            <label for={customMode ? 'custom-model-input' : undefined} class="text-sm font-medium">Model</label>
+            {#if selectedProvider?.supports_custom_models}
+              <button
+                type="button"
+                onclick={toggleCustomMode}
+                class="text-xs font-medium text-primary hover:underline"
+              >
+                {customMode ? 'Choose from catalog' : 'Use custom model ID'}
+              </button>
+            {/if}
+          </div>
+
+          {#if customMode}
+            <input
+              id="custom-model-input"
+              bind:value={selectedModel}
+              placeholder={`${selectedProvider?.id ?? 'provider'}/model-name`}
+              maxlength="200"
+              spellcheck="false"
+              autocomplete="off"
+              class="w-full rounded-md border border-border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-primary/30"
+            />
+            <div class="flex items-center justify-between gap-3">
+              <span class="rounded bg-purple-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-purple-800 dark:bg-purple-950 dark:text-purple-300">Custom</span>
+              <span class="text-[11px] text-muted-foreground">Use the full LiteLLM model ID.</span>
+            </div>
+            {#if customModelError}
+              <p class="text-xs text-red-600 dark:text-red-400">{customModelError}</p>
+            {/if}
+          {:else}
+            <ModelSelector
+              models={selectedProvider?.models ?? []}
+              bind:value={selectedModel}
+              unavailableValue={unavailableCurrentModel ? initialModel : ''}
+            />
+          {/if}
 
           {#if unavailableCurrentModel && selectedModel === initialModel}
             <div class="flex items-start gap-2 rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-xs text-yellow-800 dark:border-yellow-900 dark:bg-yellow-950/30 dark:text-yellow-300">
@@ -260,7 +342,7 @@
         <div class="space-y-2">
           <button
             onclick={handleTest}
-            disabled={testing || !selectedModel || (selectedProvider?.requires_api_key && !apiKey)}
+            disabled={testing || !selectedModel || Boolean(customModelError) || (selectedProvider?.requires_api_key && !apiKey)}
             class="w-full px-4 py-2 rounded-md border border-border text-sm hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
           >
             {#if testing}<Loader2 class="w-4 h-4 animate-spin" />Testing…{:else}Test Connection{/if}
@@ -281,7 +363,7 @@
           {#if initialProviderId && selectedProvider?.requires_api_key}
             <button
               onclick={() => handleSave(false)}
-              disabled={saving !== null || !selectedModel || (!apiKey && !canReuseStoredKey)}
+              disabled={saving !== null || !selectedModel || Boolean(customModelError) || (!apiKey && !canReuseStoredKey)}
               class="px-4 py-2 rounded-md text-sm border border-border hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             >
               {#if saving === 'key'}<Loader2 class="w-4 h-4 animate-spin" />{/if}
@@ -290,7 +372,7 @@
           {/if}
           <button
             onclick={() => handleSave(true)}
-            disabled={saving !== null || !selectedModel || (selectedProvider?.requires_api_key && !apiKey && !canReuseStoredKey)}
+            disabled={saving !== null || !selectedModel || Boolean(customModelError) || (selectedProvider?.requires_api_key && !apiKey && !canReuseStoredKey)}
             class="px-4 py-2 rounded-md text-sm bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
           >
             {#if saving === 'activate'}<Loader2 class="w-4 h-4 animate-spin" />{/if}

--- a/frontend/src/lib/llm-catalog.test.ts
+++ b/frontend/src/lib/llm-catalog.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   credentialActionLabel,
+  customModelValidationError,
   filterCatalogModels,
+  isCustomModel,
   type CatalogModelFilters,
   type CatalogModelOption,
 } from '$lib/llm-catalog';
@@ -45,6 +47,36 @@ describe('credentialActionLabel', () => {
   test('uses token-specific copy only for token providers', () => {
     expect(credentialActionLabel('token')).toBe('Get access token');
     expect(credentialActionLabel('api_key')).toBe('Get API key');
+  });
+});
+
+describe('custom model helpers', () => {
+  test('accepts provider-prefixed IDs and rejects invalid input', () => {
+    expect(customModelValidationError('ollama', 'ollama/qwen3:14b')).toBeNull();
+    expect(customModelValidationError('openrouter', 'openrouter/google/gemini-2.5-flash')).toBeNull();
+    expect(customModelValidationError('openrouter', 'google/gemini')).toContain('openrouter/');
+    expect(customModelValidationError('ollama', 'ollama/model with spaces')).toContain('spaces');
+  });
+
+  test('recognizes non-catalog selections only for supported providers', () => {
+    expect(
+      isCustomModel(
+        { supports_custom_models: true, models },
+        'ollama/qwen3:14b',
+      ),
+    ).toBe(true);
+    expect(
+      isCustomModel(
+        { supports_custom_models: false, models },
+        'openai/not-in-catalog',
+      ),
+    ).toBe(false);
+    expect(
+      isCustomModel(
+        { supports_custom_models: true, models },
+        'ollama/llama3.2',
+      ),
+    ).toBe(false);
   });
 });
 

--- a/frontend/src/lib/llm-catalog.ts
+++ b/frontend/src/lib/llm-catalog.ts
@@ -14,6 +14,7 @@ export interface CatalogProviderInfo extends Omit<ProviderInfo, 'models'> {
   auth_type: ProviderAuthType;
   local: boolean;
   credential_url: string | null;
+  supports_custom_models: boolean;
   models: CatalogModelOption[];
 }
 
@@ -26,6 +27,29 @@ export interface CatalogModelFilters {
 
 export function credentialActionLabel(authType: ProviderAuthType): string {
   return authType === 'token' ? 'Get access token' : 'Get API key';
+}
+
+export function customModelValidationError(providerId: string, modelId: string): string | null {
+  const normalized = modelId.trim();
+  if (!normalized) return 'Enter a model ID.';
+  if (normalized.length > 200) return 'Model ID must be at most 200 characters.';
+  if (/\s/.test(normalized)) return 'Model ID cannot contain spaces or line breaks.';
+  if (!normalized.startsWith(`${providerId}/`)) {
+    return `Model ID must start with ${providerId}/.`;
+  }
+  if (normalized === `${providerId}/`) return 'Enter a model name after the provider prefix.';
+  return null;
+}
+
+export function isCustomModel(
+  provider: Pick<CatalogProviderInfo, 'supports_custom_models' | 'models'> | undefined,
+  modelId: string,
+): boolean {
+  return Boolean(
+    provider?.supports_custom_models &&
+      modelId &&
+      !provider.models.some((model) => model.value === modelId),
+  );
 }
 
 export function filterCatalogModels(


### PR DESCRIPTION
## Summary
- allow custom LiteLLM model IDs for OpenRouter, Hugging Face, and Ollama
- keep all other providers restricted to the release-managed catalog
- validate provider prefix, whitespace, empty values, and a 200-character limit in backend routes
- expose `supports_custom_models` through the settings model API
- add a catalog/custom toggle in the Settings modal
- restore saved custom models with a `Custom` badge instead of treating them as unavailable
- preserve test-connection, save, activation, and per-provider model persistence behavior
- add backend and frontend validation tests

## Examples
- `openrouter/google/gemini-2.5-flash:free`
- `huggingface/meta-llama/Llama-3.3-70B-Instruct`
- `ollama/qwen3:14b`

Merge only after Backend CI and Frontend CI are green. No tag or release is included.