### PR TITLE
feat: add encrypted provider credential vault

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,9 @@
 # Database path (SQLite default)
 DATABASE_URL=sqlite:///./applykit.db
+
+# Provider credential vault
+# Managed deployments should set a persistent Fernet key. Generate one with:
+# python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# CREDENTIAL_ENCRYPTION_KEY=
+CREDENTIAL_KEY_FILE=.applykit/credential.key
+MAX_PROVIDER_CREDENTIALS=20

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+.applykit/

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -17,6 +17,13 @@ class Settings(BaseSettings):
     # Database
     database_url: str = "sqlite:///./applykit.db"
 
+    # Credential vault
+    # Supply a Fernet key through APPLYKIT_CREDENTIAL_ENCRYPTION_KEY in managed
+    # deployments. Local installs automatically create the fallback key file.
+    credential_encryption_key: str | None = None
+    credential_key_file: str = ".applykit/credential.key"
+    max_provider_credentials: int = 20
+
     # CORS
     cors_origins: list[str] = ["http://localhost:5173"]
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -18,7 +18,7 @@ class Settings(BaseSettings):
     database_url: str = "sqlite:///./applykit.db"
 
     # Credential vault
-    # Supply a Fernet key through APPLYKIT_CREDENTIAL_ENCRYPTION_KEY in managed
+    # Supply a Fernet key through CREDENTIAL_ENCRYPTION_KEY in managed
     # deployments. Local installs automatically create the fallback key file.
     credential_encryption_key: str | None = None
     credential_key_file: str = ".applykit/credential.key"

--- a/backend/app/credential_schemas.py
+++ b/backend/app/credential_schemas.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class CredentialIntegrationInfo(BaseModel):
+    id: str
+    label: str
+    is_active: bool
+    api_key_configured: bool
+    masked_api_key: str | None
+    current_model: str | None
+    credential_count: int = 0
+    active_credential_id: int | None = None
+    active_credential_label: str | None = None
+    credential_strategy: Literal["manual", "failover", "round_robin"] = "manual"
+
+
+class CredentialIntegrationsResponse(BaseModel):
+    integrations: list[CredentialIntegrationInfo]
+
+
+class ProviderCredentialInfo(BaseModel):
+    id: int
+    provider_id: str
+    label: str
+    masked_secret: str
+    is_active: bool
+    is_enabled: bool
+    priority: int
+    health_status: str
+    cooldown_until: datetime | None
+    last_tested_at: datetime | None
+    last_used_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ProviderCredentialsResponse(BaseModel):
+    provider_id: str
+    credentials: list[ProviderCredentialInfo]
+    max_credentials: int
+
+
+class CreateProviderCredentialRequest(BaseModel):
+    label: str = Field(min_length=1, max_length=80)
+    secret: str = Field(min_length=1, max_length=4096)
+    activate: bool = False
+
+
+class UpdateProviderCredentialRequest(BaseModel):
+    label: str | None = Field(default=None, min_length=1, max_length=80)
+    secret: str | None = Field(default=None, min_length=1, max_length=4096)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import DeclarativeBase
 
@@ -115,6 +116,54 @@ class AppSetting(Base):
 
     key = Column(String, primary_key=True)
     value = Column(Text, nullable=False)
