### PR TITLE
feat: test configured AI integrations

### DIFF
--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -1,5 +1,3 @@
-import logging
-
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
@@ -9,7 +7,6 @@ from app.llm.catalog import CATALOG, get_provider
 from app.llm.model_selection import supports_custom_models, validate_model_id
 from app.llm.provider_credentials import credential_url_for_provider
 from app.llm.schemas import ModelOption, ModelsResponse, ProviderInfo
-from app.public_errors import PROVIDER_CONNECTION_ERROR_MESSAGE
 from app.schemas import (
     ActivateProviderRequest,
     IntegrationInfo,
@@ -18,6 +15,7 @@ from app.schemas import (
     TestConnectionResponse,
     UpdateSettingsRequest,
 )
+from app.services.provider_connection import test_provider_connection
 from app.services.settings import (
     clear_provider_api_key,
     get_llm_config,
@@ -33,7 +31,6 @@ from app.services.settings import (
 )
 
 router = APIRouter()
-logger = logging.getLogger(__name__)
 
 
 def _mask_api_key(key: str) -> str | None:
@@ -147,8 +144,6 @@ def activate_provider(req: ActivateProviderRequest, db: Session = Depends(get_db
 
 @router.post("/settings/test", response_model=TestConnectionResponse)
 def test_connection(req: UpdateSettingsRequest):
-    import litellm
-
     model_id = _validate_model_or_422(req.model)
     provider_id = provider_from_model(model_id)
     api_key = req.api_key.strip() if req.api_key else ""
@@ -158,31 +153,42 @@ def test_connection(req: UpdateSettingsRequest):
             message="API key is required for this provider.",
         )
 
-    request_kwargs = {
-        "model": model_id,
-        "messages": [{"role": "user", "content": "Reply with the single word: ok"}],
-        "timeout": 15,
-        "max_tokens": 5,
-    }
-    if api_key:
-        request_kwargs["api_key"] = api_key
+    return test_provider_connection(model_id, api_key or None)
 
-    try:
-        response = litellm.completion(**request_kwargs)
-        content = response.choices[0].message.content if response.choices else ""
-        if content:
-            return TestConnectionResponse(ok=True, message="Connection successful.")
-        return TestConnectionResponse(ok=False, message="LLM returned empty response.")
-    except Exception as exc:
-        logger.warning(
-            "LLM connection test failed for model %s",
-            model_id,
-            exc_info=(type(exc), exc, exc.__traceback__),
-        )
-        return TestConnectionResponse(
-            ok=False,
-            message=PROVIDER_CONNECTION_ERROR_MESSAGE,
-        )
+
+@router.post(
+    "/settings/integrations/{provider_id}/test",
+    response_model=TestConnectionResponse,
+)
+def test_configured_integration(
+    provider_id: str,
+    db: Session = Depends(get_db),
+):
+    provider = get_provider(provider_id)
+    if provider is None:
+        raise ProviderNotFoundError(provider_id)
+
+    active_model = get_setting(db, "llm_provider") or ""
+    active_provider = provider_from_model(active_model)
+    saved_model = (
+        active_model
+        if active_provider == provider_id
+        else get_setting(db, f"selected_model_{provider_id}")
+    )
+    model_id = saved_model or provider.models[0].id
+
+    api_key = ""
+    if provider_requires_api_key(provider_id):
+        api_key = get_provider_api_key(db, provider_id) or ""
+        if not api_key and active_provider == provider_id:
+            api_key = get_setting(db, "llm_api_key") or ""
+        if not api_key:
+            return TestConnectionResponse(
+                ok=False,
+                message="Credential is not configured.",
+            )
+
+    return test_provider_connection(model_id, api_key or None)
 
 
 @router.delete("/settings/integrations/{provider_id}", response_model=IntegrationsResponse)

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -188,7 +188,11 @@ def test_configured_integration(
                 message="Credential is not configured.",
             )
 
-    return test_provider_connection(model_id, api_key or None)
+    return test_provider_connection(
+        model_id,
+        api_key or None,
+        failure_message="Provider connection failed.",
+    )
 
 
 @router.delete("/settings/integrations/{provider_id}", response_model=IntegrationsResponse)

--- a/backend/app/services/provider_connection.py
+++ b/backend/app/services/provider_connection.py
@@ -2,6 +2,7 @@ import logging
 
 import litellm
 
+from app.public_errors import PROVIDER_CONNECTION_ERROR_MESSAGE
 from app.schemas import TestConnectionResponse
 
 logger = logging.getLogger(__name__)
@@ -10,6 +11,8 @@ logger = logging.getLogger(__name__)
 def test_provider_connection(
     model_id: str,
     api_key: str | None = None,
+    *,
+    failure_message: str = PROVIDER_CONNECTION_ERROR_MESSAGE,
 ) -> TestConnectionResponse:
     request_kwargs: dict[str, object] = {
         "model": model_id,
@@ -34,5 +37,5 @@ def test_provider_connection(
         )
         return TestConnectionResponse(
             ok=False,
-            message="Provider connection failed.",
+            message=failure_message,
         )

--- a/backend/app/services/provider_connection.py
+++ b/backend/app/services/provider_connection.py
@@ -1,0 +1,38 @@
+import logging
+
+import litellm
+
+from app.schemas import TestConnectionResponse
+
+logger = logging.getLogger(__name__)
+
+
+def test_provider_connection(
+    model_id: str,
+    api_key: str | None = None,
+) -> TestConnectionResponse:
+    request_kwargs: dict[str, object] = {
+        "model": model_id,
+        "messages": [{"role": "user", "content": "Reply with the single word: ok"}],
+        "timeout": 15,
+        "max_tokens": 5,
+    }
+    if api_key:
+        request_kwargs["api_key"] = api_key
+
+    try:
+        response = litellm.completion(**request_kwargs)
+        content = response.choices[0].message.content if response.choices else ""
+        if content:
+            return TestConnectionResponse(ok=True, message="Connection successful.")
+        return TestConnectionResponse(ok=False, message="LLM returned empty response.")
+    except Exception as exc:
+        logger.warning(
+            "LLM connection test failed for model %s",
+            model_id,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+        return TestConnectionResponse(
+            ok=False,
+            message="Provider connection failed.",
+        )

--- a/backend/tests/test_configured_integration_testing.py
+++ b/backend/tests/test_configured_integration_testing.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.routes.settings import test_configured_integration
+from app.services.settings import set_provider_api_key, set_setting
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _successful_completion(**_):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+    )
+
+
+def test_configured_integration_uses_saved_model_and_secret(monkeypatch):
+    db = _make_session()
+    captured = {}
+
+    def completion(**kwargs):
+        captured.update(kwargs)
+        return _successful_completion()
+
+    monkeypatch.setattr("app.services.provider_connection.litellm.completion", completion)
+    try:
+        set_setting(db, "selected_model_openai", "openai/gpt-4.1-mini")
+        set_provider_api_key(db, "openai", "sk-stored-secret")
+
+        result = test_configured_integration("openai", db)
+
+        assert result.ok is True
+        assert result.message == "Connection successful."
+        assert captured["model"] == "openai/gpt-4.1-mini"
+        assert captured["api_key"] == "sk-stored-secret"
+    finally:
+        db.close()
+
+
+def test_configured_integration_reports_missing_credential_without_calling_provider(monkeypatch):
+    db = _make_session()
+
+    def completion(**_):
+        raise AssertionError("provider should not be called")
+
+    monkeypatch.setattr("app.services.provider_connection.litellm.completion", completion)
+    try:
+        set_setting(db, "selected_model_openai", "openai/gpt-4.1-mini")
+
+        result = test_configured_integration("openai", db)
+
+        assert result.ok is False
+        assert result.message == "Credential is not configured."
+    finally:
+        db.close()
+
+
+def test_configured_integration_uses_catalog_model_when_none_is_saved(monkeypatch):
+    db = _make_session()
+    captured = {}
+
+    def completion(**kwargs):
+        captured.update(kwargs)
+        return _successful_completion()
+
+    monkeypatch.setattr("app.services.provider_connection.litellm.completion", completion)
+    try:
+        set_provider_api_key(db, "gemini", "stored-gemini-key")
+
+        result = test_configured_integration("gemini", db)
+
+        assert result.ok is True
+        assert captured["model"].startswith("gemini/")
+        assert captured["api_key"] == "stored-gemini-key"
+    finally:
+        db.close()
+
+
+def test_configured_integration_returns_sanitized_failure(monkeypatch):
+    db = _make_session()
+    secret = "stored-secret-value"
+
+    def completion(**_):
+        raise RuntimeError(f"provider leaked {secret}")
+
+    monkeypatch.setattr("app.services.provider_connection.litellm.completion", completion)
+    try:
+        set_setting(db, "selected_model_openai", "openai/gpt-4.1-mini")
+        set_provider_api_key(db, "openai", secret)
+
+        result = test_configured_integration("openai", db)
+
+        assert result.ok is False
+        assert result.message == "Provider connection failed."
+        assert secret not in result.message
+    finally:
+        db.close()

--- a/backend/tests/test_configured_integration_testing.py
+++ b/backend/tests/test_configured_integration_testing.py
@@ -4,7 +4,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from app.models import Base
-from app.routes.settings import test_configured_integration
+from app.routes.settings import (
+    test_configured_integration as run_configured_integration_test,
+)
 from app.services.settings import set_provider_api_key, set_setting
 
 
@@ -33,7 +35,7 @@ def test_configured_integration_uses_saved_model_and_secret(monkeypatch):
         set_setting(db, "selected_model_openai", "openai/gpt-4.1-mini")
         set_provider_api_key(db, "openai", "sk-stored-secret")
 
-        result = test_configured_integration("openai", db)
+        result = run_configured_integration_test("openai", db)
 
         assert result.ok is True
         assert result.message == "Connection successful."
@@ -53,7 +55,7 @@ def test_configured_integration_reports_missing_credential_without_calling_provi
     try:
         set_setting(db, "selected_model_openai", "openai/gpt-4.1-mini")
 
-        result = test_configured_integration("openai", db)
+        result = run_configured_integration_test("openai", db)
 
         assert result.ok is False
         assert result.message == "Credential is not configured."
@@ -73,7 +75,7 @@ def test_configured_integration_uses_catalog_model_when_none_is_saved(monkeypatc
     try:
         set_provider_api_key(db, "gemini", "stored-gemini-key")
 
-        result = test_configured_integration("gemini", db)
+        result = run_configured_integration_test("gemini", db)
 
         assert result.ok is True
         assert captured["model"].startswith("gemini/")
@@ -94,7 +96,7 @@ def test_configured_integration_returns_sanitized_failure(monkeypatch):
         set_setting(db, "selected_model_openai", "openai/gpt-4.1-mini")
         set_provider_api_key(db, "openai", secret)
 
-        result = test_configured_integration("openai", db)
+        result = run_configured_integration_test("openai", db)
 
         assert result.ok is False
         assert result.message == "Provider connection failed."

--- a/frontend/src/lib/integration-api.ts
+++ b/frontend/src/lib/integration-api.ts
@@ -1,0 +1,21 @@
+import type { TestConnectionResponse } from '$lib/types';
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000/api';
+
+export async function testConfiguredIntegration(
+  providerId: string,
+): Promise<TestConnectionResponse> {
+  const response = await fetch(
+    `${BASE_URL}/settings/integrations/${encodeURIComponent(providerId)}/test`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error('Configured integration test request failed.');
+  }
+
+  return response.json() as Promise<TestConnectionResponse>;
+}

--- a/frontend/src/lib/integration-testing.test.ts
+++ b/frontend/src/lib/integration-testing.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  connectedIntegrations,
+  testConnectedIntegrations,
+  type IntegrationTestState,
+} from '$lib/integration-testing';
+import type { IntegrationInfo } from '$lib/types';
+
+const integrations: IntegrationInfo[] = [
+  {
+    id: 'openai',
+    label: 'OpenAI',
+    is_active: true,
+    api_key_configured: true,
+    masked_api_key: 'sk••••••••key',
+    current_model: 'openai/gpt-5-mini',
+  },
+  {
+    id: 'gemini',
+    label: 'Google Gemini',
+    is_active: false,
+    api_key_configured: false,
+    masked_api_key: null,
+    current_model: null,
+  },
+  {
+    id: 'ollama',
+    label: 'Ollama',
+    is_active: false,
+    api_key_configured: false,
+    masked_api_key: null,
+    current_model: 'ollama/qwen3:14b',
+  },
+  {
+    id: 'anthropic',
+    label: 'Anthropic Claude',
+    is_active: false,
+    api_key_configured: true,
+    masked_api_key: 'sk••••••••key',
+    current_model: 'anthropic/claude-haiku-4-5-20251001',
+  },
+];
+
+describe('connectedIntegrations', () => {
+  test('includes configured API providers and Ollama with a selected model', () => {
+    expect(connectedIntegrations(integrations).map((item) => item.id)).toEqual([
+      'openai',
+      'ollama',
+      'anthropic',
+    ]);
+  });
+});
+
+describe('testConnectedIntegrations', () => {
+  test('tests every connected provider and returns a summary', async () => {
+    const states: Record<string, IntegrationTestState> = {};
+
+    const summary = await testConnectedIntegrations(
+      integrations,
+      async (providerId) => ({
+        ok: providerId !== 'anthropic',
+        message: providerId === 'anthropic' ? 'Provider connection failed.' : 'Connection successful.',
+      }),
+      (providerId, state) => {
+        states[providerId] = state;
+      },
+    );
+
+    expect(summary).toEqual({ total: 3, passed: 2, failed: 1 });
+    expect(states.openai.status).toBe('success');
+    expect(states.ollama.status).toBe('success');
+    expect(states.anthropic.status).toBe('failure');
+    expect(states.gemini).toBeUndefined();
+  });
+
+  test('runs at most three provider tests concurrently', async () => {
+    let active = 0;
+    let peak = 0;
+    const many = Array.from({ length: 7 }, (_, index): IntegrationInfo => ({
+      id: `provider-${index}`,
+      label: `Provider ${index}`,
+      is_active: false,
+      api_key_configured: true,
+      masked_api_key: null,
+      current_model: `provider-${index}/model`,
+    }));
+
+    await testConnectedIntegrations(
+      many,
+      async () => {
+        active += 1;
+        peak = Math.max(peak, active);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        active -= 1;
+        return { ok: true, message: 'Connection successful.' };
+      },
+      () => undefined,
+    );
+
+    expect(peak).toBeLessThanOrEqual(3);
+  });
+});

--- a/frontend/src/lib/integration-testing.ts
+++ b/frontend/src/lib/integration-testing.ts
@@ -1,0 +1,91 @@
+import type { IntegrationInfo, TestConnectionResponse } from '$lib/types';
+
+export type IntegrationTestStatus = 'testing' | 'success' | 'failure';
+
+export interface IntegrationTestState {
+  status: IntegrationTestStatus;
+  message: string;
+}
+
+export interface IntegrationTestSummary {
+  total: number;
+  passed: number;
+  failed: number;
+}
+
+export type IntegrationTester = (providerId: string) => Promise<TestConnectionResponse>;
+export type IntegrationTestUpdater = (
+  providerId: string,
+  state: IntegrationTestState,
+) => void;
+
+export function connectedIntegrations(
+  integrations: IntegrationInfo[],
+): IntegrationInfo[] {
+  return integrations.filter(
+    (integration) =>
+      integration.api_key_configured ||
+      (integration.id === 'ollama' && Boolean(integration.current_model)),
+  );
+}
+
+export async function testConnectedIntegrations(
+  integrations: IntegrationInfo[],
+  testProvider: IntegrationTester,
+  onUpdate: IntegrationTestUpdater,
+  concurrency = 3,
+): Promise<IntegrationTestSummary> {
+  const candidates = connectedIntegrations(integrations);
+  let nextIndex = 0;
+  let passed = 0;
+  let failed = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < candidates.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      const integration = candidates[currentIndex];
+
+      onUpdate(integration.id, {
+        status: 'testing',
+        message: 'Testing connection…',
+      });
+
+      let response: TestConnectionResponse;
+      try {
+        response = await testProvider(integration.id);
+      } catch {
+        response = {
+          ok: false,
+          message: 'Connection test request failed.',
+        };
+      }
+
+      if (response.ok) {
+        passed += 1;
+        onUpdate(integration.id, {
+          status: 'success',
+          message: response.message,
+        });
+      } else {
+        failed += 1;
+        onUpdate(integration.id, {
+          status: 'failure',
+          message: response.message,
+        });
+      }
+    }
+  }
+
+  const workerCount = Math.min(
+    Math.max(1, concurrency),
+    candidates.length,
+  );
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  return {
+    total: candidates.length,
+    passed,
+    failed,
+  };
+}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1,11 +1,25 @@
 <script lang="ts">
   import { invalidateAll } from '$app/navigation';
-  import { page } from '$app/state';
   import { activateProvider, disconnectProvider, getIntegrations } from '$lib/api';
   import SettingsModal from '$lib/components/SettingsModal.svelte';
+  import { testConfiguredIntegration } from '$lib/integration-api';
+  import {
+    connectedIntegrations,
+    testConnectedIntegrations,
+    type IntegrationTestState,
+    type IntegrationTestSummary,
+  } from '$lib/integration-testing';
   import { toastState } from '$lib/toast.svelte';
   import type { IntegrationInfo } from '$lib/types';
-  import { ChevronRight, CircleAlert, CircleCheck, Pencil, Plus, Settings, Zap } from '@lucide/svelte';
+  import {
+    CircleAlert,
+    CircleCheck,
+    Loader2,
+    Pencil,
+    Plus,
+    Settings,
+    Zap,
+  } from '@lucide/svelte';
 
   let modalOpen = $state(false);
   let modalProviderId = $state('');
@@ -17,6 +31,9 @@
   let confirmingActivate = $state('');
   let disconnecting = $state('');
   let confirmingDisconnect = $state('');
+  let testStates = $state<Record<string, IntegrationTestState>>({});
+  let testingAll = $state(false);
+  let testSummary = $state<IntegrationTestSummary | null>(null);
 
   const PROVIDER_COLORS: Record<string, string> = {
     gemini: '#8b5cf6',
@@ -71,6 +88,10 @@
     try {
       const res = await disconnectProvider(providerId);
       integrations = res.integrations;
+      const nextStates = { ...testStates };
+      delete nextStates[providerId];
+      testStates = nextStates;
+      testSummary = null;
       await invalidateAll();
       toastState.success('Provider disconnected.');
     } catch {
@@ -81,20 +102,58 @@
     }
   }
 
-  const anyConfigured = $derived(
-    integrations.some((i) => i.api_key_configured || (i.id === 'ollama' && Boolean(i.current_model)))
-  );
+  function updateTestState(providerId: string, state: IntegrationTestState) {
+    testStates = { ...testStates, [providerId]: state };
+  }
+
+  async function handleTestIntegration(providerId: string) {
+    updateTestState(providerId, {
+      status: 'testing',
+      message: 'Testing connection…',
+    });
+    testSummary = null;
+
+    try {
+      const result = await testConfiguredIntegration(providerId);
+      updateTestState(providerId, {
+        status: result.ok ? 'success' : 'failure',
+        message: result.message,
+      });
+    } catch {
+      updateTestState(providerId, {
+        status: 'failure',
+        message: 'Connection test request failed.',
+      });
+    }
+  }
+
+  async function handleTestAll() {
+    testingAll = true;
+    testSummary = null;
+    try {
+      testSummary = await testConnectedIntegrations(
+        integrations,
+        testConfiguredIntegration,
+        updateTestState,
+      );
+    } finally {
+      testingAll = false;
+    }
+  }
+
+  const testableIntegrations = $derived(connectedIntegrations(integrations));
+  const anyConfigured = $derived(testableIntegrations.length > 0);
 </script>
 
 <div class="max-w-2xl space-y-6">
   <div class="flex items-start justify-between gap-4">
     <div>
-    <h1 class="text-2xl font-bold flex items-center gap-2">
-      <Settings class="w-6 h-6 text-primary" />
-      Settings
-    </h1>
-    <p class="text-sm text-muted-foreground mt-1">Manage your AI integrations. You can connect multiple providers and switch between them.</p>
-  </div>
+      <h1 class="text-2xl font-bold flex items-center gap-2">
+        <Settings class="w-6 h-6 text-primary" />
+        Settings
+      </h1>
+      <p class="text-sm text-muted-foreground mt-1">Manage your AI integrations. You can connect multiple providers and switch between them.</p>
+    </div>
     <a href="/usage" class="shrink-0 text-xs text-primary hover:underline mt-1">View LLM Usage →</a>
   </div>
 
@@ -119,7 +178,29 @@
   {/if}
 
   <div class="space-y-3">
-    <h2 class="text-sm font-medium text-muted-foreground uppercase tracking-wide">AI Integrations</h2>
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <h2 class="text-sm font-medium text-muted-foreground uppercase tracking-wide">AI Integrations</h2>
+      <div class="flex flex-wrap items-center justify-end gap-2">
+        {#if testSummary}
+          <span class="text-xs text-muted-foreground">
+            {testSummary.passed} passed · {testSummary.failed} failed
+          </span>
+        {/if}
+        <button
+          onclick={handleTestAll}
+          disabled={loading || testingAll || testableIntegrations.length === 0}
+          title="Sends one minimal request to each connected provider and may incur a small provider charge."
+          class="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {#if testingAll}
+            <Loader2 class="h-3.5 w-3.5 animate-spin" />
+            Testing all…
+          {:else}
+            Test All Connected
+          {/if}
+        </button>
+      </div>
+    </div>
 
     {#if loading}
       {#each [1, 2, 3, 4] as _}
@@ -129,6 +210,8 @@
       {#each integrations as integration}
         {@const color = PROVIDER_COLORS[integration.id] ?? '#6b7280'}
         {@const icon = PROVIDER_ICONS[integration.id] ?? '◉'}
+        {@const testState = testStates[integration.id]}
+        {@const canTest = integration.api_key_configured || (integration.id === 'ollama' && Boolean(integration.current_model))}
         <div class="border rounded-lg p-4 bg-card flex items-center gap-4 transition-colors {integration.is_active ? 'border-l-4 border-l-primary border-primary/20 bg-primary/5' : 'border-border'}">
           <!-- Icon -->
           <div class="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 text-base font-bold" style="background:{color}18; color:{color}">
@@ -171,11 +254,30 @@
                 {integration.current_model.split('/').pop()}
               </p>
             {/if}
+            {#if testState}
+              <p class="mt-1 text-xs {testState.status === 'success' ? 'text-green-600 dark:text-green-400' : testState.status === 'failure' ? 'text-red-600 dark:text-red-400' : 'text-muted-foreground'}">
+                {testState.message}
+              </p>
+            {/if}
           </div>
 
           <!-- Actions -->
-          <div class="flex items-center gap-2 shrink-0">
-            {#if (integration.api_key_configured || integration.id === 'ollama') && !integration.is_active}
+          <div class="flex flex-wrap items-center justify-end gap-2 shrink-0">
+            {#if canTest}
+              <button
+                onclick={() => handleTestIntegration(integration.id)}
+                disabled={testingAll || testState?.status === 'testing'}
+                class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium border border-border hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {#if testState?.status === 'testing'}
+                  <Loader2 class="w-3 h-3 animate-spin" />
+                  Testing…
+                {:else}
+                  Test
+                {/if}
+              </button>
+            {/if}
+            {#if canTest && !integration.is_active}
               {#if confirmingActivate === integration.id}
                 <div class="flex items-center gap-1.5">
                   <span class="text-xs text-muted-foreground">Switch to {integration.label}?</span>
@@ -229,7 +331,7 @@
               onclick={() => openEdit(integration)}
               class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm border border-border hover:bg-accent transition-colors text-muted-foreground"
             >
-              {#if integration.api_key_configured || integration.id === 'ollama'}
+              {#if canTest}
                 <Pencil class="w-3.5 h-3.5" />
                 Edit
               {:else}


### PR DESCRIPTION
## Scope

This PR adds configured integration connection testing in two stages:

1. tests first to define backend and frontend behavior
2. implementation after CI verifies the new tests fail for the missing feature

Planned behavior:
- test one provider using its saved model and credential
- test all connected providers from the Settings page with a maximum concurrency of three
- include configured API providers and Ollama only when a model is selected
- return only sanitized success/failure messages
- keep results in frontend session state only

The broader Settings UI/UX redesign will be handled in a separate PR after this behavior is stable. No tag or release is included.