### PR TITLE
feat: add provider credential rotation strategies

### DIFF
--- a/backend/app/credential_schemas.py
+++ b/backend/app/credential_schemas.py
@@ -3,6 +3,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+CredentialStrategyName = Literal["manual", "failover", "round_robin"]
+
 
 class CredentialIntegrationInfo(BaseModel):
     id: str
@@ -14,7 +16,7 @@ class CredentialIntegrationInfo(BaseModel):
     credential_count: int = 0
     active_credential_id: int | None = None
     active_credential_label: str | None = None
-    credential_strategy: Literal["manual", "failover", "round_robin"] = "manual"
+    credential_strategy: CredentialStrategyName = "manual"
 
 
 class CredentialIntegrationsResponse(BaseModel):
@@ -54,3 +56,14 @@ class CreateProviderCredentialRequest(BaseModel):
 class UpdateProviderCredentialRequest(BaseModel):
     label: str | None = Field(default=None, min_length=1, max_length=80)
     secret: str | None = Field(default=None, min_length=1, max_length=4096)
+
+
+class CredentialPolicyResponse(BaseModel):
+    provider_id: str
+    strategy: CredentialStrategyName
+    max_attempts: int
+
+
+class UpdateCredentialPolicyRequest(BaseModel):
+    strategy: CredentialStrategyName
+    max_attempts: int = Field(default=2, ge=1, le=5)

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -8,8 +8,10 @@ from app.credential_schemas import (
     CreateProviderCredentialRequest,
     CredentialIntegrationInfo,
     CredentialIntegrationsResponse,
+    CredentialPolicyResponse,
     ProviderCredentialInfo,
     ProviderCredentialsResponse,
+    UpdateCredentialPolicyRequest,
     UpdateProviderCredentialRequest,
 )
 from app.database import get_db
@@ -18,7 +20,6 @@ from app.llm.catalog import CATALOG, get_provider
 from app.llm.model_selection import supports_custom_models, validate_model_id
 from app.llm.provider_credentials import credential_url_for_provider
 from app.llm.schemas import ModelOption, ModelsResponse, ProviderInfo