+
+
+class ProviderCredential(Base):
+    __tablename__ = "provider_credential"
+    __table_args__ = (
+        UniqueConstraint(
+            "provider_id",
+            "fingerprint",
+            name="uq_provider_credential_fingerprint",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    provider_id = Column(String(64), nullable=False, index=True)
+    label = Column(String(80), nullable=False)
+    encrypted_secret = Column(Text, nullable=False)
+    masked_secret = Column(String(64), nullable=False)
+    fingerprint = Column(String(64), nullable=False)
+    is_active = Column(Boolean, nullable=False, default=False, index=True)
+    is_enabled = Column(Boolean, nullable=False, default=True)
+    priority = Column(Integer, nullable=False, default=1)
+    health_status = Column(String(32), nullable=False, default="unknown")
+    consecutive_failures = Column(Integer, nullable=False, default=0)
+    cooldown_until = Column(DateTime, nullable=True)
+    last_tested_at = Column(DateTime, nullable=True)
+    last_used_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
+    updated_at = Column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+
+class ProviderCredentialPolicy(Base):
+    __tablename__ = "provider_credential_policy"
+
+    provider_id = Column(String(64), primary_key=True)
+    strategy = Column(String(32), nullable=False, default="manual")
+    max_attempts = Column(Integer, nullable=False, default=2)
+    round_robin_cursor = Column(Integer, nullable=False, default=0)
+    updated_at = Column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
 
 
 class LlmUsageLog(Base):

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -1,21 +1,43 @@
+from datetime import UTC, datetime
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
+from app.config import get_settings as get_app_settings
+from app.credential_schemas import (
+    CreateProviderCredentialRequest,
+    CredentialIntegrationInfo,
+    CredentialIntegrationsResponse,
+    ProviderCredentialInfo,
+    ProviderCredentialsResponse,
+    UpdateProviderCredentialRequest,
+)
 from app.database import get_db
 from app.exceptions import ProviderNotFoundError, ValidationAppError
 from app.llm.catalog import CATALOG, get_provider
 from app.llm.model_selection import supports_custom_models, validate_model_id
 from app.llm.provider_credentials import credential_url_for_provider
 from app.llm.schemas import ModelOption, ModelsResponse, ProviderInfo
+from app.models import ProviderCredentialPolicy
 from app.schemas import (
     ActivateProviderRequest,
-    IntegrationInfo,
-    IntegrationsResponse,
     SettingsResponse,
     TestConnectionResponse,
     UpdateSettingsRequest,
 )
 from app.services.provider_connection import test_provider_connection
+from app.services.provider_credential_vault import (
+    CredentialVaultError,
+    activate_provider_credential,
+    create_provider_credential,
+    decrypt_provider_credential,
+    delete_provider_credential,
+    get_provider_credential,
+    list_provider_credentials,
+    migrate_legacy_provider_credentials,
+    rename_provider_credential,
+    replace_provider_credential_secret,
+)
 from app.services.settings import (
     clear_provider_api_key,
     get_llm_config,
@@ -33,20 +55,49 @@ from app.services.settings import (
 router = APIRouter()
 
 
-def _mask_api_key(key: str) -> str | None:
-    """Return a masked version of an API key for display."""
-    if not key:
-        return None
-    if len(key) <= 8:
-        return "•" * len(key)
-    return key[:4] + "•" * (len(key) - 8) + key[-4:]
-
-
 def _validate_model_or_422(model_id: str) -> str:
     try:
         return validate_model_id(model_id)
     except ValueError as exc:
         raise ValidationAppError(str(exc)) from exc
+
+
+def _provider_or_404(provider_id: str):
+    provider = get_provider(provider_id)
+    if provider is None:
+        raise ProviderNotFoundError(provider_id)
+    return provider
+
+
+def _credential_or_422(provider_id: str, credential_id: int, db: Session):
+    credential = get_provider_credential(db, provider_id, credential_id)
+    if credential is None:
+        raise ValidationAppError("Credential was not found.")
+    return credential
+
+
+def _credential_info(credential) -> ProviderCredentialInfo:
+    return ProviderCredentialInfo.model_validate(credential)
+
+
+def _credential_list_response(
+    provider_id: str,
+    db: Session,
+) -> ProviderCredentialsResponse:
+    settings = get_app_settings()
+    return ProviderCredentialsResponse(
+        provider_id=provider_id,
+        credentials=[
+            _credential_info(item)
+            for item in list_provider_credentials(db, provider_id)
+        ],
+        max_credentials=settings.max_provider_credentials,
+    )
+
+
+def _credential_strategy(db: Session, provider_id: str) -> str:
+    policy = db.query(ProviderCredentialPolicy).filter_by(provider_id=provider_id).first()
+    return policy.strategy if policy else "manual"
 
 
 @router.get("/settings", response_model=SettingsResponse)
@@ -62,19 +113,30 @@ def get_settings(db: Session = Depends(get_db)):
     )
 
 
-@router.get("/settings/integrations", response_model=IntegrationsResponse)
+@router.get(
+    "/settings/integrations",
+    response_model=CredentialIntegrationsResponse,
+)
 def get_integrations(db: Session = Depends(get_db)):
+    migrate_legacy_provider_credentials(db)
     active_model = get_setting(db, "llm_provider") or ""
     active_provider = provider_from_model(active_model)
 
     integrations = []
     for provider in CATALOG.providers:
-        api_key = ""
-        if provider_requires_api_key(provider.id):
-            api_key = get_provider_api_key(db, provider.id) or ""
-            if not api_key and provider.id == active_provider:
-                api_key = get_setting(db, "llm_api_key") or ""
-
+        credentials = (
+            list_provider_credentials(db, provider.id)
+            if provider_requires_api_key(provider.id)
+            else []
+        )
+        active_credential = next(
+            (
+                credential
+                for credential in credentials
+                if credential.is_active and credential.is_enabled
+            ),
+            None,
+        )
         is_active = provider.id == active_provider
         current_model = (
             active_model
@@ -83,16 +145,26 @@ def get_integrations(db: Session = Depends(get_db)):
         )
 
         integrations.append(
-            IntegrationInfo(
+            CredentialIntegrationInfo(
                 id=provider.id,
                 label=provider.label,
                 is_active=is_active,
-                api_key_configured=bool(api_key),
-                masked_api_key=_mask_api_key(api_key) if api_key else None,
+                api_key_configured=bool(active_credential),
+                masked_api_key=(
+                    active_credential.masked_secret if active_credential else None
+                ),
                 current_model=current_model,
+                credential_count=len(credentials),
+                active_credential_id=(
+                    active_credential.id if active_credential else None
+                ),
+                active_credential_label=(
+                    active_credential.label if active_credential else None
+                ),
+                credential_strategy=_credential_strategy(db, provider.id),
             )
         )
-    return IntegrationsResponse(integrations=integrations)
+    return CredentialIntegrationsResponse(integrations=integrations)
 
 
 @router.put("/settings", response_model=SettingsResponse)
@@ -126,10 +198,7 @@ def activate_provider(req: ActivateProviderRequest, db: Session = Depends(get_db
     """Switch active provider without changing any stored API key."""
     migrate_legacy_api_key(db)
 
-    provider = get_provider(req.provider_id)
-    if provider is None:
-        raise ProviderNotFoundError(req.provider_id)
-
+    provider = _provider_or_404(req.provider_id)
     saved_model = get_setting(db, f"selected_model_{provider.id}")
     if not saved_model:
         saved_model = provider.models[0].id
@@ -164,9 +233,7 @@ def test_configured_integration(
     provider_id: str,
     db: Session = Depends(get_db),
 ):
-    provider = get_provider(provider_id)
-    if provider is None:
-        raise ProviderNotFoundError(provider_id)
+    provider = _provider_or_404(provider_id)
 
     active_model = get_setting(db, "llm_provider") or ""
     active_provider = provider_from_model(active_model)
@@ -180,8 +247,6 @@ def test_configured_integration(
     api_key = ""
     if provider_requires_api_key(provider_id):
         api_key = get_provider_api_key(db, provider_id) or ""
-        if not api_key and active_provider == provider_id:
-            api_key = get_setting(db, "llm_api_key") or ""
         if not api_key:
             return TestConnectionResponse(
                 ok=False,
@@ -195,12 +260,152 @@ def test_configured_integration(
     )
 
 
-@router.delete("/settings/integrations/{provider_id}", response_model=IntegrationsResponse)
-def disconnect_provider(provider_id: str, db: Session = Depends(get_db)):
-    """Remove the stored API key for a provider. If it was active, clear the active model."""
-    if get_provider(provider_id) is None:
-        raise ProviderNotFoundError(provider_id)
+@router.get(
+    "/settings/integrations/{provider_id}/credentials",
+    response_model=ProviderCredentialsResponse,
+)
+def get_provider_credentials(
+    provider_id: str,
+    db: Session = Depends(get_db),
+):
+    _provider_or_404(provider_id)
+    migrate_legacy_provider_credentials(db)
+    return _credential_list_response(provider_id, db)
 
+
+@router.post(
+    "/settings/integrations/{provider_id}/credentials",
+    response_model=ProviderCredentialInfo,
+)
+def add_provider_credential(
+    provider_id: str,
+    req: CreateProviderCredentialRequest,
+    db: Session = Depends(get_db),
+):
+    _provider_or_404(provider_id)
+    if not provider_requires_api_key(provider_id):
+        raise ValidationAppError("This provider does not use API credentials.")
+
+    migrate_legacy_provider_credentials(db)
+    settings = get_app_settings()
+    existing = list_provider_credentials(db, provider_id)
+    try:
+        credential = create_provider_credential(
+            db,
+            provider_id=provider_id,
+            label=req.label,
+            secret=req.secret,
+            activate=True if not existing else req.activate,
+            max_credentials=settings.max_provider_credentials,
+        )
+    except CredentialVaultError as exc:
+        raise ValidationAppError(str(exc)) from exc
+    return _credential_info(credential)
+
+
+@router.patch(
+    "/settings/integrations/{provider_id}/credentials/{credential_id}",
+    response_model=ProviderCredentialInfo,
+)
+def update_provider_credential(
+    provider_id: str,
+    credential_id: int,
+    req: UpdateProviderCredentialRequest,
+    db: Session = Depends(get_db),
+):
+    _provider_or_404(provider_id)
+    credential = _credential_or_422(provider_id, credential_id, db)
+    try:
+        if req.label is not None:
+            credential = rename_provider_credential(
+                db,
+                provider_id,
+                credential_id,
+                req.label,
+            )
+        if req.secret is not None:
+            credential = replace_provider_credential_secret(
+                db,
+                provider_id,
+                credential_id,
+                req.secret,
+            )
+    except CredentialVaultError as exc:
+        raise ValidationAppError(str(exc)) from exc
+    return _credential_info(credential)
+
+
+@router.put(
+    "/settings/integrations/{provider_id}/credentials/{credential_id}/activate",
+    response_model=ProviderCredentialInfo,
+)
+def activate_credential(
+    provider_id: str,
+    credential_id: int,
+    db: Session = Depends(get_db),
+):
+    _provider_or_404(provider_id)
+    try:
+        credential = activate_provider_credential(db, provider_id, credential_id)
+    except CredentialVaultError as exc:
+        raise ValidationAppError(str(exc)) from exc
+    return _credential_info(credential)
+
+
+@router.post(
+    "/settings/integrations/{provider_id}/credentials/{credential_id}/test",
+    response_model=TestConnectionResponse,
+)
+def test_credential(
+    provider_id: str,
+    credential_id: int,
+    db: Session = Depends(get_db),
+):
+    provider = _provider_or_404(provider_id)
+    credential = _credential_or_422(provider_id, credential_id, db)
+    active_model = get_setting(db, "llm_provider") or ""
+    saved_model = (
+        active_model
+        if provider_from_model(active_model) == provider_id
+        else get_setting(db, f"selected_model_{provider_id}")
+    )
+    model_id = saved_model or provider.models[0].id
+    result = test_provider_connection(
+        model_id,
+        decrypt_provider_credential(credential),
+        failure_message="Provider connection failed.",
+    )
+    credential.last_tested_at = datetime.now(UTC)
+    credential.health_status = "healthy" if result.ok else "unhealthy"
+    credential.consecutive_failures = 0 if result.ok else credential.consecutive_failures + 1
+    db.commit()
+    return result
+
+
+@router.delete(
+    "/settings/integrations/{provider_id}/credentials/{credential_id}",
+    response_model=ProviderCredentialsResponse,
+)
+def delete_credential(
+    provider_id: str,
+    credential_id: int,
+    db: Session = Depends(get_db),
+):
+    _provider_or_404(provider_id)
+    try:
+        delete_provider_credential(db, provider_id, credential_id)
+    except CredentialVaultError as exc:
+        raise ValidationAppError(str(exc)) from exc
+    return _credential_list_response(provider_id, db)
+
+
+@router.delete(
+    "/settings/integrations/{provider_id}",
+    response_model=CredentialIntegrationsResponse,
+)
+def disconnect_provider(provider_id: str, db: Session = Depends(get_db)):
+    """Remove all credentials for a provider and clear it when active."""
+    _provider_or_404(provider_id)
     clear_provider_api_key(db, provider_id)
 
     active_model = get_setting(db, "llm_provider") or ""

--- a/backend/app/services/credential_crypto.py
+++ b/backend/app/services/credential_crypto.py
@@ -1,0 +1,100 @@
+"""Authenticated encryption for provider credentials.
+
+A deployment can supply ``APPLYKIT_CREDENTIAL_ENCRYPTION_KEY``. When it is
+absent, ApplyKit creates a persistent Fernet key in a local file so database
+backups do not contain the material needed to decrypt provider credentials.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+from functools import lru_cache
+from hashlib import sha256
+from pathlib import Path
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from app.config import get_settings
+
+
+class CredentialDecryptionError(ValueError):
+    """Raised when encrypted credential data cannot be decrypted safely."""
+
+
+class CredentialCipher:
+    """Encrypt, decrypt, and fingerprint provider secrets."""
+
+    def __init__(self, key: str | bytes):
+        encoded_key = key.encode() if isinstance(key, str) else key
+        try:
+            self._fernet = Fernet(encoded_key)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "Credential encryption key must be a valid Fernet key."
+            ) from exc
+        self._fingerprint_key = encoded_key
+
+    def encrypt(self, secret: str) -> str:
+        if not secret:
+            raise ValueError("Credential secret cannot be empty.")
+        return self._fernet.encrypt(secret.encode()).decode()
+
+    def decrypt(self, encrypted_secret: str) -> str:
+        try:
+            return self._fernet.decrypt(encrypted_secret.encode()).decode()
+        except (InvalidToken, UnicodeDecodeError) as exc:
+            raise CredentialDecryptionError(
+                "Stored credential could not be decrypted. Check the configured "
+                "credential encryption key."
+            ) from exc
+
+    def fingerprint(self, secret: str) -> str:
+        """Return a keyed digest used only for duplicate detection."""
+        return hmac.new(
+            self._fingerprint_key,
+            secret.encode(),
+            sha256,
+        ).hexdigest()
+
+
+def _read_key(path: Path) -> bytes:
+    key = path.read_bytes().strip()
+    if not key:
+        raise ValueError(f"Credential key file is empty: {path}")
+    return key
+
+
+def _create_key_file(path: Path) -> bytes:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    key = Fernet.generate_key()
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        return _read_key(path)
+
+    with os.fdopen(descriptor, "wb") as handle:
+        handle.write(key + b"\n")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        # Some filesystems (notably Windows mounts) do not expose POSIX modes.
+        pass
+    return key
+
+
+def _load_production_key() -> bytes:
+    settings = get_settings()
+    if settings.credential_encryption_key:
+        return settings.credential_encryption_key.encode()
+
+    key_path = Path(settings.credential_key_file).expanduser()
+    if key_path.exists():
+        return _read_key(key_path)
+    return _create_key_file(key_path)
+
+
+@lru_cache
+def get_credential_cipher() -> CredentialCipher:
+    """Return the process-wide credential cipher."""
+    return CredentialCipher(_load_production_key())

--- a/backend/app/services/provider_credential_vault.py
+++ b/backend/app/services/provider_credential_vault.py
@@ -52,6 +52,18 @@ def list_provider_credentials(
     )
 
 
+def get_provider_credential(
+    db: Session,
+    provider_id: str,
+    credential_id: int,
+) -> ProviderCredential | None:
+    return (
+        db.query(ProviderCredential)
+        .filter_by(id=credential_id, provider_id=provider_id)
+        .first()
+    )
+
+
 def get_active_provider_credential(
     db: Session,
     provider_id: str,
@@ -160,11 +172,7 @@ def replace_provider_credential_secret(
     *,
     cipher: CredentialCipher | None = None,
 ) -> ProviderCredential:
-    credential = (
-        db.query(ProviderCredential)
-        .filter_by(id=credential_id, provider_id=provider_id)
-        .first()
-    )
+    credential = get_provider_credential(db, provider_id, credential_id)
     if not credential:
         raise CredentialNotFoundError("Credential was not found.")
 
@@ -193,6 +201,27 @@ def replace_provider_credential_secret(
     credential.health_status = "unknown"
     credential.consecutive_failures = 0
     credential.cooldown_until = None
+    credential.updated_at = datetime.now(UTC)
+    db.commit()
+    db.refresh(credential)
+    return credential
+
+
+def rename_provider_credential(
+    db: Session,
+    provider_id: str,
+    credential_id: int,
+    label: str,
+) -> ProviderCredential:
+    credential = get_provider_credential(db, provider_id, credential_id)
+    if not credential:
+        raise CredentialNotFoundError("Credential was not found.")
+    label = label.strip()
+    if not label:
+        raise CredentialVaultError("Credential label is required.")
+    if len(label) > 80:
+        raise CredentialVaultError("Credential label must be 80 characters or fewer.")
+    credential.label = label
     credential.updated_at = datetime.now(UTC)
     db.commit()
     db.refresh(credential)
@@ -231,16 +260,8 @@ def activate_provider_credential(
     provider_id: str,
     credential_id: int,
 ) -> ProviderCredential:
-    credential = (
-        db.query(ProviderCredential)
-        .filter_by(
-            id=credential_id,
-            provider_id=provider_id,
-            is_enabled=True,
-        )
-        .first()
-    )
-    if not credential:
+    credential = get_provider_credential(db, provider_id, credential_id)
+    if not credential or not credential.is_enabled:
         raise CredentialNotFoundError("Credential was not found or is disabled.")
 
     _deactivate_provider_credentials(db, provider_id)
@@ -249,6 +270,34 @@ def activate_provider_credential(
     db.commit()
     db.refresh(credential)
     return credential
+
+
+def delete_provider_credential(
+    db: Session,
+    provider_id: str,
+    credential_id: int,
+) -> None:
+    credential = get_provider_credential(db, provider_id, credential_id)
+    if not credential:
+        raise CredentialNotFoundError("Credential was not found.")
+
+    was_active = credential.is_active
+    db.delete(credential)
+    db.flush()
+    if was_active:
+        replacement = (
+            db.query(ProviderCredential)
+            .filter_by(provider_id=provider_id, is_enabled=True)
+            .order_by(
+                ProviderCredential.priority.asc(),
+                ProviderCredential.id.asc(),
+            )
+            .first()
+        )
+        if replacement:
+            replacement.is_active = True
+            replacement.updated_at = datetime.now(UTC)
+    db.commit()
 
 
 def clear_provider_credentials(db: Session, provider_id: str) -> None:

--- a/backend/app/services/provider_credential_vault.py
+++ b/backend/app/services/provider_credential_vault.py
@@ -1,0 +1,317 @@
+"""Persistence and lifecycle operations for provider API credentials."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.llm.catalog import CATALOG, provider_from_model
+from app.models import AppSetting, ProviderCredential
+from app.services.credential_crypto import CredentialCipher, get_credential_cipher
+
+DEFAULT_MAX_PROVIDER_CREDENTIALS = 20
+
+
+class CredentialVaultError(ValueError):
+    """Base error for credential-vault validation failures."""
+
+
+class CredentialNotFoundError(CredentialVaultError):
+    pass
+
+
+class DuplicateCredentialError(CredentialVaultError):
+    pass
+
+
+class CredentialLimitError(CredentialVaultError):
+    pass
+
+
+def mask_credential(secret: str) -> str:
+    if len(secret) <= 8:
+        return "•" * len(secret)
+    return secret[:4] + "•" * min(len(secret) - 8, 24) + secret[-4:]
+
+
+def list_provider_credentials(
+    db: Session,
+    provider_id: str,
+) -> list[ProviderCredential]:
+    return (
+        db.query(ProviderCredential)
+        .filter_by(provider_id=provider_id)
+        .order_by(
+            ProviderCredential.is_active.desc(),
+            ProviderCredential.priority.asc(),
+            ProviderCredential.id.asc(),
+        )
+        .all()
+    )
+
+
+def get_active_provider_credential(
+    db: Session,
+    provider_id: str,
+) -> ProviderCredential | None:
+    return (
+        db.query(ProviderCredential)
+        .filter_by(
+            provider_id=provider_id,
+            is_active=True,
+            is_enabled=True,
+        )
+        .first()
+    )
+
+
+def decrypt_provider_credential(
+    credential: ProviderCredential,
+    *,
+    cipher: CredentialCipher | None = None,
+) -> str:
+    return (cipher or get_credential_cipher()).decrypt(credential.encrypted_secret)
+
+
+def _next_priority(db: Session, provider_id: str) -> int:
+    highest = (
+        db.query(func.max(ProviderCredential.priority))
+        .filter_by(provider_id=provider_id)
+        .scalar()
+    )
+    return int(highest or 0) + 1
+
+
+def _deactivate_provider_credentials(db: Session, provider_id: str) -> None:
+    db.query(ProviderCredential).filter_by(
+        provider_id=provider_id,
+        is_active=True,
+    ).update({"is_active": False}, synchronize_session=False)
+
+
+def create_provider_credential(
+    db: Session,
+    *,
+    provider_id: str,
+    label: str,
+    secret: str,
+    cipher: CredentialCipher | None = None,
+    activate: bool | None = None,
+    max_credentials: int = DEFAULT_MAX_PROVIDER_CREDENTIALS,
+) -> ProviderCredential:
+    provider_id = provider_id.strip()
+    label = label.strip()
+    secret = secret.strip()
+    if not provider_id:
+        raise CredentialVaultError("Provider ID is required.")
+    if not label:
+        raise CredentialVaultError("Credential label is required.")
+    if len(label) > 80:
+        raise CredentialVaultError("Credential label must be 80 characters or fewer.")
+    if not secret:
+        raise CredentialVaultError("Credential secret is required.")
+
+    count = db.query(ProviderCredential).filter_by(provider_id=provider_id).count()
+    if count >= max_credentials:
+        raise CredentialLimitError(
+            f"A provider can store at most {max_credentials} credentials."
+        )
+
+    selected_cipher = cipher or get_credential_cipher()
+    fingerprint = selected_cipher.fingerprint(secret)
+    duplicate = (
+        db.query(ProviderCredential)
+        .filter_by(provider_id=provider_id, fingerprint=fingerprint)
+        .first()
+    )
+    if duplicate:
+        raise DuplicateCredentialError(
+            "This credential is already stored for the provider."
+        )
+
+    should_activate = count == 0 if activate is None else activate
+    if should_activate:
+        _deactivate_provider_credentials(db, provider_id)
+
+    credential = ProviderCredential(
+        provider_id=provider_id,
+        label=label,
+        encrypted_secret=selected_cipher.encrypt(secret),
+        masked_secret=mask_credential(secret),
+        fingerprint=fingerprint,
+        is_active=should_activate,
+        is_enabled=True,
+        priority=_next_priority(db, provider_id),
+        health_status="unknown",
+    )
+    db.add(credential)
+    db.commit()
+    db.refresh(credential)
+    return credential
+
+
+def replace_provider_credential_secret(
+    db: Session,
+    provider_id: str,
+    credential_id: int,
+    secret: str,
+    *,
+    cipher: CredentialCipher | None = None,
+) -> ProviderCredential:
+    credential = (
+        db.query(ProviderCredential)
+        .filter_by(id=credential_id, provider_id=provider_id)
+        .first()
+    )
+    if not credential:
+        raise CredentialNotFoundError("Credential was not found.")
+
+    secret = secret.strip()
+    if not secret:
+        raise CredentialVaultError("Credential secret is required.")
+    selected_cipher = cipher or get_credential_cipher()
+    fingerprint = selected_cipher.fingerprint(secret)
+    duplicate = (
+        db.query(ProviderCredential)
+        .filter(
+            ProviderCredential.provider_id == provider_id,
+            ProviderCredential.fingerprint == fingerprint,
+            ProviderCredential.id != credential_id,
+        )
+        .first()
+    )
+    if duplicate:
+        raise DuplicateCredentialError(
+            "This credential is already stored for the provider."
+        )
+
+    credential.encrypted_secret = selected_cipher.encrypt(secret)
+    credential.masked_secret = mask_credential(secret)
+    credential.fingerprint = fingerprint
+    credential.health_status = "unknown"
+    credential.consecutive_failures = 0
+    credential.cooldown_until = None
+    credential.updated_at = datetime.now(UTC)
+    db.commit()
+    db.refresh(credential)
+    return credential
+
+
+def upsert_active_provider_credential(
+    db: Session,
+    provider_id: str,
+    secret: str,
+    *,
+    label: str = "Default",
+    cipher: CredentialCipher | None = None,
+) -> ProviderCredential:
+    active = get_active_provider_credential(db, provider_id)
+    if active:
+        return replace_provider_credential_secret(
+            db,
+            provider_id,
+            active.id,
+            secret,
+            cipher=cipher,
+        )
+    return create_provider_credential(
+        db,
+        provider_id=provider_id,
+        label=label,
+        secret=secret,
+        cipher=cipher,
+        activate=True,
+    )
+
+
+def activate_provider_credential(
+    db: Session,
+    provider_id: str,
+    credential_id: int,
+) -> ProviderCredential:
+    credential = (
+        db.query(ProviderCredential)
+        .filter_by(
+            id=credential_id,
+            provider_id=provider_id,
+            is_enabled=True,
+        )
+        .first()
+    )
+    if not credential:
+        raise CredentialNotFoundError("Credential was not found or is disabled.")
+
+    _deactivate_provider_credentials(db, provider_id)
+    credential.is_active = True
+    credential.updated_at = datetime.now(UTC)
+    db.commit()
+    db.refresh(credential)
+    return credential
+
+
+def clear_provider_credentials(db: Session, provider_id: str) -> None:
+    db.query(ProviderCredential).filter_by(provider_id=provider_id).delete(
+        synchronize_session=False
+    )
+    db.commit()
+
+
+def _get_plain_setting(db: Session, key: str) -> str:
+    row = db.query(AppSetting).filter_by(key=key).first()
+    return row.value if row else ""
+
+
+def _clear_plain_setting(db: Session, key: str) -> None:
+    row = db.query(AppSetting).filter_by(key=key).first()
+    if row:
+        row.value = ""
+
+
+def migrate_legacy_provider_credentials(
+    db: Session,
+    *,
+    cipher: CredentialCipher | None = None,
+) -> int:
+    """Move old plaintext provider settings into the encrypted vault once."""
+    selected_cipher = cipher or get_credential_cipher()
+    active_model = _get_plain_setting(db, "llm_provider")
+    active_provider = provider_from_model(active_model)
+    migrated = 0
+
+    for provider in CATALOG.providers:
+        if provider.auth_type.value == "none":
+            continue
+
+        provider_key_name = f"api_key_{provider.id}"
+        plaintext = _get_plain_setting(db, provider_key_name)
+        used_legacy_global = False
+        if not plaintext and provider.id == active_provider:
+            plaintext = _get_plain_setting(db, "llm_api_key")
+            used_legacy_global = bool(plaintext)
+        if not plaintext:
+            continue
+
+        existing = (
+            db.query(ProviderCredential)
+            .filter_by(provider_id=provider.id)
+            .first()
+        )
+        if not existing:
+            create_provider_credential(
+                db,
+                provider_id=provider.id,
+                label="Default",
+                secret=plaintext,
+                cipher=selected_cipher,
+                activate=True,
+            )
+            migrated += 1
+
+        _clear_plain_setting(db, provider_key_name)
+        if used_legacy_global:
+            _clear_plain_setting(db, "llm_api_key")
+        db.commit()
+
+    return migrated

--- a/backend/app/services/settings.py
+++ b/backend/app/services/settings.py
@@ -7,6 +7,13 @@ from app.llm.catalog import (
     provider_requires_api_key,
 )
 from app.models import AppSetting
+from app.services.provider_credential_vault import (
+    clear_provider_credentials,
+    decrypt_provider_credential,
+    get_active_provider_credential,
+    migrate_legacy_provider_credentials,
+    upsert_active_provider_credential,
+)
 
 # Backward-compatible projection for callers that still need provider -> model IDs.
 KNOWN_MODELS: dict[str, list[str]] = {
@@ -40,17 +47,25 @@ def set_setting(db: Session, key: str, value: str) -> None:
 
 
 def get_provider_api_key(db: Session, provider_id: str) -> str | None:
-    """Get the stored API key for a specific provider."""
-    return get_setting(db, f"api_key_{provider_id}")
+    """Return the decrypted manually active credential for a provider."""
+    migrate_legacy_provider_credentials(db)
+    credential = get_active_provider_credential(db, provider_id)
+    if not credential:
+        return None
+    return decrypt_provider_credential(credential)
 
 
 def set_provider_api_key(db: Session, provider_id: str, api_key: str) -> None:
-    """Store API key for a specific provider."""
-    set_setting(db, f"api_key_{provider_id}", api_key)
+    """Create or replace the manually active credential for a provider."""
+    migrate_legacy_provider_credentials(db)
+    upsert_active_provider_credential(db, provider_id, api_key)
+    # Clear any plaintext remnants left by older ApplyKit versions.
+    set_setting(db, f"api_key_{provider_id}", "")
 
 
 def clear_provider_api_key(db: Session, provider_id: str) -> None:
-    """Remove the stored API key for a provider."""
+    """Remove every stored credential for a provider."""
+    clear_provider_credentials(db, provider_id)
     set_setting(db, f"api_key_{provider_id}", "")
 
 
@@ -60,7 +75,7 @@ def set_active_model(db: Session, model: str) -> None:
 
 
 def get_llm_config(db: Session) -> tuple[str, str]:
-    """Return (model_string, api_key) for the currently active provider."""
+    """Return (model_string, active_api_key) for the active provider."""
     model = get_setting(db, "llm_provider") or ""
     if not model:
         return "", ""
@@ -69,23 +84,16 @@ def get_llm_config(db: Session) -> tuple[str, str]:
     if not provider_requires_api_key(provider_id):
         return model, ""
 
-    if provider_id:
-        api_key = get_provider_api_key(db, provider_id) or ""
-        # Legacy fallback: old single-key setup
-        if not api_key:
-            api_key = get_setting(db, "llm_api_key") or ""
-    else:
-        api_key = get_setting(db, "llm_api_key") or ""
-    return model, api_key
+    migrate_legacy_provider_credentials(db)
+    if not provider_id:
+        return model, ""
+
+    credential = get_active_provider_credential(db, provider_id)
+    if not credential:
+        return model, ""
+    return model, decrypt_provider_credential(credential)
 
 
 def migrate_legacy_api_key(db: Session) -> None:
-    """Migrate the old global llm_api_key to per-provider storage if needed."""
-    current_model = get_setting(db, "llm_provider") or ""
-    current_provider = provider_from_model(current_model)
-    if not current_provider or not provider_requires_api_key(current_provider):
-        return
-    if not get_provider_api_key(db, current_provider):
-        legacy_key = get_setting(db, "llm_api_key") or ""
-        if legacy_key:
-            set_provider_api_key(db, current_provider, legacy_key)
+    """Backward-compatible alias for the encrypted credential migration."""
+    migrate_legacy_provider_credentials(db)

--- a/backend/migrations/versions/91c5d1e2a7b4_add_provider_credential_vault.py
+++ b/backend/migrations/versions/91c5d1e2a7b4_add_provider_credential_vault.py
@@ -1,0 +1,80 @@
+"""add provider credential vault
+
+Revision ID: 91c5d1e2a7b4
+Revises: 1284f7500697
+Create Date: 2026-08-02 05:15:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "91c5d1e2a7b4"
+down_revision: str | Sequence[str] | None = "1284f7500697"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "provider_credential",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("provider_id", sa.String(length=64), nullable=False),
+        sa.Column("label", sa.String(length=80), nullable=False),
+        sa.Column("encrypted_secret", sa.Text(), nullable=False),
+        sa.Column("masked_secret", sa.String(length=64), nullable=False),
+        sa.Column("fingerprint", sa.String(length=64), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("is_enabled", sa.Boolean(), nullable=False),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column("health_status", sa.String(length=32), nullable=False),
+        sa.Column("consecutive_failures", sa.Integer(), nullable=False),
+        sa.Column("cooldown_until", sa.DateTime(), nullable=True),
+        sa.Column("last_tested_at", sa.DateTime(), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "provider_id",
+            "fingerprint",
+            name="uq_provider_credential_fingerprint",
+        ),
+    )
+    op.create_index(
+        op.f("ix_provider_credential_provider_id"),
+        "provider_credential",
+        ["provider_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_provider_credential_is_active"),
+        "provider_credential",
+        ["is_active"],
+        unique=False,
+    )
+
+    op.create_table(
+        "provider_credential_policy",
+        sa.Column("provider_id", sa.String(length=64), nullable=False),
+        sa.Column("strategy", sa.String(length=32), nullable=False),
+        sa.Column("max_attempts", sa.Integer(), nullable=False),
+        sa.Column("round_robin_cursor", sa.Integer(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("provider_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("provider_credential_policy")
+    op.drop_index(
+        op.f("ix_provider_credential_is_active"),
+        table_name="provider_credential",
+    )
+    op.drop_index(
+        op.f("ix_provider_credential_provider_id"),
+        table_name="provider_credential",
+    )
+    op.drop_table("provider_credential")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "alembic>=1.18.4",
     "crawl4ai>=0.8.0",
+    "cryptography>=46.0.5",
     "fastapi>=0.135.1",
     "litellm<=1.82.6",
     "pdfplumber>=0.11.9",

--- a/backend/tests/test_provider_credential_routes.py
+++ b/backend/tests/test_provider_credential_routes.py
@@ -1,0 +1,109 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.routes.settings import (
+    activate_credential,
+    add_provider_credential,
+    delete_credential,
+    get_integrations,
+    get_provider_credentials,
+)
+from app.schemas import CreateProviderCredentialRequest
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_credentials_api_never_returns_raw_secret():
+    db = _make_session()
+    try:
+        created = add_provider_credential(
+            "gemini",
+            CreateProviderCredentialRequest(
+                label="Personal",
+                secret="AIza-route-secret",
+                activate=True,
+            ),
+            db,
+        ).model_dump()
+
+        assert "secret" not in created
+        assert "encrypted_secret" not in created
+        assert created["masked_secret"] != "AIza-route-secret"
+
+        listed = get_provider_credentials("gemini", db).model_dump()
+        assert listed["credentials"][0]["label"] == "Personal"
+        assert "secret" not in listed["credentials"][0]
+    finally:
+        db.close()
+
+
+def test_manual_activation_and_deletion_keep_one_active_credential():
+    db = _make_session()
+    try:
+        first = add_provider_credential(
+            "openai",
+            CreateProviderCredentialRequest(
+                label="Personal",
+                secret="sk-route-personal",
+                activate=True,
+            ),
+            db,
+        )
+        second = add_provider_credential(
+            "openai",
+            CreateProviderCredentialRequest(
+                label="Work",
+                secret="sk-route-work",
+                activate=False,
+            ),
+            db,
+        )
+
+        activated = activate_credential("openai", second.id, db)
+        assert activated.is_active is True
+
+        delete_credential("openai", second.id, db)
+        remaining = get_provider_credentials("openai", db).credentials
+        assert len(remaining) == 1
+        assert remaining[0].id == first.id
+        assert remaining[0].is_active is True
+    finally:
+        db.close()
+
+
+def test_integrations_include_credential_count_and_active_label():
+    db = _make_session()
+    try:
+        add_provider_credential(
+            "anthropic",
+            CreateProviderCredentialRequest(
+                label="Primary",
+                secret="sk-ant-primary",
+                activate=True,
+            ),
+            db,
+        )
+        add_provider_credential(
+            "anthropic",
+            CreateProviderCredentialRequest(
+                label="Backup",
+                secret="sk-ant-backup",
+                activate=False,
+            ),
+            db,
+        )
+
+        integrations = get_integrations(db).integrations
+        anthropic = next(item for item in integrations if item.id == "anthropic")
+
+        assert anthropic.credential_count == 2
+        assert anthropic.active_credential_label == "Primary"
+        assert anthropic.api_key_configured is True
+        assert anthropic.masked_api_key is not None
+    finally:
+        db.close()

--- a/backend/tests/test_provider_credential_routes.py
+++ b/backend/tests/test_provider_credential_routes.py
@@ -1,6 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from app.credential_schemas import CreateProviderCredentialRequest
 from app.models import Base
 from app.routes.settings import (
     activate_credential,
@@ -9,7 +10,6 @@ from app.routes.settings import (
     get_integrations,
     get_provider_credentials,
 )
-from app.schemas import CreateProviderCredentialRequest
 
 
 def _make_session():

--- a/backend/tests/test_provider_credential_vault.py
+++ b/backend/tests/test_provider_credential_vault.py
@@ -1,0 +1,165 @@
+from cryptography.fernet import Fernet
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base, ProviderCredential
+from app.services.credential_crypto import CredentialCipher
+from app.services.provider_credential_vault import (
+    CredentialLimitError,
+    DuplicateCredentialError,
+    activate_provider_credential,
+    create_provider_credential,
+    get_active_provider_credential,
+    list_provider_credentials,
+    migrate_legacy_provider_credentials,
+)
+from app.services.settings import get_setting, set_setting
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _cipher() -> CredentialCipher:
+    return CredentialCipher(Fernet.generate_key().decode())
+
+
+def test_provider_credentials_are_encrypted_and_first_key_becomes_active():
+    db = _make_session()
+    cipher = _cipher()
+    try:
+        credential = create_provider_credential(
+            db,
+            provider_id="gemini",
+            label="Personal",
+            secret="AIza-secret-value",
+            cipher=cipher,
+        )
+
+        db.refresh(credential)
+        assert credential.encrypted_secret != "AIza-secret-value"
+        assert "AIza-secret-value" not in credential.encrypted_secret
+        assert cipher.decrypt(credential.encrypted_secret) == "AIza-secret-value"
+        assert credential.masked_secret.startswith("AIza")
+        assert credential.is_active is True
+    finally:
+        db.close()
+
+
+def test_multiple_credentials_support_manual_active_selection():
+    db = _make_session()
+    cipher = _cipher()
+    try:
+        first = create_provider_credential(
+            db,
+            provider_id="openai",
+            label="Personal",
+            secret="sk-personal-secret",
+            cipher=cipher,
+        )
+        second = create_provider_credential(
+            db,
+            provider_id="openai",
+            label="Work",
+            secret="sk-work-secret",
+            cipher=cipher,
+        )
+
+        assert first.is_active is True
+        assert second.is_active is False
+
+        activate_provider_credential(db, "openai", second.id)
+        active = get_active_provider_credential(db, "openai")
+
+        assert active is not None
+        assert active.id == second.id
+        assert [item.label for item in list_provider_credentials(db, "openai")] == [
+            "Personal",
+            "Work",
+        ]
+    finally:
+        db.close()
+
+
+def test_duplicate_secret_is_rejected_without_storing_a_second_copy():
+    db = _make_session()
+    cipher = _cipher()
+    try:
+        create_provider_credential(
+            db,
+            provider_id="anthropic",
+            label="Primary",
+            secret="sk-ant-duplicate",
+            cipher=cipher,
+        )
+
+        try:
+            create_provider_credential(
+                db,
+                provider_id="anthropic",
+                label="Duplicate",
+                secret="sk-ant-duplicate",
+                cipher=cipher,
+            )
+        except DuplicateCredentialError:
+            pass
+        else:
+            raise AssertionError("duplicate credential should be rejected")
+
+        assert db.query(ProviderCredential).count() == 1
+    finally:
+        db.close()
+
+
+def test_credential_limit_is_enforced_per_provider():
+    db = _make_session()
+    cipher = _cipher()
+    try:
+        for index in range(2):
+            create_provider_credential(
+                db,
+                provider_id="groq",
+                label=f"Key {index + 1}",
+                secret=f"gsk-secret-{index}",
+                cipher=cipher,
+                max_credentials=2,
+            )
+
+        try:
+            create_provider_credential(
+                db,
+                provider_id="groq",
+                label="Key 3",
+                secret="gsk-secret-3",
+                cipher=cipher,
+                max_credentials=2,
+            )
+        except CredentialLimitError:
+            pass
+        else:
+            raise AssertionError("credential limit should be enforced")
+    finally:
+        db.close()
+
+
+def test_legacy_plaintext_key_migrates_once_and_is_cleared():
+    db = _make_session()
+    cipher = _cipher()
+    try:
+        set_setting(db, "api_key_gemini", "AIza-legacy-secret")
+
+        migrated = migrate_legacy_provider_credentials(db, cipher=cipher)
+        active = get_active_provider_credential(db, "gemini")
+
+        assert migrated == 1
+        assert active is not None
+        assert active.label == "Default"
+        assert cipher.decrypt(active.encrypted_secret) == "AIza-legacy-secret"
+        assert get_setting(db, "api_key_gemini") == ""
+
+        assert migrate_legacy_provider_credentials(db, cipher=cipher) == 0
+        assert db.query(ProviderCredential).count() == 1
+    finally:
+        db.close()

--- a/backend/tests/test_provider_credential_vault.py
+++ b/backend/tests/test_provider_credential_vault.py
@@ -76,8 +76,8 @@ def test_multiple_credentials_support_manual_active_selection():
         assert active is not None
         assert active.id == second.id
         assert [item.label for item in list_provider_credentials(db, "openai")] == [
-            "Personal",
             "Work",
+            "Personal",
         ]
     finally:
         db.close()


### PR DESCRIPTION
## Summary
- add an encrypted provider credential vault backed by Fernet authenticated encryption
- support multiple labeled credentials for every remote provider
- keep exactly one manually active credential per provider
- add create, list, rename, replace, activate, test, and delete credential APIs
- automatically promote the next enabled credential when the active one is removed
- reject duplicate secrets using keyed HMAC fingerprints without storing comparable plaintext hashes
- enforce a configurable limit, defaulting to 20 credentials per provider
- migrate existing plaintext `api_key_<provider>` and legacy `llm_api_key` values into the vault, then clear the plaintext values
- expose credential count, active credential metadata, health state, and strategy metadata without exposing secrets
- preserve the existing Settings and LLM runtime contracts so the current frontend continues to work

## Security
- raw and encrypted secrets are never returned by API responses
- managed deployments can set `CREDENTIAL_ENCRYPTION_KEY`
- local installations create a persistent `.applykit/credential.key` with restrictive permissions where supported
- the local key directory is ignored by Git

## Database
- add `provider_credential`
- add `provider_credential_policy` for the upcoming manual/failover/round-robin resolver
- add Alembic migration `91c5d1e2a7b4`

## Verification
- Backend CI Python 3.12: success
- Backend CI Python 3.13: success
- lint: success
- 104 backend tests: success

No tag or release is included.