### PR TITLE
feat: add single-provider LLM smoke test

### DIFF
--- a/backend/app/llm/smoke_test.py
+++ b/backend/app/llm/smoke_test.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from typing import Callable, Literal
+
+from app.llm.catalog import get_provider
+
+SmokeStatus = Literal["PASS", "FAIL", "SKIP"]
+CompletionCallable = Callable[..., object]
+
+_CREDENTIAL_ENV_VARS: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "huggingface": "HF_TOKEN",
+    "mistral": "MISTRAL_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "xai": "XAI_API_KEY",
+}
+
+
+@dataclass(frozen=True)
+class SmokeResult:
+    status: SmokeStatus
+    provider_id: str
+    model_id: str
+    message: str
+    credential_env: str | None = None
+    error_type: str | None = None
+
+
+def credential_env_var(provider_id: str) -> str | None:
+    return _CREDENTIAL_ENV_VARS.get(provider_id)
+
+
+def resolve_smoke_model(provider_id: str) -> str:
+    provider = get_provider(provider_id)
+    if provider is None:
+        raise ValueError(f"Unknown provider: {provider_id}.")
+
+    stable_models = [model for model in provider.models if model.status.value == "stable"]
+    candidates = stable_models or list(provider.models)
+    if not candidates:
+        raise ValueError(f"Provider {provider_id} has no catalog models.")
+
+    def priority(model) -> tuple[int, int, str]:
+        traits = {trait.value for trait in model.traits}
+        return (
+            0 if model.free_tier else 1,
+            0 if "low_cost" in traits else 1,
+            model.label.casefold(),
+        )
+
+    return min(candidates, key=priority).id
+
+
+def run_smoke_test(
+    provider_id: str,
+    *,
+    model_id: str | None = None,
+    completion: CompletionCallable | None = None,
+) -> SmokeResult:
+    provider = get_provider(provider_id)
+    if provider is None:
+        raise ValueError(f"Unknown provider: {provider_id}.")
+
+    selected_model = model_id or resolve_smoke_model(provider_id)
+    expected_prefix = f"{provider_id}/"
+    if not selected_model.startswith(expected_prefix):
+        raise ValueError(
+            f"Model ID for provider {provider_id} must start with {expected_prefix}"
+        )
+
+    env_name = credential_env_var(provider_id)
+    api_key = os.environ.get(env_name, "").strip() if env_name else ""
+    if provider.auth_type.value != "none" and not api_key:
+        return SmokeResult(
+            status="SKIP",
+            provider_id=provider_id,
+            model_id=selected_model,
+            credential_env=env_name,
+            message=f"Credential is not set in {env_name}.",
+        )
+
+    if completion is None:
+        import litellm
+
+        completion = litellm.completion
+
+    request_kwargs: dict[str, object] = {
+        "model": selected_model,
+        "messages": [{"role": "user", "content": "Reply exactly: ok"}],
+        "timeout": 20,
+        "max_tokens": 3,
+    }
+    if api_key:
+        request_kwargs["api_key"] = api_key
+
+    try:
+        response = completion(**request_kwargs)
+        choices = getattr(response, "choices", None) or []
+        content = getattr(getattr(choices[0], "message", None), "content", "") if choices else ""
+        if not content:
+            return SmokeResult(
+                status="FAIL",
+                provider_id=provider_id,
+                model_id=selected_model,
+                message="Provider returned an empty response.",
+            )
+        return SmokeResult(
+            status="PASS",
+            provider_id=provider_id,
+            model_id=selected_model,
+            message="Connection successful.",
+        )
+    except Exception as exc:
+        return SmokeResult(
+            status="FAIL",
+            provider_id=provider_id,
+            model_id=selected_model,
+            error_type=type(exc).__name__,
+            message="Provider request failed. See the error type for diagnosis.",
+        )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a minimal live LiteLLM smoke test for one provider."
+    )
+    parser.add_argument(
+        "--provider",
+        required=True,
+        help="Provider ID from the ApplyKit catalog, for example gemini or openai.",
+    )
+    parser.add_argument(
+        "--model",
+        help="Optional full LiteLLM model ID. It must match the selected provider prefix.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = run_smoke_test(args.provider, model_id=args.model)
+    except ValueError as exc:
+        print(f"ERROR {exc}")
+        return 2
+
+    suffix = f" ({result.error_type})" if result.error_type else ""
+    print(
+        f"{result.status} provider={result.provider_id} "
+        f"model={result.model_id}: {result.message}{suffix}"
+    )
+    if result.status == "PASS":
+        return 0
+    if result.status == "SKIP":
+        return 2
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_llm_smoke_test.py
+++ b/backend/tests/test_llm_smoke_test.py
@@ -1,0 +1,104 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.llm.smoke_test import (
+    SmokeResult,
+    credential_env_var,
+    resolve_smoke_model,
+    run_smoke_test,
+)
+
+
+def test_credential_env_var_uses_provider_specific_names():
+    assert credential_env_var("gemini") == "GEMINI_API_KEY"
+    assert credential_env_var("huggingface") == "HF_TOKEN"
+    assert credential_env_var("ollama") is None
+
+
+def test_resolve_smoke_model_prefers_stable_free_or_low_cost_model():
+    model = resolve_smoke_model("gemini")
+
+    assert model.startswith("gemini/")
+
+
+def test_resolve_smoke_model_rejects_unknown_provider():
+    with pytest.raises(ValueError, match="Unknown provider"):
+        resolve_smoke_model("missing")
+
+
+def test_run_smoke_test_skips_when_required_credential_is_missing(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    result = run_smoke_test("openai", completion=lambda **_: None)
+
+    assert result.status == "SKIP"
+    assert result.provider_id == "openai"
+    assert result.credential_env == "OPENAI_API_KEY"
+    assert "OPENAI_API_KEY" in result.message
+
+
+def test_run_smoke_test_passes_key_without_exposing_it(monkeypatch):
+    secret = "sk-super-secret"
+    monkeypatch.setenv("OPENAI_API_KEY", secret)
+    captured = {}
+
+    def completion(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+    result = run_smoke_test("openai", completion=completion)
+
+    assert result.status == "PASS"
+    assert captured["api_key"] == secret
+    assert secret not in result.message
+    assert captured["max_tokens"] == 3
+    assert captured["timeout"] == 20
+
+
+def test_run_smoke_test_never_includes_exception_message(monkeypatch):
+    secret = "secret-token-value"
+    monkeypatch.setenv("GROQ_API_KEY", secret)
+
+    def completion(**_):
+        raise RuntimeError(f"request failed with {secret}")
+
+    result = run_smoke_test("groq", completion=completion)
+
+    assert result.status == "FAIL"
+    assert result.error_type == "RuntimeError"
+    assert secret not in result.message
+    assert "request failed" not in result.message
+
+
+def test_run_smoke_test_supports_keyless_ollama(monkeypatch):
+    captured = {}
+
+    def completion(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+    result = run_smoke_test("ollama", model_id="ollama/llama3.2", completion=completion)
+
+    assert result == SmokeResult(
+        status="PASS",
+        provider_id="ollama",
+        model_id="ollama/llama3.2",
+        message="Connection successful.",
+    )
+    assert "api_key" not in captured
+
+
+def test_run_smoke_test_rejects_model_from_another_provider(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+
+    with pytest.raises(ValueError, match="must start with openai/"):
+        run_smoke_test(
+            "openai",
+            model_id="gemini/gemini-2.5-flash",
+            completion=lambda **_: None,
+        )


### PR DESCRIPTION
## Summary
- add a safe live LiteLLM smoke-test command for exactly one provider at a time
- require `--provider` and support an optional full `--model` override
- choose a stable free-tier or low-cost catalog model when `--model` is omitted
- read provider credentials only from environment variables
- never print API keys, tokens, or raw provider exception messages
- return explicit `PASS`, `FAIL`, or `SKIP` output and meaningful exit codes
- support keyless Ollama checks
- add unit coverage for credential mapping, model selection, prefix validation, secret handling, and sanitized failures

## Usage
```bash
cd backend
GEMINI_API_KEY=... uv run python -m app.llm.smoke_test --provider gemini
uv run python -m app.llm.smoke_test --provider ollama --model ollama/qwen3:14b
```

## Exit codes
- `0`: PASS
- `1`: FAIL
- `2`: SKIP or invalid command input

This command is intentionally not added to CI because it requires live credentials and may incur provider cost. Merge only after Backend CI is green. No tag or release is included.