-from app.models import ProviderCredentialPolicy
 from app.schemas import (
     ActivateProviderRequest,
     SettingsResponse,
@@ -26,6 +27,11 @@ from app.schemas import (
     UpdateSettingsRequest,
 )
 from app.services.provider_connection import test_provider_connection
+from app.services.provider_credential_rotation import (
+    CredentialStrategy,
+    get_credential_policy,
+    update_credential_policy,
+)
 from app.services.provider_credential_vault import (
     CredentialVaultError,
     activate_provider_credential,
@@ -96,8 +102,16 @@ def _credential_list_response(
 
 
 def _credential_strategy(db: Session, provider_id: str) -> str:
-    policy = db.query(ProviderCredentialPolicy).filter_by(provider_id=provider_id).first()
-    return policy.strategy if policy else "manual"
+    return get_credential_policy(db, provider_id).strategy
+
+
+def _policy_response(provider_id: str, db: Session) -> CredentialPolicyResponse:
+    policy = get_credential_policy(db, provider_id)
+    return CredentialPolicyResponse(
+        provider_id=provider_id,
+        strategy=policy.strategy,
+        max_attempts=policy.max_attempts,
+    )
 
 
 @router.get("/settings", response_model=SettingsResponse)
@@ -161,7 +175,11 @@ def get_integrations(db: Session = Depends(get_db)):
                 active_credential_label=(
                     active_credential.label if active_credential else None
                 ),
-                credential_strategy=_credential_strategy(db, provider.id),
+                credential_strategy=(
+                    _credential_strategy(db, provider.id)
+                    if provider_requires_api_key(provider.id)
+                    else CredentialStrategy.MANUAL.value
+                ),
             )
         )
     return CredentialIntegrationsResponse(integrations=integrations)
@@ -258,6 +276,44 @@ def test_configured_integration(
         api_key or None,
         failure_message="Provider connection failed.",
     )
+
+
+@router.get(
+    "/settings/integrations/{provider_id}/credential-policy",
+    response_model=CredentialPolicyResponse,
+)
+def get_credential_policy_route(
+    provider_id: str,
+    db: Session = Depends(get_db),
+):
+    _provider_or_404(provider_id)
+    if not provider_requires_api_key(provider_id):
+        raise ValidationAppError("This provider does not use API credentials.")
+    return _policy_response(provider_id, db)
+
+
+@router.put(
+    "/settings/integrations/{provider_id}/credential-policy",
+    response_model=CredentialPolicyResponse,
+)
+def update_credential_policy_route(
+    provider_id: str,
+    req: UpdateCredentialPolicyRequest,
+    db: Session = Depends(get_db),
+):
+    _provider_or_404(provider_id)
+    if not provider_requires_api_key(provider_id):
+        raise ValidationAppError("This provider does not use API credentials.")
+    try:
+        update_credential_policy(
+            db,
+            provider_id,
+            strategy=req.strategy,
+            max_attempts=req.max_attempts,
+        )
+    except ValueError as exc:
+        raise ValidationAppError(str(exc)) from exc
+    return _policy_response(provider_id, db)
 
 
 @router.get(
@@ -377,7 +433,9 @@ def test_credential(
     )
     credential.last_tested_at = datetime.now(UTC)
     credential.health_status = "healthy" if result.ok else "unhealthy"
-    credential.consecutive_failures = 0 if result.ok else credential.consecutive_failures + 1
+    credential.consecutive_failures = (
+        0 if result.ok else credential.consecutive_failures + 1
+    )
     db.commit()
     return result
 
@@ -433,7 +491,9 @@ def get_models():
                         value=model.id,
                         label=model.label,
                         status=model.status.value,
-                        capabilities=sorted(capability.value for capability in model.capabilities),
+                        capabilities=sorted(
+                            capability.value for capability in model.capabilities
+                        ),
                         traits=sorted(trait.value for trait in model.traits),
                         free_tier=model.free_tier,
                     )

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -2,17 +2,31 @@
 
 import json
 import logging
-import re
 import time
 from collections.abc import AsyncGenerator, Callable
 from typing import Any, TypeVar
 
 import litellm
 from pydantic import BaseModel, ValidationError
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
 
+from app.database import SessionLocal
 from app.exceptions import RateLimitError
 from app.exceptions.llm import APIKeyNotConfiguredError, LLMCallError, LLMOutputError
+from app.llm.catalog import provider_from_model, provider_requires_api_key
+from app.models import ProviderCredential
 from app.public_errors import LLM_PROVIDER_ERROR_MESSAGE
+from app.services.credential_crypto import CredentialCipher
+from app.services.provider_credential_rotation import (
+    CredentialAttemptError,
+    CredentialFailureKind,
+    CredentialRotationPlan,
+    CredentialStrategy,
+    NoEligibleCredentialError,
+    classify_provider_exception,
+    execute_with_credential_rotation,
+)
 from app.services.settings import is_llm_configured
 from app.services.usage_logging import log_usage_background
 
@@ -42,28 +56,6 @@ def _prepare_messages(prompt: str, system: str | None = None) -> list[dict]:
     return messages
 
 
-def _extract_retry_delay(error_str: str) -> float:
-    match = re.search(
-        r"retry[_\s]delay[\":\s]+(\d+(?:\.\d+)?)", error_str, re.IGNORECASE
-    )
-    if match:
-        return float(match.group(1))
-    match = re.search(r"retry in (\d+(?:\.\d+)?)s", error_str, re.IGNORECASE)
-    if match:
-        return float(match.group(1))
-    return 60.0
-
-
-def _handle_rate_limit(error_str: str, original: Exception) -> None:
-    """Raise RateLimitError if the error looks like a 429."""
-    if "RateLimitError" in error_str or "429" in error_str:
-        retry_after = _extract_retry_delay(error_str)
-        raise RateLimitError(
-            f"Rate limit exceeded. Please retry in {retry_after:.0f}s if available.",
-            retry_after=retry_after,
-        ) from original
-
-
 def _compute_cost(response, provider: str) -> float | None:
     """Try to extract or compute cost from a LiteLLM response."""
     cost = getattr(response, "cost", None)
@@ -72,7 +64,8 @@ def _compute_cost(response, provider: str) -> float | None:
         if usage is not None:
             try:
                 cost = litellm.completion_cost(
-                    completion_response=response, model=provider
+                    completion_response=response,
+                    model=provider,
                 )
             except Exception:
                 pass
@@ -112,6 +105,155 @@ def parse_structured_output(
         raise LLMOutputError() from None
 
 
+def _open_rotation_session(
+    provider: str,
+    provided_db: Session | None,
+) -> tuple[Session | None, bool]:
+    provider_id = provider_from_model(provider)
+    if not provider_id or not provider_requires_api_key(provider_id):
+        return None, False
+
+    db = provided_db or SessionLocal()
+    owns_session = provided_db is None
+    try:
+        has_credentials = (
+            db.query(ProviderCredential)
+            .filter_by(provider_id=provider_id)
+            .first()
+            is not None
+        )
+    except OperationalError:
+        if owns_session:
+            db.close()
+        logger.warning(
+            "Credential vault table is unavailable; using the resolved active key."
+        )
+        return None, False
+
+    if not has_credentials:
+        if owns_session:
+            db.close()
+        return None, False
+    return db, owns_session
+
+
+def _completion_request(
+    provider: str,
+    messages: list[dict],
+    timeout: int,
+    api_key: str,
+):
+    request_kwargs: dict[str, Any] = {
+        "model": provider,
+        "messages": messages,
+        "timeout": timeout,
+    }
+    if api_key:
+        request_kwargs["api_key"] = api_key
+    return litellm.completion(**request_kwargs)
+
+
+def _rotation_completion_attempt(
+    provider: str,
+    messages: list[dict],
+    timeout: int,
+    api_key: str,
+):
+    try:
+        return _completion_request(provider, messages, timeout, api_key)
+    except (APIKeyNotConfiguredError, LLMCallError, RateLimitError):
+        raise
+    except Exception as exc:
+        raise classify_provider_exception(exc) from exc
+
+
+def _log_failure(
+    *,
+    operation: str | None,
+    provider: str,
+    started_at: float,
+    profile_id: int | None,
+    message: str,
+) -> None:
+    if not operation:
+        return
+    log_usage_background(
+        operation=operation,
+        model_identifier=provider,
+        latency_ms=int((time.time() - started_at) * 1000),
+        profile_id=profile_id,
+        success=False,
+        error_message=message,
+    )
+
+
+def _raise_public_rotation_error(
+    error: CredentialAttemptError,
+    *,
+    operation: str | None,
+    provider: str,
+    started_at: float,
+    profile_id: int | None,
+) -> None:
+    original = error.original or error
+    logger.warning(
+        "LLM provider attempt failed model=%s error_type=%s",
+        provider,
+        type(original).__name__,
+    )
+
+    if error.kind is CredentialFailureKind.RATE_LIMIT:
+        retry_after = max(float(error.retry_after or 60), 1.0)
+        public_error = RateLimitError(
+            f"Rate limit exceeded. Please retry in {retry_after:.0f}s if available.",
+            retry_after=retry_after,
+        )
+        _log_failure(
+            operation=operation,
+            provider=provider,
+            started_at=started_at,
+            profile_id=profile_id,
+            message=public_error.message,
+        )
+        raise public_error from original
+
+    _log_failure(
+        operation=operation,
+        provider=provider,
+        started_at=started_at,
+        profile_id=profile_id,
+        message=LLM_PROVIDER_ERROR_MESSAGE,
+    )
+    raise LLMCallError(LLM_PROVIDER_ERROR_MESSAGE) from original
+
+
+def _record_completion_usage(
+    response,
+    *,
+    operation: str | None,
+    provider: str,
+    profile_id: int | None,
+) -> None:
+    if not operation:
+        return
+    usage = getattr(response, "usage", None)
+    prompt_tokens = usage.prompt_tokens if usage else None
+    completion_tokens = usage.completion_tokens if usage else None
+    total_tokens = usage.total_tokens if usage else None
+    cost = _compute_cost(response, provider)
+    latency_ms = getattr(response, "_response_ms", None)
+    log_usage_background(
+        operation=operation,
+        model_identifier=provider,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+        cost=cost,
+        latency_ms=latency_ms or 0,
+        profile_id=profile_id,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Synchronous LLM call
 # ---------------------------------------------------------------------------
@@ -125,6 +267,8 @@ def call_llm(
     api_key: str = "",
     operation: str | None = None,
     profile_id: int | None = None,
+    credential_db: Session | None = None,
+    credential_cipher: CredentialCipher | None = None,
 ) -> str:
     if not is_llm_configured(provider, api_key):
         raise APIKeyNotConfiguredError(
@@ -132,80 +276,118 @@ def call_llm(
         )
 
     messages = _prepare_messages(prompt, system)
+    started_at = time.time()
+    rotation_db, owns_rotation_db = _open_rotation_session(provider, credential_db)
+    provider_id = provider_from_model(provider)
 
     try:
-        start_time = time.time()
-        request_kwargs = {
-            "model": provider,
-            "messages": messages,
-            "timeout": timeout,
-        }
-        if api_key:
-            request_kwargs["api_key"] = api_key
-        response = litellm.completion(**request_kwargs)
+        if rotation_db is not None and provider_id:
+            response = execute_with_credential_rotation(
+                rotation_db,
+                provider_id,
+                lambda selected_key, _credential_id: _rotation_completion_attempt(
+                    provider,
+                    messages,
+                    timeout,
+                    selected_key,
+                ),
+                cipher=credential_cipher,
+            )
+        else:
+            response = _completion_request(provider, messages, timeout, api_key)
+
         content = response.choices[0].message.content if response.choices else None
         if not content:
             raise LLMCallError("LLM returned an empty response.")
 
-        usage = getattr(response, "usage", None)
-        prompt_tokens = usage.prompt_tokens if usage else None
-        completion_tokens = usage.completion_tokens if usage else None
-        total_tokens = usage.total_tokens if usage else None
-        cost = _compute_cost(response, provider)
-        latency_ms = getattr(response, "_response_ms", None)
-
-        if operation:
-            log_usage_background(
-                operation=operation,
-                model_identifier=provider,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                total_tokens=total_tokens,
-                cost=cost,
-                latency_ms=latency_ms or 0,
-                profile_id=profile_id,
-            )
-
+        _record_completion_usage(
+            response,
+            operation=operation,
+            provider=provider,
+            profile_id=profile_id,
+        )
         return content
 
     except (APIKeyNotConfiguredError, LLMCallError, RateLimitError):
         raise
-    except Exception as exc:
-        error_str = str(exc)
-        logger.warning(
-            "LLM request failed for model %s",
-            provider,
-            exc_info=(type(exc), exc, exc.__traceback__),
+    except NoEligibleCredentialError as exc:
+        raise APIKeyNotConfiguredError(
+            "No enabled provider credential is currently available."
+        ) from exc
+    except CredentialAttemptError as exc:
+        _raise_public_rotation_error(
+            exc,
+            operation=operation,
+            provider=provider,
+            started_at=started_at,
+            profile_id=profile_id,
         )
-        try:
-            _handle_rate_limit(error_str, exc)
-        except RateLimitError as rate_error:
-            if operation:
-                log_usage_background(
-                    operation=operation,
-                    model_identifier=provider,
-                    latency_ms=int((time.time() - start_time) * 1000),
-                    profile_id=profile_id,
-                    success=False,
-                    error_message=rate_error.message,
-                )
-            raise
-
-        if operation:
-            log_usage_background(
-                operation=operation,
-                model_identifier=provider,
-                latency_ms=int((time.time() - start_time) * 1000),
-                profile_id=profile_id,
-                success=False,
-                error_message=LLM_PROVIDER_ERROR_MESSAGE,
-            )
-        raise LLMCallError(LLM_PROVIDER_ERROR_MESSAGE) from exc
+    except Exception as exc:
+        _raise_public_rotation_error(
+            classify_provider_exception(exc),
+            operation=operation,
+            provider=provider,
+            started_at=started_at,
+            profile_id=profile_id,
+        )
+    finally:
+        if owns_rotation_db and rotation_db is not None:
+            rotation_db.close()
 
 
 # ---------------------------------------------------------------------------
 # Async streaming LLM call
 # ---------------------------------------------------------------------------
+
+
+async def _stream_request(
+    provider: str,
+    messages: list[dict],
+    api_key: str,
+):
+    request_kwargs: dict[str, Any] = {
+        "model": provider,
+        "messages": messages,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "timeout": 60,
+    }
+    if api_key:
+        request_kwargs["api_key"] = api_key
+    return await litellm.acompletion(**request_kwargs)
+
+
+def _record_stream_usage(
+    *,
+    operation: str | None,
+    provider: str,
+    profile_id: int | None,
+    started_at: float,
+    final_usage,
+    final_chunk,
+) -> None:
+    if not operation:
+        return
+    latency_ms = int((time.time() - started_at) * 1000)
+    if final_usage is not None:
+        cost = _compute_cost(final_chunk, provider) if final_chunk is not None else None
+        log_usage_background(
+            operation=operation,
+            model_identifier=provider,
+            prompt_tokens=getattr(final_usage, "prompt_tokens", None),
+            completion_tokens=getattr(final_usage, "completion_tokens", None),
+            total_tokens=getattr(final_usage, "total_tokens", None),
+            cost=cost,
+            latency_ms=latency_ms,
+            profile_id=profile_id,
+        )
+        return
+    log_usage_background(
+        operation=operation,
+        model_identifier=provider,
+        latency_ms=latency_ms,
+        profile_id=profile_id,
+    )
 
 
 async def stream_llm(
@@ -215,6 +397,8 @@ async def stream_llm(
     api_key: str = "",
     operation: str | None = None,
     profile_id: int | None = None,
+    credential_db: Session | None = None,
+    credential_cipher: CredentialCipher | None = None,
 ) -> AsyncGenerator[str, None]:
     if not is_llm_configured(provider, api_key):
         raise APIKeyNotConfiguredError(
@@ -222,86 +406,116 @@ async def stream_llm(
         )
 
     messages = _prepare_messages(prompt, system)
+    started_at = time.time()
+    rotation_db, owns_rotation_db = _open_rotation_session(provider, credential_db)
+    provider_id = provider_from_model(provider)
 
     try:
-        start_time = time.time()
-        request_kwargs = {
-            "model": provider,
-            "messages": messages,
-            "stream": True,
-            "stream_options": {"include_usage": True},
-            "timeout": 60,
-        }
-        if api_key:
-            request_kwargs["api_key"] = api_key
-        response = await litellm.acompletion(**request_kwargs)
+        if rotation_db is None or not provider_id:
+            try:
+                response = await _stream_request(provider, messages, api_key)
+                final_usage = None
+                final_chunk = None
+                async for chunk in response:
+                    final_chunk = chunk
+                    usage = getattr(chunk, "usage", None)
+                    if usage and getattr(usage, "total_tokens", None):
+                        final_usage = usage
+                    delta = chunk.choices[0].delta.content if chunk.choices else None
+                    if delta:
+                        yield delta
+                _record_stream_usage(
+                    operation=operation,
+                    provider=provider,
+                    profile_id=profile_id,
+                    started_at=started_at,
+                    final_usage=final_usage,
+                    final_chunk=final_chunk,
+                )
+                return
+            except (APIKeyNotConfiguredError, LLMCallError, RateLimitError):
+                raise
+            except Exception as exc:
+                _raise_public_rotation_error(
+                    classify_provider_exception(exc),
+                    operation=operation,
+                    provider=provider,
+                    started_at=started_at,
+                    profile_id=profile_id,
+                )
 
-        # Track final usage from the last chunk
-        final_usage = None
-        async for chunk in response:
-            # The last chunk with include_usage=True has usage data but empty choices
-            usage = getattr(chunk, "usage", None)
-            if usage and getattr(usage, "total_tokens", None):
-                final_usage = usage
+        plan = CredentialRotationPlan(
+            rotation_db,
+            provider_id,
+            cipher=credential_cipher,
+        )
+        last_error: CredentialAttemptError | None = None
 
-            delta = chunk.choices[0].delta.content if chunk.choices else None
-            if delta:
-                yield delta
+        for resolved in plan.attempts():
+            emitted_content = False
+            final_usage = None
+            final_chunk = None
+            try:
+                response = await _stream_request(
+                    provider,
+                    messages,
+                    resolved.secret,
+                )
+                async for chunk in response:
+                    final_chunk = chunk
+                    usage = getattr(chunk, "usage", None)
+                    if usage and getattr(usage, "total_tokens", None):
+                        final_usage = usage
+                    delta = chunk.choices[0].delta.content if chunk.choices else None
+                    if delta:
+                        emitted_content = True
+                        yield delta
+            except (APIKeyNotConfiguredError, LLMCallError, RateLimitError):
+                raise
+            except Exception as exc:
+                error = classify_provider_exception(exc)
+                last_error = error
+                plan.record_failure(resolved.credential_id, error)
+                can_retry = (
+                    not emitted_content
+                    and error.kind is not CredentialFailureKind.NON_RETRYABLE
+                    and plan.strategy is not CredentialStrategy.MANUAL
+                )
+                if can_retry:
+                    continue
+                _raise_public_rotation_error(
+                    error,
+                    operation=operation,
+                    provider=provider,
+                    started_at=started_at,
+                    profile_id=profile_id,
+                )
 
-        # Log usage after streaming completes
-        if operation and final_usage:
-            cost = _compute_cost(chunk, provider)
-            latency_ms = int((time.time() - start_time) * 1000)
-            log_usage_background(
+            plan.record_success(resolved.credential_id)
+            _record_stream_usage(
                 operation=operation,
-                model_identifier=provider,
-                prompt_tokens=getattr(final_usage, "prompt_tokens", None),
-                completion_tokens=getattr(final_usage, "completion_tokens", None),
-                total_tokens=getattr(final_usage, "total_tokens", None),
-                cost=cost,
-                latency_ms=latency_ms,
+                provider=provider,
+                profile_id=profile_id,
+                started_at=started_at,
+                final_usage=final_usage,
+                final_chunk=final_chunk,
+            )
+            return
+
+        if last_error is not None:
+            _raise_public_rotation_error(
+                last_error,
+                operation=operation,
+                provider=provider,
+                started_at=started_at,
                 profile_id=profile_id,
             )
-        elif operation:
-            # No usage info returned, but still log the call
-            latency_ms = int((time.time() - start_time) * 1000)
-            log_usage_background(
-                operation=operation,
-                model_identifier=provider,
-                latency_ms=latency_ms,
-                profile_id=profile_id,
-            )
-
     except (APIKeyNotConfiguredError, LLMCallError, RateLimitError):
         raise
-    except Exception as exc:
-        error_str = str(exc)
-        logger.warning(
-            "Streaming LLM request failed for model %s",
-            provider,
-            exc_info=(type(exc), exc, exc.__traceback__),
-        )
-        try:
-            _handle_rate_limit(error_str, exc)
-        except RateLimitError as rate_error:
-            if operation:
-                log_usage_background(
-                    operation=operation,
-                    model_identifier=provider,
-                    latency_ms=int((time.time() - start_time) * 1000),
-                    profile_id=profile_id,
-                    success=False,
-                    error_message=rate_error.message,
-                )
-            raise
-
-        if operation:
-            log_usage_background(
-                operation=operation,
-                model_identifier=provider,
-                latency_ms=int((time.time() - start_time) * 1000),
-                profile_id=profile_id,
-                success=False,
-                error_message=LLM_PROVIDER_ERROR_MESSAGE,
-            )
-        raise LLMCallError(LLM_PROVIDER_ERROR_MESSAGE) from exc
+    except NoEligibleCredentialError as exc:
+        raise APIKeyNotConfiguredError(
+            "No enabled provider credential is currently available."
+        ) from exc
+    finally:
+        if owns_rotation_db and rotation_db is not None:
+            rotation_db.close()

--- a/backend/app/services/provider_credential_rotation.py
+++ b/backend/app/services/provider_credential_rotation.py
@@ -1,0 +1,283 @@
+"""Credential strategy selection and bounded provider-key rotation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import TypeVar
+
+from sqlalchemy.orm import Session
+
+from app.models import ProviderCredential, ProviderCredentialPolicy
+from app.services.credential_crypto import CredentialCipher, get_credential_cipher
+from app.services.provider_credential_vault import decrypt_provider_credential
+
+ResultT = TypeVar("ResultT")
+MAX_ROTATION_ATTEMPTS = 5
+DEFAULT_TEMPORARY_COOLDOWN_SECONDS = 30
+DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS = 60
+
+
+class CredentialStrategy(StrEnum):
+    MANUAL = "manual"
+    FAILOVER = "failover"
+    ROUND_ROBIN = "round_robin"
+
+
+class CredentialFailureKind(StrEnum):
+    AUTHENTICATION = "authentication"
+    RATE_LIMIT = "rate_limit"
+    TEMPORARY = "temporary"
+    NON_RETRYABLE = "non_retryable"
+
+
+class CredentialAttemptError(Exception):
+    """Internal typed failure used by the rotation executor."""
+
+    def __init__(
+        self,
+        kind: CredentialFailureKind,
+        *,
+        retry_after: float | None = None,
+        original: Exception | None = None,
+    ) -> None:
+        self.kind = kind
+        self.retry_after = retry_after
+        self.original = original
+        super().__init__(kind.value)
+
+
+class NoEligibleCredentialError(ValueError):
+    pass
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _db_datetime(value: datetime) -> datetime:
+    """SQLite persists UTC timestamps without timezone metadata."""
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(UTC).replace(tzinfo=None)
+
+
+def get_credential_policy(
+    db: Session,
+    provider_id: str,
+) -> ProviderCredentialPolicy:
+    policy = db.query(ProviderCredentialPolicy).filter_by(provider_id=provider_id).first()
+    if policy:
+        return policy
+
+    policy = ProviderCredentialPolicy(
+        provider_id=provider_id,
+        strategy=CredentialStrategy.MANUAL.value,
+        max_attempts=2,
+        round_robin_cursor=0,
+    )
+    db.add(policy)
+    db.commit()
+    db.refresh(policy)
+    return policy
+
+
+def update_credential_policy(
+    db: Session,
+    provider_id: str,
+    *,
+    strategy: CredentialStrategy | str,
+    max_attempts: int,
+) -> ProviderCredentialPolicy:
+    try:
+        normalized_strategy = CredentialStrategy(strategy)
+    except ValueError as exc:
+        raise ValueError("Unsupported credential strategy.") from exc
+    if not 1 <= max_attempts <= MAX_ROTATION_ATTEMPTS:
+        raise ValueError(
+            f"Maximum attempts must be between 1 and {MAX_ROTATION_ATTEMPTS}."
+        )
+
+    policy = get_credential_policy(db, provider_id)
+    policy.strategy = normalized_strategy.value
+    policy.max_attempts = max_attempts
+    if normalized_strategy is not CredentialStrategy.ROUND_ROBIN:
+        policy.round_robin_cursor = 0
+    policy.updated_at = _db_datetime(_utc_now())
+    db.commit()
+    db.refresh(policy)
+    return policy
+
+
+def _is_eligible(credential: ProviderCredential, now: datetime) -> bool:
+    if not credential.is_enabled:
+        return False
+    if credential.cooldown_until is None:
+        return True
+    cooldown = credential.cooldown_until
+    comparable_now = _db_datetime(now)
+    if cooldown.tzinfo is not None:
+        cooldown = _db_datetime(cooldown)
+    return cooldown <= comparable_now
+
+
+def _eligible_credentials(
+    db: Session,
+    provider_id: str,
+    now: datetime,
+) -> list[ProviderCredential]:
+    credentials = (
+        db.query(ProviderCredential)
+        .filter_by(provider_id=provider_id)
+        .order_by(
+            ProviderCredential.priority.asc(),
+            ProviderCredential.id.asc(),
+        )
+        .all()
+    )
+    return [credential for credential in credentials if _is_eligible(credential, now)]
+
+
+def _ordered_candidates(
+    credentials: list[ProviderCredential],
+    policy: ProviderCredentialPolicy,
+) -> list[ProviderCredential]:
+    strategy = CredentialStrategy(policy.strategy)
+    if strategy is CredentialStrategy.MANUAL:
+        active = next((item for item in credentials if item.is_active), None)
+        return [active] if active else []
+
+    if strategy is CredentialStrategy.FAILOVER:
+        active = next((item for item in credentials if item.is_active), None)
+        if not active:
+            return credentials
+        return [active, *(item for item in credentials if item.id != active.id)]
+
+    if not credentials:
+        return []
+    cursor = policy.round_robin_cursor % len(credentials)
+    return [*credentials[cursor:], *credentials[:cursor]]
+
+
+def _promote_next_active(
+    db: Session,
+    provider_id: str,
+    excluded_id: int,
+) -> None:
+    replacement = (
+        db.query(ProviderCredential)
+        .filter(
+            ProviderCredential.provider_id == provider_id,
+            ProviderCredential.is_enabled.is_(True),
+            ProviderCredential.id != excluded_id,
+        )
+        .order_by(
+            ProviderCredential.priority.asc(),
+            ProviderCredential.id.asc(),
+        )
+        .first()
+    )
+    if replacement:
+        replacement.is_active = True
+
+
+def _record_success(
+    credential: ProviderCredential,
+    now: datetime,
+) -> None:
+    credential.health_status = "healthy"
+    credential.consecutive_failures = 0
+    credential.cooldown_until = None
+    credential.last_used_at = _db_datetime(now)
+    credential.updated_at = _db_datetime(now)
+
+
+def _record_failure(
+    db: Session,
+    credential: ProviderCredential,
+    error: CredentialAttemptError,
+    now: datetime,
+) -> None:
+    credential.consecutive_failures += 1
+    credential.updated_at = _db_datetime(now)
+
+    if error.kind is CredentialFailureKind.AUTHENTICATION:
+        credential.health_status = "invalid"
+        credential.is_enabled = False
+        credential.cooldown_until = None
+        if credential.is_active:
+            credential.is_active = False
+            _promote_next_active(db, credential.provider_id, credential.id)
+        return
+
+    if error.kind is CredentialFailureKind.RATE_LIMIT:
+        retry_after = max(
+            float(error.retry_after or DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS),
+            1.0,
+        )
+        credential.health_status = "rate_limited"
+        credential.cooldown_until = _db_datetime(
+            now + timedelta(seconds=retry_after)
+        )
+        return
+
+    if error.kind is CredentialFailureKind.TEMPORARY:
+        credential.health_status = "degraded"
+        credential.cooldown_until = _db_datetime(
+            now + timedelta(seconds=DEFAULT_TEMPORARY_COOLDOWN_SECONDS)
+        )
+
+
+def execute_with_credential_rotation(
+    db: Session,
+    provider_id: str,
+    attempt: Callable[[str, int], ResultT],
+    *,
+    cipher: CredentialCipher | None = None,
+    now: datetime | None = None,
+) -> ResultT:
+    """Execute one operation using the provider's configured credential policy."""
+    current_time = now or _utc_now()
+    policy = get_credential_policy(db, provider_id)
+    eligible = _eligible_credentials(db, provider_id, current_time)
+    candidates = _ordered_candidates(eligible, policy)
+    if not candidates:
+        raise NoEligibleCredentialError(
+            "No enabled provider credential is currently available."
+        )
+
+    strategy = CredentialStrategy(policy.strategy)
+    allowed_attempts = 1 if strategy is CredentialStrategy.MANUAL else policy.max_attempts
+    selected_cipher = cipher or get_credential_cipher()
+    last_error: CredentialAttemptError | None = None
+
+    for credential in candidates[: min(allowed_attempts, len(candidates))]:
+        secret = decrypt_provider_credential(credential, cipher=selected_cipher)
+        try:
+            result = attempt(secret, credential.id)
+        except CredentialAttemptError as error:
+            last_error = error
+            if error.kind is CredentialFailureKind.NON_RETRYABLE:
+                raise
+            _record_failure(db, credential, error, current_time)
+            db.commit()
+            if strategy is CredentialStrategy.MANUAL:
+                raise
+            continue
+
+        _record_success(credential, current_time)
+        if strategy is CredentialStrategy.ROUND_ROBIN and eligible:
+            successful_index = next(
+                index for index, item in enumerate(eligible) if item.id == credential.id
+            )
+            policy.round_robin_cursor = (successful_index + 1) % len(eligible)
+            policy.updated_at = _db_datetime(current_time)
+        db.commit()
+        return result
+
+    if last_error is not None:
+        raise last_error
+    raise NoEligibleCredentialError(
+        "No provider credential attempt could be performed."
+    )

--- a/backend/app/services/provider_credential_rotation.py
+++ b/backend/app/services/provider_credential_rotation.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import re
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import TypeVar
@@ -52,6 +54,12 @@ class NoEligibleCredentialError(ValueError):
     pass
 
 
+@dataclass(frozen=True)
+class ResolvedCredentialAttempt:
+    credential_id: int
+    secret: str
+
+
 def _utc_now() -> datetime:
     return datetime.now(UTC)
 
@@ -61,6 +69,72 @@ def _db_datetime(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value
     return value.astimezone(UTC).replace(tzinfo=None)
+
+
+def _status_code(error: Exception) -> int | None:
+    status = getattr(error, "status_code", None)
+    if isinstance(status, int):
+        return status
+    response = getattr(error, "response", None)
+    response_status = getattr(response, "status_code", None)
+    return response_status if isinstance(response_status, int) else None
+
+
+def _retry_after(error: Exception) -> float | None:
+    direct = getattr(error, "retry_after", None)
+    if isinstance(direct, int | float):
+        return float(direct)
+
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers:
+        value = headers.get("retry-after") or headers.get("Retry-After")
+        try:
+            return float(value) if value is not None else None
+        except (TypeError, ValueError):
+            pass
+
+    message = str(error)
+    for pattern in (
+        r"retry[_\s]delay[\":\s]+(\d+(?:\.\d+)?)",
+        r"retry in (\d+(?:\.\d+)?)s",
+    ):
+        match = re.search(pattern, message, re.IGNORECASE)
+        if match:
+            return float(match.group(1))
+    return None
+
+
+def classify_provider_exception(error: Exception) -> CredentialAttemptError:
+    """Map provider exceptions to the limited set of safe rotation decisions."""
+    status = _status_code(error)
+    name = type(error).__name__.lower()
+
+    if status in {401, 403} or any(
+        marker in name
+        for marker in ("authentication", "permissiondenied", "unauthorized")
+    ):
+        kind = CredentialFailureKind.AUTHENTICATION
+    elif status == 429 or "ratelimit" in name:
+        kind = CredentialFailureKind.RATE_LIMIT
+    elif (status is not None and 500 <= status <= 599) or any(
+        marker in name
+        for marker in (
+            "serviceunavailable",
+            "apiconnection",
+            "timeout",
+            "internalserver",
+        )
+    ):
+        kind = CredentialFailureKind.TEMPORARY
+    else:
+        kind = CredentialFailureKind.NON_RETRYABLE
+
+    return CredentialAttemptError(
+        kind,
+        retry_after=_retry_after(error),
+        original=error,
+    )
 
 
 def get_credential_policy(
@@ -229,6 +303,77 @@ def _record_failure(
         )
 
 
+class CredentialRotationPlan:
+    """Reusable rotation state for synchronous and streaming operations."""
+
+    def __init__(
+        self,
+        db: Session,
+        provider_id: str,
+        *,
+        cipher: CredentialCipher | None = None,
+        now: datetime | None = None,
+    ) -> None:
+        self.db = db
+        self.provider_id = provider_id
+        self.now = now or _utc_now()
+        self.policy = get_credential_policy(db, provider_id)
+        self.strategy = CredentialStrategy(self.policy.strategy)
+        self.eligible = _eligible_credentials(db, provider_id, self.now)
+        candidates = _ordered_candidates(self.eligible, self.policy)
+        allowed_attempts = (
+            1 if self.strategy is CredentialStrategy.MANUAL else self.policy.max_attempts
+        )
+        self.candidates = candidates[: min(allowed_attempts, len(candidates))]
+        self.cipher = cipher or get_credential_cipher()
+
+        if not self.candidates:
+            raise NoEligibleCredentialError(
+                "No enabled provider credential is currently available."
+            )
+
+    def attempts(self) -> Iterator[ResolvedCredentialAttempt]:
+        for credential in self.candidates:
+            yield ResolvedCredentialAttempt(
+                credential_id=credential.id,
+                secret=decrypt_provider_credential(credential, cipher=self.cipher),
+            )
+
+    def _credential(self, credential_id: int) -> ProviderCredential:
+        credential = next(
+            (item for item in self.candidates if item.id == credential_id),
+            None,
+        )
+        if credential is None:
+            raise NoEligibleCredentialError("Credential is not part of this rotation plan.")
+        return credential
+
+    def record_failure(
+        self,
+        credential_id: int,
+        error: CredentialAttemptError,
+    ) -> None:
+        if error.kind is CredentialFailureKind.NON_RETRYABLE:
+            return
+        _record_failure(self.db, self._credential(credential_id), error, self.now)
+        self.db.commit()
+
+    def record_success(self, credential_id: int) -> None:
+        credential = self._credential(credential_id)
+        _record_success(credential, self.now)
+        if self.strategy is CredentialStrategy.ROUND_ROBIN and self.eligible:
+            successful_index = next(
+                index
+                for index, item in enumerate(self.eligible)
+                if item.id == credential.id
+            )
+            self.policy.round_robin_cursor = (successful_index + 1) % len(
+                self.eligible
+            )
+            self.policy.updated_at = _db_datetime(self.now)
+        self.db.commit()
+
+
 def execute_with_credential_rotation(
     db: Session,
     provider_id: str,
@@ -238,42 +383,27 @@ def execute_with_credential_rotation(
     now: datetime | None = None,
 ) -> ResultT:
     """Execute one operation using the provider's configured credential policy."""
-    current_time = now or _utc_now()
-    policy = get_credential_policy(db, provider_id)
-    eligible = _eligible_credentials(db, provider_id, current_time)
-    candidates = _ordered_candidates(eligible, policy)
-    if not candidates:
-        raise NoEligibleCredentialError(
-            "No enabled provider credential is currently available."
-        )
-
-    strategy = CredentialStrategy(policy.strategy)
-    allowed_attempts = 1 if strategy is CredentialStrategy.MANUAL else policy.max_attempts
-    selected_cipher = cipher or get_credential_cipher()
+    plan = CredentialRotationPlan(
+        db,
+        provider_id,
+        cipher=cipher,
+        now=now,
+    )
     last_error: CredentialAttemptError | None = None
 
-    for credential in candidates[: min(allowed_attempts, len(candidates))]:
-        secret = decrypt_provider_credential(credential, cipher=selected_cipher)
+    for resolved in plan.attempts():
         try:
-            result = attempt(secret, credential.id)
+            result = attempt(resolved.secret, resolved.credential_id)
         except CredentialAttemptError as error:
             last_error = error
             if error.kind is CredentialFailureKind.NON_RETRYABLE:
                 raise
-            _record_failure(db, credential, error, current_time)
-            db.commit()
-            if strategy is CredentialStrategy.MANUAL:
+            plan.record_failure(resolved.credential_id, error)
+            if plan.strategy is CredentialStrategy.MANUAL:
                 raise
             continue
 
-        _record_success(credential, current_time)
-        if strategy is CredentialStrategy.ROUND_ROBIN and eligible:
-            successful_index = next(
-                index for index, item in enumerate(eligible) if item.id == credential.id
-            )
-            policy.round_robin_cursor = (successful_index + 1) % len(eligible)
-            policy.updated_at = _db_datetime(current_time)
-        db.commit()
+        plan.record_success(resolved.credential_id)
         return result
 
     if last_error is not None:

--- a/backend/tests/test_llm_credential_rotation.py
+++ b/backend/tests/test_llm_credential_rotation.py
@@ -242,5 +242,5 @@ def test_all_rate_limited_credentials_surface_safe_rate_limit_error(monkeypatch)
     finally:
         db.close()
 
-    assert exc_info.value.retry_after == 12
+    assert exc_info.value.details["retry_after"] == 12
     assert "sk-primary" not in exc_info.value.message

--- a/backend/tests/test_llm_credential_rotation.py
+++ b/backend/tests/test_llm_credential_rotation.py
@@ -1,0 +1,246 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.exceptions import RateLimitError
+from app.models import Base
+from app.services import llm as llm_service
+from app.services.credential_crypto import CredentialCipher
+from app.services.provider_credential_rotation import (
+    CredentialStrategy,
+    update_credential_policy,
+)
+from app.services.provider_credential_vault import create_provider_credential
+
+
+class FakeRateLimitError(Exception):
+    status_code = 429
+    retry_after = 12
+
+
+class FakeAuthenticationError(Exception):
+    status_code = 401
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _cipher() -> CredentialCipher:
+    return CredentialCipher(Fernet.generate_key().decode())
+
+
+def _response(text: str):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))],
+        usage=None,
+        cost=None,
+        _response_ms=1,
+    )
+
+
+def _chunk(text: str):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=SimpleNamespace(content=text))],
+        usage=None,
+    )
+
+
+def _configure(db, cipher, strategy=CredentialStrategy.FAILOVER):
+    create_provider_credential(
+        db,
+        provider_id="openai",
+        label="Primary",
+        secret="sk-primary",
+        cipher=cipher,
+        activate=True,
+    )
+    create_provider_credential(
+        db,
+        provider_id="openai",
+        label="Backup",
+        secret="sk-backup",
+        cipher=cipher,
+        activate=False,
+    )
+    update_credential_policy(
+        db,
+        "openai",
+        strategy=strategy,
+        max_attempts=2,
+    )
+
+
+def test_call_llm_fails_over_to_backup_credential(monkeypatch):
+    db = _make_session()
+    cipher = _cipher()
+    _configure(db, cipher)
+    attempted: list[str] = []
+
+    def completion(**kwargs):
+        attempted.append(kwargs["api_key"])
+        if kwargs["api_key"] == "sk-primary":
+            raise FakeRateLimitError("retry in 12s")
+        return _response("backup worked")
+
+    monkeypatch.setattr(llm_service.litellm, "completion", completion)
+    try:
+        result = llm_service.call_llm(
+            "hello",
+            provider="openai/gpt-5-mini",
+            api_key="sk-primary",
+            credential_db=db,
+            credential_cipher=cipher,
+        )
+    finally:
+        db.close()
+
+    assert result == "backup worked"
+    assert attempted == ["sk-primary", "sk-backup"]
+
+
+def test_round_robin_is_applied_by_normal_llm_calls(monkeypatch):
+    db = _make_session()
+    cipher = _cipher()
+    _configure(db, cipher, strategy=CredentialStrategy.ROUND_ROBIN)
+    selected: list[str] = []
+
+    def completion(**kwargs):
+        selected.append(kwargs["api_key"])
+        return _response("ok")
+
+    monkeypatch.setattr(llm_service.litellm, "completion", completion)
+    try:
+        for _ in range(3):
+            llm_service.call_llm(
+                "hello",
+                provider="openai/gpt-5-mini",
+                api_key="sk-primary",
+                credential_db=db,
+                credential_cipher=cipher,
+            )
+    finally:
+        db.close()
+
+    assert selected == ["sk-primary", "sk-backup", "sk-primary"]
+
+
+def test_streaming_can_fail_over_before_any_content_is_emitted(monkeypatch):
+    db = _make_session()
+    cipher = _cipher()
+    _configure(db, cipher)
+    attempted: list[str] = []
+
+    class SuccessfulStream:
+        def __aiter__(self):
+            self.sent = False
+            return self
+
+        async def __anext__(self):
+            if self.sent:
+                raise StopAsyncIteration
+            self.sent = True
+            return _chunk("hello")
+
+    async def acompletion(**kwargs):
+        attempted.append(kwargs["api_key"])
+        if kwargs["api_key"] == "sk-primary":
+            raise FakeRateLimitError("retry in 12s")
+        return SuccessfulStream()
+
+    monkeypatch.setattr(llm_service.litellm, "acompletion", acompletion)
+
+    async def collect():
+        return [
+            chunk
+            async for chunk in llm_service.stream_llm(
+                "hello",
+                provider="openai/gpt-5-mini",
+                api_key="sk-primary",
+                credential_db=db,
+                credential_cipher=cipher,
+            )
+        ]
+
+    try:
+        chunks = asyncio.run(collect())
+    finally:
+        db.close()
+
+    assert chunks == ["hello"]
+    assert attempted == ["sk-primary", "sk-backup"]
+
+
+def test_streaming_never_retries_after_content_was_emitted(monkeypatch):
+    db = _make_session()
+    cipher = _cipher()
+    _configure(db, cipher)
+    attempted: list[str] = []
+
+    class PartialStream:
+        def __aiter__(self):
+            self.index = 0
+            return self
+
+        async def __anext__(self):
+            self.index += 1
+            if self.index == 1:
+                return _chunk("partial")
+            raise FakeRateLimitError("retry in 12s")
+
+    async def acompletion(**kwargs):
+        attempted.append(kwargs["api_key"])
+        return PartialStream()
+
+    monkeypatch.setattr(llm_service.litellm, "acompletion", acompletion)
+
+    async def collect():
+        chunks = []
+        async for chunk in llm_service.stream_llm(
+            "hello",
+            provider="openai/gpt-5-mini",
+            api_key="sk-primary",
+            credential_db=db,
+            credential_cipher=cipher,
+        ):
+            chunks.append(chunk)
+        return chunks
+
+    try:
+        with pytest.raises(RateLimitError):
+            asyncio.run(collect())
+    finally:
+        db.close()
+
+    assert attempted == ["sk-primary"]
+
+
+def test_all_rate_limited_credentials_surface_safe_rate_limit_error(monkeypatch):
+    db = _make_session()
+    cipher = _cipher()
+    _configure(db, cipher)
+
+    def completion(**_kwargs):
+        raise FakeRateLimitError("secret=sk-primary retry in 12s")
+
+    monkeypatch.setattr(llm_service.litellm, "completion", completion)
+    try:
+        with pytest.raises(RateLimitError) as exc_info:
+            llm_service.call_llm(
+                "hello",
+                provider="openai/gpt-5-mini",
+                api_key="sk-primary",
+                credential_db=db,
+                credential_cipher=cipher,
+            )
+    finally:
+        db.close()
+
+    assert exc_info.value.retry_after == 12
+    assert "sk-primary" not in exc_info.value.message

--- a/backend/tests/test_provider_credential_policy_routes.py
+++ b/backend/tests/test_provider_credential_policy_routes.py
@@ -1,0 +1,43 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.credential_schemas import UpdateCredentialPolicyRequest
+from app.models import Base
+from app.routes.settings import get_credential_policy_route, update_credential_policy_route
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_policy_defaults_to_manual_with_two_max_attempts():
+    db = _make_session()
+    try:
+        policy = get_credential_policy_route("openai", db)
+        assert policy.strategy == "manual"
+        assert policy.max_attempts == 2
+    finally:
+        db.close()
+
+
+def test_policy_can_enable_failover_and_round_robin():
+    db = _make_session()
+    try:
+        failover = update_credential_policy_route(
+            "openai",
+            UpdateCredentialPolicyRequest(strategy="failover", max_attempts=2),
+            db,
+        )
+        assert failover.strategy == "failover"
+
+        round_robin = update_credential_policy_route(
+            "openai",
+            UpdateCredentialPolicyRequest(strategy="round_robin", max_attempts=3),
+            db,
+        )
+        assert round_robin.strategy == "round_robin"
+        assert round_robin.max_attempts == 3
+    finally:
+        db.close()

--- a/backend/tests/test_provider_credential_rotation.py
+++ b/backend/tests/test_provider_credential_rotation.py
@@ -1,0 +1,296 @@
+from datetime import UTC, datetime, timedelta
+
+from cryptography.fernet import Fernet
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.services.credential_crypto import CredentialCipher
+from app.services.provider_credential_vault import create_provider_credential
+from app.services.provider_credential_rotation import (
+    CredentialAttemptError,
+    CredentialFailureKind,
+    CredentialStrategy,
+    NoEligibleCredentialError,
+    execute_with_credential_rotation,
+    get_credential_policy,
+    update_credential_policy,
+)
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _cipher() -> CredentialCipher:
+    return CredentialCipher(Fernet.generate_key().decode())
+
+
+def _add_credentials(db, cipher):
+    first = create_provider_credential(
+        db,
+        provider_id="openai",
+        label="Primary",
+        secret="sk-primary",
+        cipher=cipher,
+        activate=True,
+    )
+    second = create_provider_credential(
+        db,
+        provider_id="openai",
+        label="Backup",
+        secret="sk-backup",
+        cipher=cipher,
+        activate=False,
+    )
+    third = create_provider_credential(
+        db,
+        provider_id="openai",
+        label="Third",
+        secret="sk-third",
+        cipher=cipher,
+        activate=False,
+    )
+    return first, second, third
+
+
+def test_manual_strategy_uses_only_the_active_credential():
+    db = _make_session()
+    cipher = _cipher()
+    try:
+        _add_credentials(db, cipher)
+        update_credential_policy(
+            db,
+            "openai",
+            strategy=CredentialStrategy.MANUAL,
+            max_attempts=3,
+        )
+        attempted: list[str] = []
+
+        def attempt(secret: str, _credential_id: int) -> str:
+            attempted.append(secret)
+            raise CredentialAttemptError(CredentialFailureKind.RATE_LIMIT, retry_after=30)
+
+        try:
+            execute_with_credential_rotation(
+                db,
+                "openai",
+                attempt,
+                cipher=cipher,
+            )
+        except CredentialAttemptError:
+            pass
+        else:
+            raise AssertionError("manual strategy should surface the active-key failure")
+
+        assert attempted == ["sk-primary"]
+    finally:
+        db.close()
+
+
+def test_failover_disables_invalid_key_and_promotes_the_next_credential():
+    db = _make_session()
+    cipher = _cipher()
+    try:
+        primary, backup, _ = _add_credentials(db, cipher)
+        update_credential_policy(
+            db,
+            "openai",
+            strategy=CredentialStrategy.FAILOVER,
+            max_attempts=2,
+        )
+        attempted: list[str] = []
+
+        def attempt(secret: str, _credential_id: int) -> str:
+            attempted.append(secret)
+            if secret == "sk-primary":
+                raise CredentialAttemptError(CredentialFailureKind.AUTHENTICATION)
+            return "ok"
+
+        result = execute_with_credential_rotation(
+            db,
+            "openai",
+            attempt,
+            cipher=cipher,
+        )
+
+        db.refresh(primary)
+        db.refresh(backup)
+        assert result == "ok"
+        assert attempted == ["sk-primary", "sk-backup"]
+        assert primary.is_enabled is False
+        assert primary.is_active is False
+        assert backup.is_active is True
+        assert backup.health_status == "healthy"
+    finally:
+        db.close()
+
+
+def test_failover_places_rate_limited_key_in_cooldown_without_disabling_it():
+    db = _make_session()
+    cipher = _cipher()
+    now = datetime(2026, 8, 2, 1, 0, tzinfo=UTC)
+    try:
+        primary, backup, _ = _add_credentials(db, cipher)
+        update_credential_policy(
+            db,
+            "openai",
+            strategy=CredentialStrategy.FAILOVER,
+            max_attempts=2,
+        )
+
+        def attempt(secret: str, _credential_id: int) -> str:
+            if secret == "sk-primary":
+                raise CredentialAttemptError(
+                    CredentialFailureKind.RATE_LIMIT,
+                    retry_after=45,
+                )
+            return "ok"
+
+        assert execute_with_credential_rotation(
+            db,
+            "openai",
+            attempt,
+            cipher=cipher,
+            now=now,
+        ) == "ok"
+
+        db.refresh(primary)
+        db.refresh(backup)
+        assert primary.is_enabled is True
+        assert primary.is_active is True
+        assert primary.health_status == "rate_limited"
+        assert primary.cooldown_until == now + timedelta(seconds=45)
+        assert backup.last_used_at == now
+    finally:
+        db.close()
+
+
+def test_non_retryable_failure_never_rotates_to_another_key():
+    db = _make_session()
+    cipher = _cipher()
+    try:
+        _add_credentials(db, cipher)
+        update_credential_policy(
+            db,
+            "openai",
+            strategy=CredentialStrategy.FAILOVER,
+            max_attempts=3,
+        )
+        attempted: list[str] = []
+
+        def attempt(secret: str, _credential_id: int) -> str:
+            attempted.append(secret)
+            raise CredentialAttemptError(CredentialFailureKind.NON_RETRYABLE)
+
+        try:
+            execute_with_credential_rotation(
+                db,
+                "openai",
+                attempt,
+                cipher=cipher,
+            )
+        except CredentialAttemptError as exc:
+            assert exc.kind is CredentialFailureKind.NON_RETRYABLE
+        else:
+            raise AssertionError("non-retryable failure should be surfaced")
+
+        assert attempted == ["sk-primary"]
+    finally:
+        db.close()
+
+
+def test_round_robin_cycles_through_eligible_credentials_across_requests():
+    db = _make_session()
+    cipher = _cipher()
+    try:
+        _add_credentials(db, cipher)
+        update_credential_policy(
+            db,
+            "openai",
+            strategy=CredentialStrategy.ROUND_ROBIN,
+            max_attempts=2,
+        )
+        selected: list[str] = []
+
+        def attempt(secret: str, _credential_id: int) -> str:
+            selected.append(secret)
+            return secret
+
+        for _ in range(4):
+            execute_with_credential_rotation(
+                db,
+                "openai",
+                attempt,
+                cipher=cipher,
+            )
+
+        assert selected == [
+            "sk-primary",
+            "sk-backup",
+            "sk-third",
+            "sk-primary",
+        ]
+        assert get_credential_policy(db, "openai").round_robin_cursor == 1
+    finally:
+        db.close()
+
+
+def test_cooldown_and_disabled_credentials_are_skipped():
+    db = _make_session()
+    cipher = _cipher()
+    now = datetime(2026, 8, 2, 1, 0, tzinfo=UTC)
+    try:
+        primary, backup, third = _add_credentials(db, cipher)
+        primary.cooldown_until = now + timedelta(minutes=5)
+        backup.is_enabled = False
+        db.commit()
+        update_credential_policy(
+            db,
+            "openai",
+            strategy=CredentialStrategy.FAILOVER,
+            max_attempts=3,
+        )
+
+        selected: list[int] = []
+
+        result = execute_with_credential_rotation(
+            db,
+            "openai",
+            lambda _secret, credential_id: selected.append(credential_id) or "ok",
+            cipher=cipher,
+            now=now,
+        )
+
+        assert result == "ok"
+        assert selected == [third.id]
+    finally:
+        db.close()
+
+
+def test_no_eligible_credentials_has_a_typed_failure():
+    db = _make_session()
+    cipher = _cipher()
+    now = datetime(2026, 8, 2, 1, 0, tzinfo=UTC)
+    try:
+        primary, backup, third = _add_credentials(db, cipher)
+        for credential in (primary, backup, third):
+            credential.is_enabled = False
+        db.commit()
+
+        try:
+            execute_with_credential_rotation(
+                db,
+                "openai",
+                lambda _secret, _credential_id: "unexpected",
+                cipher=cipher,
+                now=now,
+            )
+        except NoEligibleCredentialError:
+            pass
+        else:
+            raise AssertionError("missing eligible credentials should fail clearly")
+    finally:
+        db.close()

--- a/backend/tests/test_provider_credential_rotation.py
+++ b/backend/tests/test_provider_credential_rotation.py
@@ -132,6 +132,7 @@ def test_failover_places_rate_limited_key_in_cooldown_without_disabling_it():
     db = _make_session()
     cipher = _cipher()
     now = datetime(2026, 8, 2, 1, 0, tzinfo=UTC)
+    persisted_now = now.replace(tzinfo=None)
     try:
         primary, backup, _ = _add_credentials(db, cipher)
         update_credential_policy(
@@ -162,8 +163,8 @@ def test_failover_places_rate_limited_key_in_cooldown_without_disabling_it():
         assert primary.is_enabled is True
         assert primary.is_active is True
         assert primary.health_status == "rate_limited"
-        assert primary.cooldown_until == now + timedelta(seconds=45)
-        assert backup.last_used_at == now
+        assert primary.cooldown_until == persisted_now + timedelta(seconds=45)
+        assert backup.last_used_at == persisted_now
     finally:
         db.close()
 
@@ -244,7 +245,7 @@ def test_cooldown_and_disabled_credentials_are_skipped():
     now = datetime(2026, 8, 2, 1, 0, tzinfo=UTC)
     try:
         primary, backup, third = _add_credentials(db, cipher)
-        primary.cooldown_until = now + timedelta(minutes=5)
+        primary.cooldown_until = (now + timedelta(minutes=5)).replace(tzinfo=None)
         backup.is_enabled = False
         db.commit()
         update_credential_policy(


### PR DESCRIPTION
## Summary
- add Manual, Automatic Failover, and Round Robin credential strategies
- persist per-provider strategy, bounded max attempts, and round-robin cursor
- expose GET/PUT credential-policy endpoints
- apply the selected strategy to normal and streaming LiteLLM requests
- keep the existing LLM call signatures backward-compatible
- skip disabled credentials and credentials still in cooldown
- disable credentials that return authentication failures and promote the next enabled key
- apply retry cooldowns to rate-limited credentials without disabling them
- temporarily cool down credentials after safe transient provider failures
- never rotate for validation, content, or other non-retryable failures
- retry streaming requests only before any content has been emitted
- preserve sanitized public errors and avoid logging secrets or raw provider messages

## Strategy behavior
- `manual`: only the active credential is attempted
- `failover`: active credential first, then healthy credentials by priority
- `round_robin`: begin at the persisted cursor and advance after a successful request
- automatic modes default to at most two attempts and are capped at five

## Verification
- Backend CI Python 3.12: success
- Backend CI Python 3.13: success
- lint: success
- 118 backend tests: success

No tag or release is included.