### PR TITLE
feat: add provider credential management UI

### DIFF
--- a/backend/app/services/provider_credential_vault.py
+++ b/backend/app/services/provider_credential_vault.py
@@ -272,6 +272,12 @@ def activate_provider_credential(
     return credential
 
 
+def _clear_active_model_for_provider(db: Session, provider_id: str) -> None:
+    active_model = db.query(AppSetting).filter_by(key="llm_provider").first()
+    if active_model and provider_from_model(active_model.value) == provider_id:
+        active_model.value = ""
+
+
 def delete_provider_credential(
     db: Session,
     provider_id: str,
@@ -297,6 +303,8 @@ def delete_provider_credential(
         if replacement:
             replacement.is_active = True
             replacement.updated_at = datetime.now(UTC)
+        else:
+            _clear_active_model_for_provider(db, provider_id)
     db.commit()
 
 

--- a/backend/tests/test_provider_credential_routes.py
+++ b/backend/tests/test_provider_credential_routes.py
@@ -10,6 +10,7 @@ from app.routes.settings import (
     get_integrations,
     get_provider_credentials,
 )
+from app.services.settings import get_setting, set_setting
 
 
 def _make_session():
@@ -72,6 +73,28 @@ def test_manual_activation_and_deletion_keep_one_active_credential():
         assert len(remaining) == 1
         assert remaining[0].id == first.id
         assert remaining[0].is_active is True
+    finally:
+        db.close()
+
+
+def test_deleting_final_credential_clears_active_model_for_provider():
+    db = _make_session()
+    try:
+        set_setting(db, "llm_provider", "openai/gpt-5-mini")
+        credential = add_provider_credential(
+            "openai",
+            CreateProviderCredentialRequest(
+                label="Only key",
+                secret="sk-route-only",
+                activate=True,
+            ),
+            db,
+        )
+
+        delete_credential("openai", credential.id, db)
+
+        assert get_provider_credentials("openai", db).credentials == []
+        assert get_setting(db, "llm_provider") == ""
     finally:
         db.close()
 

--- a/frontend/src/lib/components/ProviderCredentialsPanel.svelte
+++ b/frontend/src/lib/components/ProviderCredentialsPanel.svelte
@@ -1,0 +1,566 @@
+<script lang="ts">
+  import {
+    activateProviderCredential,
+    addProviderCredential,
+    deleteProviderCredential,
+    getCredentialPolicy,
+    getProviderCredentials,
+    testProviderCredential,
+    updateCredentialPolicy,
+    updateProviderCredential,
+  } from '$lib/integration-api';
+  import {
+    canUseAutomaticStrategy,
+    credentialHealthLabel,
+    credentialHealthTone,
+    credentialStrategyDescription,
+    credentialStrategyLabel,
+  } from '$lib/provider-credentials';
+  import type {
+    CredentialPolicyResponse,
+    CredentialStrategy,
+    ProviderCredentialInfo,
+  } from '$lib/provider-credential-types';
+  import type { TestConnectionResponse } from '$lib/types';
+  import { errorMessage } from '$lib/utils';
+  import {
+    Activity,
+    Check,
+    ChevronDown,
+    CircleAlert,
+    CircleCheck,
+    ExternalLink,
+    Eye,
+    EyeOff,
+    KeyRound,
+    Loader2,
+    Pencil,
+    Plus,
+    RefreshCw,
+    ShieldCheck,
+    Trash2,
+    X,
+  } from '@lucide/svelte';
+
+  let {
+    providerId,
+    providerLabel,
+    credentialUrl = null,
+    authType = 'api_key',
+    onChanged,
+  }: {
+    providerId: string;
+    providerLabel: string;
+    credentialUrl?: string | null;
+    authType?: string;
+    onChanged?: () => void | Promise<void>;
+  } = $props();
+
+  type EditMode = 'rename' | 'replace' | 'remove' | null;
+
+  let credentials: ProviderCredentialInfo[] = $state([]);
+  let policy: CredentialPolicyResponse = $state({
+    provider_id: '',
+    strategy: 'manual',
+    max_attempts: 2,
+  });
+  let maxCredentials = $state(20);
+  let loading = $state(true);
+  let panelError = $state('');
+  let operation = $state('');
+  let addOpen = $state(false);
+  let newLabel = $state('');
+  let newSecret = $state('');
+  let newSecretVisible = $state(false);
+  let activateNew = $state(false);
+  let editingId: number | null = $state(null);
+  let editMode: EditMode = $state(null);
+  let editValue = $state('');
+  let editSecretVisible = $state(false);
+  let testResults: Record<number, TestConnectionResponse> = $state({});
+
+  const automaticAvailable = $derived(canUseAutomaticStrategy(credentials));
+  const enabledCount = $derived(
+    credentials.filter((credential) => credential.is_enabled).length,
+  );
+
+  $effect(() => {
+    if (!providerId) return;
+    loadData();
+  });
+
+  async function loadData() {
+    loading = true;
+    panelError = '';
+    closeEditor();
+    try {
+      const [credentialsResponse, policyResponse] = await Promise.all([
+        getProviderCredentials(providerId),
+        getCredentialPolicy(providerId),
+      ]);
+      credentials = credentialsResponse.credentials;
+      maxCredentials = credentialsResponse.max_credentials;
+      policy = policyResponse;
+    } catch (error) {
+      panelError = errorMessage(error, 'Failed to load provider credentials.');
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function notifyChanged() {
+    await onChanged?.();
+  }
+
+  function closeEditor() {
+    editingId = null;
+    editMode = null;
+    editValue = '';
+    editSecretVisible = false;
+  }
+
+  function beginEdit(credential: ProviderCredentialInfo, mode: Exclude<EditMode, null>) {
+    editingId = credential.id;
+    editMode = mode;
+    editValue = mode === 'rename' ? credential.label : '';
+    editSecretVisible = false;
+    panelError = '';
+  }
+
+  async function handleAdd() {
+    const label = newLabel.trim();
+    const secret = newSecret.trim();
+    if (!label || !secret) {
+      panelError = 'Enter a label and credential.';
+      return;
+    }
+
+    operation = 'add';
+    panelError = '';
+    try {
+      await addProviderCredential(providerId, {
+        label,
+        secret,
+        activate: credentials.length === 0 || activateNew,
+      });
+      newLabel = '';
+      activateNew = false;
+      addOpen = false;
+      await loadData();
+      await notifyChanged();
+    } catch (error) {
+      panelError = errorMessage(error, 'Failed to add credential.');
+    } finally {
+      newSecret = '';
+      newSecretVisible = false;
+      operation = '';
+    }
+  }
+
+  async function handleEdit(credential: ProviderCredentialInfo) {
+    if (!editMode || editMode === 'remove') return;
+    const value = editValue.trim();
+    if (!value) {
+      panelError = editMode === 'rename' ? 'Enter a credential label.' : 'Enter a replacement credential.';
+      return;
+    }
+
+    operation = `${editMode}:${credential.id}`;
+    panelError = '';
+    try {
+      await updateProviderCredential(
+        providerId,
+        credential.id,
+        editMode === 'rename' ? { label: value } : { secret: value },
+      );
+      closeEditor();
+      await loadData();
+      await notifyChanged();
+    } catch (error) {
+      panelError = errorMessage(error, 'Failed to update credential.');
+    } finally {
+      if (editMode === 'replace') editValue = '';
+      editSecretVisible = false;
+      operation = '';
+    }
+  }
+
+  async function handleActivate(credential: ProviderCredentialInfo) {
+    operation = `activate:${credential.id}`;
+    panelError = '';
+    try {
+      await activateProviderCredential(providerId, credential.id);
+      await loadData();
+      await notifyChanged();
+    } catch (error) {
+      panelError = errorMessage(error, 'Failed to activate credential.');
+    } finally {
+      operation = '';
+    }
+  }
+
+  async function handleTest(credential: ProviderCredentialInfo) {
+    operation = `test:${credential.id}`;
+    panelError = '';
+    const nextResults = { ...testResults };
+    delete nextResults[credential.id];
+    testResults = nextResults;
+    try {
+      const result = await testProviderCredential(providerId, credential.id);
+      testResults = { ...testResults, [credential.id]: result };
+      await loadData();
+      await notifyChanged();
+    } catch (error) {
+      testResults = {
+        ...testResults,
+        [credential.id]: {
+          ok: false,
+          message: errorMessage(error, 'Credential test failed.'),
+        },
+      };
+    } finally {
+      operation = '';
+    }
+  }
+
+  async function handleRemove(credential: ProviderCredentialInfo) {
+    operation = `remove:${credential.id}`;
+    panelError = '';
+    try {
+      const response = await deleteProviderCredential(providerId, credential.id);
+      credentials = response.credentials;
+      maxCredentials = response.max_credentials;
+      closeEditor();
+      const nextResults = { ...testResults };
+      delete nextResults[credential.id];
+      testResults = nextResults;
+
+      if (!canUseAutomaticStrategy(credentials) && policy.strategy !== 'manual') {
+        policy = await updateCredentialPolicy(providerId, 'manual', 2);
+      }
+      await notifyChanged();
+    } catch (error) {
+      panelError = errorMessage(error, 'Failed to remove credential.');
+    } finally {
+      operation = '';
+    }
+  }
+
+  async function handleStrategy(strategy: CredentialStrategy) {
+    if (strategy !== 'manual' && !automaticAvailable) return;
+    operation = 'policy';
+    panelError = '';
+    try {
+      policy = await updateCredentialPolicy(
+        providerId,
+        strategy,
+        strategy === 'manual' ? 2 : policy.max_attempts,
+      );
+      await notifyChanged();
+    } catch (error) {
+      panelError = errorMessage(error, 'Failed to update credential strategy.');
+    } finally {
+      operation = '';
+    }
+  }
+
+  async function handleMaxAttempts(value: number) {
+    if (policy.strategy === 'manual') return;
+    operation = 'policy';
+    panelError = '';
+    try {
+      policy = await updateCredentialPolicy(providerId, policy.strategy, value);
+      await notifyChanged();
+    } catch (error) {
+      panelError = errorMessage(error, 'Failed to update retry limit.');
+    } finally {
+      operation = '';
+    }
+  }
+
+  function toneClass(credential: ProviderCredentialInfo): string {
+    const tone = credentialHealthTone(credential);
+    if (tone === 'success') return 'bg-green-100 text-green-700 dark:bg-green-950/60 dark:text-green-300';
+    if (tone === 'warning') return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-950/60 dark:text-yellow-300';
+    if (tone === 'danger') return 'bg-red-100 text-red-700 dark:bg-red-950/60 dark:text-red-300';
+    return 'bg-muted text-muted-foreground';
+  }
+</script>
+
+<section class="rounded-xl border border-border bg-card p-4 sm:p-5">
+  <div class="flex flex-wrap items-start justify-between gap-3">
+    <div class="flex min-w-0 items-start gap-3">
+      <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+        <KeyRound class="h-4 w-4" />
+      </div>
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Credentials</p>
+        <h3 class="mt-0.5 text-sm font-semibold">Manage access to {providerLabel}</h3>
+        <p class="mt-1 text-xs text-muted-foreground">
+          {credentials.length} of {maxCredentials} saved · {enabledCount} enabled
+        </p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-2">
+      {#if credentialUrl}
+        <a
+          href={credentialUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+        >
+          Get {authType === 'token' ? 'access token' : 'API key'}
+          <ExternalLink class="h-3 w-3" />
+        </a>
+      {/if}
+      <button
+        type="button"
+        onclick={() => (addOpen = !addOpen)}
+        disabled={credentials.length >= maxCredentials || operation !== ''}
+        class="inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-2 text-xs font-semibold hover:bg-accent disabled:opacity-50"
+      >
+        {#if addOpen}<X class="h-3.5 w-3.5" />Cancel{:else}<Plus class="h-3.5 w-3.5" />Add credential{/if}
+      </button>
+    </div>
+  </div>
+
+  {#if loading}
+    <div class="mt-4 flex min-h-24 items-center justify-center gap-2 rounded-lg bg-muted/30 text-sm text-muted-foreground">
+      <Loader2 class="h-4 w-4 animate-spin" />
+      Loading credentials…
+    </div>
+  {:else}
+    {#if addOpen}
+      <div class="mt-4 rounded-lg border border-primary/20 bg-primary/5 p-3">
+        <div class="grid gap-3 sm:grid-cols-[minmax(0,0.7fr)_minmax(0,1.3fr)]">
+          <label class="space-y-1 text-xs font-medium">
+            Label
+            <input
+              bind:value={newLabel}
+              maxlength="80"
+              placeholder="Personal, Work, Backup…"
+              autocomplete="off"
+              class="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            />
+          </label>
+          <label class="space-y-1 text-xs font-medium">
+            {authType === 'token' ? 'Access token' : 'API key'}
+            <div class="relative">
+              <input
+                type={newSecretVisible ? 'text' : 'password'}
+                bind:value={newSecret}
+                autocomplete="new-password"
+                placeholder="Paste credential…"
+                class="w-full rounded-md border border-border bg-background px-3 py-2 pr-10 text-sm"
+              />
+              <button
+                type="button"
+                onclick={() => (newSecretVisible = !newSecretVisible)}
+                class="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                aria-label={newSecretVisible ? 'Hide credential' : 'Show credential'}
+              >
+                {#if newSecretVisible}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
+              </button>
+            </div>
+          </label>
+        </div>
+        {#if credentials.length > 0}
+          <label class="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+            <input type="checkbox" bind:checked={activateNew} class="h-4 w-4 rounded border-border" />
+            Make this the active credential
+          </label>
+        {/if}
+        <div class="mt-3 flex justify-end">
+          <button
+            type="button"
+            onclick={handleAdd}
+            disabled={operation !== '' || !newLabel.trim() || !newSecret.trim()}
+            class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-xs font-semibold text-primary-foreground disabled:opacity-50"
+          >
+            {#if operation === 'add'}<Loader2 class="h-3.5 w-3.5 animate-spin" />{:else}<Plus class="h-3.5 w-3.5" />{/if}
+            Save credential
+          </button>
+        </div>
+      </div>
+    {/if}
+
+    {#if credentials.length > 0}
+      <div class="mt-4 divide-y divide-border overflow-hidden rounded-lg border border-border">
+        {#each credentials as credential}
+          <article class="bg-background p-3">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <div class="min-w-0 flex-1">
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="text-sm font-semibold">{credential.label}</span>
+                  {#if credential.is_active}
+                    <span class="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase text-primary">
+                      <Check class="h-2.5 w-2.5" />Active
+                    </span>
+                  {/if}
+                  <span class={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${toneClass(credential)}`}>
+                    {credentialHealthLabel(credential)}
+                  </span>
+                </div>
+                <code class="mt-1 block break-all text-xs text-muted-foreground">{credential.masked_secret}</code>
+                <p class="mt-1 text-[11px] text-muted-foreground">
+                  Priority {credential.priority}
+                  {#if credential.last_used_at} · Last used {new Date(credential.last_used_at).toLocaleString()}{/if}
+                </p>
+              </div>
+
+              <div class="flex flex-wrap items-center gap-1.5">
+                {#if !credential.is_active && credential.is_enabled}
+                  <button
+                    type="button"
+                    onclick={() => handleActivate(credential)}
+                    disabled={operation !== ''}
+                    class="rounded-md border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-accent disabled:opacity-50"
+                  >
+                    {operation === `activate:${credential.id}` ? 'Activating…' : 'Set active'}
+                  </button>
+                {/if}
+                <button
+                  type="button"
+                  onclick={() => handleTest(credential)}
+                  disabled={operation !== '' || !credential.is_enabled}
+                  class="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-accent disabled:opacity-50"
+                >
+                  {#if operation === `test:${credential.id}`}<Loader2 class="h-3 w-3 animate-spin" />{:else}<Activity class="h-3 w-3" />{/if}
+                  Test
+                </button>
+                <button type="button" onclick={() => beginEdit(credential, 'rename')} disabled={operation !== ''} class="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50" aria-label={`Rename ${credential.label}`}><Pencil class="h-3.5 w-3.5" /></button>
+                <button type="button" onclick={() => beginEdit(credential, 'replace')} disabled={operation !== ''} class="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50" aria-label={`Replace ${credential.label}`}><RefreshCw class="h-3.5 w-3.5" /></button>
+                <button type="button" onclick={() => beginEdit(credential, 'remove')} disabled={operation !== ''} class="rounded-md p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:opacity-50" aria-label={`Remove ${credential.label}`}><Trash2 class="h-3.5 w-3.5" /></button>
+              </div>
+            </div>
+
+            {#if testResults[credential.id]}
+              <div class="mt-2 flex items-start gap-2 rounded-md px-2.5 py-2 text-xs {testResults[credential.id].ok ? 'bg-green-50 text-green-700 dark:bg-green-950/30 dark:text-green-300' : 'bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-300'}">
+                {#if testResults[credential.id].ok}<CircleCheck class="mt-0.5 h-3.5 w-3.5 shrink-0" />{:else}<CircleAlert class="mt-0.5 h-3.5 w-3.5 shrink-0" />{/if}
+                {testResults[credential.id].message}
+              </div>
+            {/if}
+
+            {#if editingId === credential.id}
+              <div class="mt-3 rounded-md border border-border bg-muted/30 p-3">
+                {#if editMode === 'remove'}
+                  <p class="text-sm font-medium">Remove “{credential.label}”?</p>
+                  <p class="mt-1 text-xs text-muted-foreground">
+                    The secret cannot be recovered. {credential.is_active && credentials.length > 1 ? 'The next enabled credential becomes active.' : ''}
+                  </p>
+                  <div class="mt-3 flex justify-end gap-2">
+                    <button type="button" onclick={closeEditor} class="rounded-md border border-border px-3 py-1.5 text-xs hover:bg-accent">Cancel</button>
+                    <button type="button" onclick={() => handleRemove(credential)} disabled={operation !== ''} class="inline-flex items-center gap-1.5 rounded-md bg-destructive px-3 py-1.5 text-xs font-semibold text-destructive-foreground disabled:opacity-50">
+                      {#if operation === `remove:${credential.id}`}<Loader2 class="h-3 w-3 animate-spin" />{:else}<Trash2 class="h-3 w-3" />{/if}
+                      Remove
+                    </button>
+                  </div>
+                {:else}
+                  <label class="space-y-1 text-xs font-medium">
+                    {editMode === 'rename' ? 'Credential label' : `New ${authType === 'token' ? 'access token' : 'API key'}`}
+                    <div class="relative">
+                      <input
+                        type={editMode === 'replace' && !editSecretVisible ? 'password' : 'text'}
+                        bind:value={editValue}
+                        maxlength={editMode === 'rename' ? 80 : 4096}
+                        autocomplete={editMode === 'replace' ? 'new-password' : 'off'}
+                        class="w-full rounded-md border border-border bg-background px-3 py-2 {editMode === 'replace' ? 'pr-10' : ''} text-sm"
+                      />
+                      {#if editMode === 'replace'}
+                        <button type="button" onclick={() => (editSecretVisible = !editSecretVisible)} class="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground" aria-label={editSecretVisible ? 'Hide credential' : 'Show credential'}>
+                          {#if editSecretVisible}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
+                        </button>
+                      {/if}
+                    </div>
+                  </label>
+                  <div class="mt-3 flex justify-end gap-2">
+                    <button type="button" onclick={closeEditor} class="rounded-md border border-border px-3 py-1.5 text-xs hover:bg-accent">Cancel</button>
+                    <button type="button" onclick={() => handleEdit(credential)} disabled={operation !== '' || !editValue.trim()} class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground disabled:opacity-50">
+                      {#if operation === `${editMode}:${credential.id}`}<Loader2 class="h-3 w-3 animate-spin" />{:else}<Check class="h-3 w-3" />{/if}
+                      Save
+                    </button>
+                  </div>
+                {/if}
+              </div>
+            {/if}
+          </article>
+        {/each}
+      </div>
+    {:else}
+      <div class="mt-4 rounded-lg border border-dashed border-border bg-muted/20 px-4 py-8 text-center">
+        <KeyRound class="mx-auto h-5 w-5 text-muted-foreground" />
+        <p class="mt-2 text-sm font-medium">No credentials saved</p>
+        <p class="mt-1 text-xs text-muted-foreground">Add the first credential to connect this provider.</p>
+      </div>
+    {/if}
+
+    <div class="mt-5 border-t border-border pt-5">
+      <div class="flex items-start gap-3">
+        <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <ShieldCheck class="h-4 w-4" />
+        </div>
+        <div class="min-w-0 flex-1">
+          <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Credential strategy</p>
+          <h3 class="mt-0.5 text-sm font-semibold">Choose how ApplyKit selects a key</h3>
+        </div>
+      </div>
+
+      <div class="mt-3 grid gap-2">
+        {#each ['manual', 'failover', 'round_robin'] as strategy}
+          {@const typedStrategy = strategy as CredentialStrategy}
+          {@const automatic = typedStrategy !== 'manual'}
+          <button
+            type="button"
+            onclick={() => handleStrategy(typedStrategy)}
+            disabled={operation !== '' || (automatic && !automaticAvailable)}
+            class="flex items-start gap-3 rounded-lg border p-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50 {policy.strategy === typedStrategy ? 'border-primary bg-primary/5' : 'border-border hover:bg-accent/40'}"
+          >
+            <span class="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border {policy.strategy === typedStrategy ? 'border-primary bg-primary' : 'border-muted-foreground/50'}">
+              {#if policy.strategy === typedStrategy}<span class="h-1.5 w-1.5 rounded-full bg-primary-foreground"></span>{/if}
+            </span>
+            <span class="min-w-0 flex-1">
+              <span class="flex flex-wrap items-center gap-2 text-sm font-semibold">
+                {credentialStrategyLabel(typedStrategy)}
+                {#if typedStrategy === 'failover'}<span class="rounded bg-green-100 px-1.5 py-0.5 text-[9px] font-semibold uppercase text-green-700 dark:bg-green-950/60 dark:text-green-300">Recommended</span>{/if}
+                {#if typedStrategy === 'round_robin'}<span class="rounded bg-muted px-1.5 py-0.5 text-[9px] font-semibold uppercase text-muted-foreground">Advanced</span>{/if}
+              </span>
+              <span class="mt-0.5 block text-xs text-muted-foreground">{credentialStrategyDescription(typedStrategy)}</span>
+              {#if automatic && !automaticAvailable}<span class="mt-1 block text-[11px] text-yellow-700 dark:text-yellow-300">Requires at least two enabled credentials.</span>{/if}
+            </span>
+            {#if operation === 'policy' && policy.strategy !== typedStrategy}<Loader2 class="mt-0.5 h-4 w-4 animate-spin text-muted-foreground" />{/if}
+          </button>
+        {/each}
+      </div>
+
+      {#if policy.strategy !== 'manual'}
+        <label class="mt-3 flex items-center justify-between gap-3 rounded-lg bg-muted/40 px-3 py-2.5 text-xs">
+          <span>
+            <span class="font-semibold">Maximum attempts</span>
+            <span class="mt-0.5 block text-muted-foreground">Includes the first credential. Lower values reduce duplicate cost risk.</span>
+          </span>
+          <div class="relative shrink-0">
+            <select
+              value={policy.max_attempts}
+              onchange={(event) => handleMaxAttempts(Number(event.currentTarget.value))}
+              disabled={operation !== ''}
+              class="appearance-none rounded-md border border-border bg-background py-1.5 pl-3 pr-8 text-sm font-medium"
+            >
+              {#each [2, 3, 4, 5] as attemptCount}
+                <option value={attemptCount}>{attemptCount}</option>
+              {/each}
+            </select>
+            <ChevronDown class="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          </div>
+        </label>
+      {/if}
+    </div>
+  {/if}
+
+  {#if panelError}
+    <div class="mt-3 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+      <CircleAlert class="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      {panelError}
+    </div>
+  {/if}
+</section>

--- a/frontend/src/lib/components/SettingsModal.svelte
+++ b/frontend/src/lib/components/SettingsModal.svelte
@@ -3,7 +3,11 @@
   import { page } from '$app/state';
   import { getModels, getSettings, testConnection, updateSettings } from '$lib/api';
   import ModelSelector from '$lib/components/ModelSelector.svelte';
-  import { testConfiguredIntegration } from '$lib/integration-api';
+  import ProviderCredentialsPanel from '$lib/components/ProviderCredentialsPanel.svelte';
+  import {
+    getProviderCredentials,
+    testConfiguredIntegration,
+  } from '$lib/integration-api';
   import {
     credentialActionLabel,
     customModelValidationError,
@@ -59,6 +63,7 @@
   let source = $state<'database' | 'env' | 'none'>('none');
   let activeModel = $state('');
   let saving = $state<'activate' | 'only' | null>(null);
+  let hasStoredCredential = $state(false);
 
   const selectedProvider = $derived(
     providers.find((provider) => provider.id === selectedProviderId),
@@ -66,8 +71,11 @@
   const selectedModelInfo = $derived(
     selectedProvider?.models.find((model) => model.value === selectedModel),
   );
+  const managesCredentialVault = $derived(
+    Boolean(initialProviderId && selectedProvider?.requires_api_key),
+  );
   const mode = $derived(
-    modalMode(initialProviderId, initialModel, initialApiKeyConfigured),
+    modalMode(initialProviderId, initialModel, hasStoredCredential),
   );
   const isActive = $derived(
     Boolean(activeModel && activeModel.split('/', 1)[0] === selectedProviderId),
@@ -88,11 +96,7 @@
     ),
   );
   const canReuseStoredKey = $derived(
-    Boolean(
-      initialProviderId &&
-        initialApiKeyConfigured &&
-        selectedProvider?.requires_api_key,
-    ),
+    Boolean(hasStoredCredential && selectedProvider?.requires_api_key),
   );
   const testMode = $derived(
     connectionTestMode({
@@ -112,7 +116,9 @@
     Boolean(
       selectedModel &&
         !customModelError &&
-        (!selectedProvider?.requires_api_key || apiKey.trim() || canReuseStoredKey),
+        (!selectedProvider?.requires_api_key ||
+          hasStoredCredential ||
+          (!managesCredentialVault && apiKey.trim())),
     ),
   );
 
@@ -144,6 +150,22 @@
     return false;
   }
 
+  async function refreshCredentialState() {
+    if (!selectedProvider?.requires_api_key || !selectedProviderId) {
+      hasStoredCredential = false;
+      return;
+    }
+    try {
+      const response = await getProviderCredentials(selectedProviderId);
+      hasStoredCredential = response.credentials.some(
+        (credential) => credential.is_active && credential.is_enabled,
+      );
+      await invalidateAll();
+    } catch {
+      hasStoredCredential = initialApiKeyConfigured;
+    }
+  }
+
   async function loadData() {
     loading = true;
     testResult = null;
@@ -151,6 +173,7 @@
     apiKey = '';
     showApiKey = false;
     customMode = false;
+    hasStoredCredential = initialApiKeyConfigured;
 
     try {
       const [modelsResponse, settingsResponse] = await Promise.all([
@@ -166,11 +189,13 @@
         selectedProviderId = initialProviderId;
         selectedModel = initialModel || provider?.models[0]?.value || '';
         customMode = isCustomModel(provider, selectedModel);
+        if (provider?.requires_api_key) await refreshCredentialState();
       } else if (settingsResponse.model && selectExistingModel(settingsResponse.model)) {
-        // Restore the current configuration when the modal is opened globally.
+        hasStoredCredential = settingsResponse.api_key_configured;
       } else if (providers.length > 0) {
         selectedProviderId = providers[0].id;
         selectedModel = providers[0].models[0]?.value ?? '';
+        hasStoredCredential = false;
       }
     } catch {
       saveError = 'Failed to load settings.';
@@ -185,6 +210,7 @@
     selectedModel = provider?.models[0]?.value ?? '';
     customMode = false;
     apiKey = '';
+    hasStoredCredential = false;
     testResult = null;
     saveError = '';
   }
@@ -233,9 +259,13 @@
       return;
     }
 
-    const keyToSave = apiKey.trim() || null;
-    if (selectedProvider?.requires_api_key && !keyToSave && !canReuseStoredKey) {
-      saveError = 'API key is required.';
+    const keyToSave = managesCredentialVault ? null : apiKey.trim() || null;
+    if (
+      selectedProvider?.requires_api_key &&
+      !keyToSave &&
+      !hasStoredCredential
+    ) {
+      saveError = 'Add a credential before saving this provider.';
       return;
     }
 
@@ -252,9 +282,7 @@
           ? isActive
             ? 'Provider settings updated.'
             : 'Saved and set as active model.'
-          : keyToSave
-            ? 'Provider saved without changing the active model.'
-            : 'Model saved. Existing credential was kept.',
+          : 'Provider saved without changing the active model.',
       );
       open = false;
       await invalidateAll();
@@ -264,12 +292,16 @@
     } catch (error) {
       saveError = errorMessage(error, 'Failed to save settings.');
     } finally {
+      apiKey = '';
+      showApiKey = false;
       saving = null;
     }
   }
 
   function closeModal() {
     if (saving || testing) return;
+    apiKey = '';
+    showApiKey = false;
     open = false;
   }
 
@@ -291,106 +323,67 @@
     aria-labelledby="provider-settings-title"
   >
     <div
-      class="flex max-h-[94vh] w-full max-w-2xl flex-col overflow-hidden rounded-t-2xl border border-border bg-background shadow-2xl sm:max-h-[calc(100vh-2rem)] sm:rounded-2xl"
+      class="flex max-h-[94vh] w-full max-w-3xl flex-col overflow-hidden rounded-t-2xl border border-border bg-background shadow-2xl sm:max-h-[calc(100vh-2rem)] sm:rounded-2xl"
       onclick={(event) => event.stopPropagation()}
       role="presentation"
     >
       <header class="flex items-start justify-between gap-4 border-b border-border px-5 py-4 sm:px-6 sm:py-5">
         <div class="min-w-0">
           <div class="flex flex-wrap items-center gap-2">
-            <h2 id="provider-settings-title" class="text-lg font-semibold tracking-tight">
-              {title}
-            </h2>
+            <h2 id="provider-settings-title" class="text-lg font-semibold tracking-tight">{title}</h2>
             {#if !loading && selectedProvider}
               {#if isActive}
                 <span class="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-700 dark:bg-green-950/60 dark:text-green-300">
-                  <span class="h-1.5 w-1.5 rounded-full bg-green-500"></span>
-                  Active
+                  <span class="h-1.5 w-1.5 rounded-full bg-green-500"></span>Active
                 </span>
-              {:else if mode === 'edit'}
+              {:else if hasStoredCredential}
                 <span class="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-700 dark:bg-blue-950/60 dark:text-blue-300">
-                  <CheckCircle class="h-3 w-3" />
-                  Connected
+                  <CheckCircle class="h-3 w-3" />Connected
                 </span>
               {:else}
-                <span class="rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                  Not configured
-                </span>
+                <span class="rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Not configured</span>
               {/if}
             {/if}
           </div>
-          <p class="mt-1 text-sm text-muted-foreground">
-            Choose a model, configure access, verify the connection, then save.
-          </p>
+          <p class="mt-1 text-sm text-muted-foreground">Choose a model, manage credentials, verify the connection, then save.</p>
         </div>
-        <button
-          onclick={closeModal}
-          disabled={saving !== null || testing}
-          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
-          aria-label="Close provider settings"
-        >
+        <button onclick={closeModal} disabled={saving !== null || testing} class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50" aria-label="Close provider settings">
           <X class="h-4 w-4" />
         </button>
       </header>
 
       {#if loading}
         <div class="flex min-h-72 flex-1 items-center justify-center gap-2 text-muted-foreground">
-          <Loader2 class="h-5 w-5 animate-spin" />
-          Loading provider settings…
+          <Loader2 class="h-5 w-5 animate-spin" />Loading provider settings…
         </div>
       {:else}
         <div class="flex-1 space-y-5 overflow-y-auto px-5 py-5 sm:px-6">
           {#if source === 'env'}
             <div class="flex items-start gap-3 rounded-xl border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800 dark:border-blue-900 dark:bg-blue-950/30 dark:text-blue-300">
               <CircleAlert class="mt-0.5 h-4 w-4 shrink-0" />
-              <span>
-                ApplyKit currently uses configuration from <code class="font-mono">.env</code>.
-                Saving here will override it with the database configuration.
-              </span>
+              <span>ApplyKit currently uses configuration from <code class="font-mono">.env</code>. Saving here will override it with the database configuration.</span>
             </div>
           {/if}
 
           <section class="rounded-xl border border-border bg-card p-4 sm:p-5">
             <div class="flex items-start gap-3">
-              <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                <Server class="h-4 w-4" />
-              </div>
+              <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary"><Server class="h-4 w-4" /></div>
               <div class="min-w-0 flex-1">
-                <div class="flex items-center justify-between gap-3">
-                  <div>
-                    <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Provider</p>
-                    <h3 class="mt-0.5 text-sm font-semibold">Choose where ApplyKit sends AI requests</h3>
-                  </div>
-                </div>
-
+                <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Provider</p>
+                <h3 class="mt-0.5 text-sm font-semibold">Choose where ApplyKit sends AI requests</h3>
                 {#if !initialProviderId}
-                  <select
-                    value={selectedProviderId}
-                    onchange={(event) => onProviderChange(event.currentTarget.value)}
-                    class="mt-3 w-full rounded-lg border border-border bg-background px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-                    aria-label="AI provider"
-                  >
-                    {#each providers as provider}
-                      <option value={provider.id}>{provider.label}</option>
-                    {/each}
+                  <select value={selectedProviderId} onchange={(event) => onProviderChange(event.currentTarget.value)} class="mt-3 w-full rounded-lg border border-border bg-background px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-primary/30" aria-label="AI provider">
+                    {#each providers as provider}<option value={provider.id}>{provider.label}</option>{/each}
                   </select>
                 {:else}
                   <div class="mt-3 flex items-center justify-between gap-3 rounded-lg bg-muted/50 px-3 py-2.5">
                     <div>
                       <p class="text-sm font-medium">{selectedProvider?.label}</p>
                       <p class="text-xs text-muted-foreground">
-                        {#if selectedProvider?.local}
-                          Local provider · no credential required
-                        {:else if selectedProvider?.auth_type === 'token'}
-                          Access token authentication
-                        {:else}
-                          API key authentication
-                        {/if}
+                        {#if selectedProvider?.local}Local provider · no credential required{:else if selectedProvider?.auth_type === 'token'}Access token authentication{:else}API key authentication{/if}
                       </p>
                     </div>
-                    {#if selectedProvider?.local}
-                      <span class="rounded bg-blue-100 px-2 py-1 text-[10px] font-semibold uppercase text-blue-700 dark:bg-blue-950 dark:text-blue-300">Local</span>
-                    {/if}
+                    {#if selectedProvider?.local}<span class="rounded bg-blue-100 px-2 py-1 text-[10px] font-semibold uppercase text-blue-700 dark:bg-blue-950 dark:text-blue-300">Local</span>{/if}
                   </div>
                 {/if}
               </div>
@@ -399,9 +392,7 @@
 
           <section class="rounded-xl border border-border bg-card p-4 sm:p-5">
             <div class="flex items-start gap-3">
-              <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                <Sparkles class="h-4 w-4" />
-              </div>
+              <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary"><Sparkles class="h-4 w-4" /></div>
               <div class="min-w-0 flex-1">
                 <div class="flex flex-wrap items-start justify-between gap-3">
                   <div>
@@ -409,193 +400,101 @@
                     <h3 class="mt-0.5 text-sm font-semibold">Select the model for this provider</h3>
                   </div>
                   {#if selectedProvider?.supports_custom_models}
-                    <button
-                      type="button"
-                      onclick={toggleCustomMode}
-                      class="text-xs font-medium text-primary hover:underline"
-                    >
-                      {customMode ? 'Choose from catalog' : 'Use custom model ID'}
-                    </button>
+                    <button type="button" onclick={toggleCustomMode} class="text-xs font-medium text-primary hover:underline">{customMode ? 'Choose from catalog' : 'Use custom model ID'}</button>
                   {/if}
                 </div>
-
                 <div class="mt-3">
                   {#if customMode}
-                    <input
-                      id="custom-model-input"
-                      bind:value={selectedModel}
-                      placeholder={`${selectedProvider?.id ?? 'provider'}/model-name`}
-                      maxlength="200"
-                      spellcheck="false"
-                      autocomplete="off"
-                      class="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-sm outline-none focus:ring-2 focus:ring-primary/30"
-                    />
+                    <input bind:value={selectedModel} placeholder={`${selectedProvider?.id ?? 'provider'}/model-name`} maxlength="200" spellcheck="false" autocomplete="off" class="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-sm outline-none focus:ring-2 focus:ring-primary/30" />
                     <div class="mt-2 flex flex-wrap items-center justify-between gap-2">
                       <span class="rounded bg-purple-100 px-2 py-1 text-[10px] font-semibold uppercase text-purple-700 dark:bg-purple-950 dark:text-purple-300">Custom model</span>
                       <span class="text-xs text-muted-foreground">Use the full LiteLLM model ID.</span>
                     </div>
-                    {#if customModelError}
-                      <p class="mt-2 text-xs text-red-600 dark:text-red-400">{customModelError}</p>
-                    {/if}
+                    {#if customModelError}<p class="mt-2 text-xs text-red-600 dark:text-red-400">{customModelError}</p>{/if}
                   {:else}
-                    <ModelSelector
-                      models={selectedProvider?.models ?? []}
-                      bind:value={selectedModel}
-                      unavailableValue={unavailableCurrentModel ? initialModel : ''}
-                    />
+                    <ModelSelector models={selectedProvider?.models ?? []} bind:value={selectedModel} unavailableValue={unavailableCurrentModel ? initialModel : ''} />
                   {/if}
                 </div>
-
                 {#if unavailableCurrentModel && selectedModel === initialModel}
                   <div class="mt-3 flex items-start gap-2 rounded-lg border border-yellow-200 bg-yellow-50 px-3 py-2.5 text-xs text-yellow-800 dark:border-yellow-900 dark:bg-yellow-950/30 dark:text-yellow-300">
-                    <CircleAlert class="h-4 w-4 shrink-0" />
-                    <span>This model is no longer in the current catalog. Select an active model to replace it.</span>
+                    <CircleAlert class="h-4 w-4 shrink-0" />Select an active catalog model to replace this unavailable model.
                   </div>
                 {:else if selectedModelInfo}
                   <div class="mt-3 flex flex-wrap gap-1.5">
                     <span class="rounded bg-blue-100 px-2 py-1 text-[10px] font-semibold uppercase text-blue-700 dark:bg-blue-950 dark:text-blue-300">Catalog</span>
-                    {#if selectedModelInfo.status !== 'stable'}
-                      <span class="rounded bg-yellow-100 px-2 py-1 text-[10px] font-semibold uppercase text-yellow-800 dark:bg-yellow-950 dark:text-yellow-300">{selectedModelInfo.status}</span>
-                    {/if}
-                    {#if selectedModelInfo.free_tier}
-                      <span class="rounded bg-green-100 px-2 py-1 text-[10px] font-semibold uppercase text-green-700 dark:bg-green-950 dark:text-green-300">Free tier</span>
-                    {/if}
-                    {#if selectedProvider?.local}
-                      <span class="rounded bg-blue-100 px-2 py-1 text-[10px] font-semibold uppercase text-blue-700 dark:bg-blue-950 dark:text-blue-300">Local</span>
-                    {/if}
-                    {#each selectedModelInfo.traits as trait}
-                      <span class="rounded bg-muted px-2 py-1 text-[10px] uppercase text-muted-foreground">{trait.replaceAll('_', ' ')}</span>
-                    {/each}
+                    {#if selectedModelInfo.status !== 'stable'}<span class="rounded bg-yellow-100 px-2 py-1 text-[10px] font-semibold uppercase text-yellow-800 dark:bg-yellow-950 dark:text-yellow-300">{selectedModelInfo.status}</span>{/if}
+                    {#if selectedModelInfo.free_tier}<span class="rounded bg-green-100 px-2 py-1 text-[10px] font-semibold uppercase text-green-700 dark:bg-green-950 dark:text-green-300">Free tier</span>{/if}
+                    {#each selectedModelInfo.traits as trait}<span class="rounded bg-muted px-2 py-1 text-[10px] uppercase text-muted-foreground">{trait.replaceAll('_', ' ')}</span>{/each}
                   </div>
                 {/if}
               </div>
             </div>
           </section>
 
-          <section class="rounded-xl border border-border bg-card p-4 sm:p-5">
-            <div class="flex items-start gap-3">
-              <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                <KeyRound class="h-4 w-4" />
-              </div>
-              <div class="min-w-0 flex-1">
-                <div class="flex flex-wrap items-start justify-between gap-3">
-                  <div>
-                    <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Credential</p>
-                    <h3 class="mt-0.5 text-sm font-semibold">
-                      {#if selectedProvider?.requires_api_key}
-                        {selectedProvider.auth_type === 'token' ? 'Provide an access token' : 'Provide an API key'}
-                      {:else}
-                        No credential required
-                      {/if}
-                    </h3>
+          {#if managesCredentialVault && selectedProvider}
+            <ProviderCredentialsPanel
+              providerId={selectedProvider.id}
+              providerLabel={selectedProvider.label}
+              credentialUrl={selectedProvider.credential_url}
+              authType={selectedProvider.auth_type}
+              onChanged={refreshCredentialState}
+            />
+          {:else}
+            <section class="rounded-xl border border-border bg-card p-4 sm:p-5">
+              <div class="flex items-start gap-3">
+                <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary"><KeyRound class="h-4 w-4" /></div>
+                <div class="min-w-0 flex-1">
+                  <div class="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Credential</p>
+                      <h3 class="mt-0.5 text-sm font-semibold">{selectedProvider?.requires_api_key ? selectedProvider.auth_type === 'token' ? 'Provide an access token' : 'Provide an API key' : 'No credential required'}</h3>
+                    </div>
+                    {#if selectedProvider?.credential_url}
+                      <a href={selectedProvider.credential_url} target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">
+                        {credentialActionLabel(selectedProvider.auth_type)}<ExternalLink class="h-3 w-3" />
+                      </a>
+                    {/if}
                   </div>
-                  {#if selectedProvider?.credential_url}
-                    <a
-                      href={selectedProvider.credential_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
-                    >
-                      {credentialActionLabel(selectedProvider.auth_type)}
-                      <ExternalLink class="h-3 w-3" />
-                    </a>
+                  {#if selectedProvider?.requires_api_key}
+                    <div class="relative mt-3">
+                      <input type={showApiKey ? 'text' : 'password'} bind:value={apiKey} placeholder="Enter your credential…" class="w-full rounded-lg border border-border bg-background px-3 py-2.5 pr-11 text-sm outline-none focus:ring-2 focus:ring-primary/30" autocomplete="new-password" />
+                      <button type="button" onclick={() => (showApiKey = !showApiKey)} class="absolute right-2.5 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground" aria-label={showApiKey ? 'Hide credential' : 'Show credential'}>
+                        {#if showApiKey}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
+                      </button>
+                    </div>
+                  {:else}
+                    <p class="mt-3 text-sm text-muted-foreground">This local provider does not require an API key.</p>
                   {/if}
                 </div>
-
-                {#if selectedProvider?.requires_api_key}
-                  {#if canReuseStoredKey}
-                    <div class="mt-3 flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-xs text-green-700 dark:border-green-900 dark:bg-green-950/30 dark:text-green-300">
-                      <ShieldCheck class="h-4 w-4 shrink-0" />
-                      A credential is already saved. Leave the field empty to keep using it.
-                    </div>
-                  {/if}
-                  <div class="relative mt-3">
-                    <input
-                      id="api-key-input"
-                      type={showApiKey ? 'text' : 'password'}
-                      bind:value={apiKey}
-                      placeholder={canReuseStoredKey ? 'Enter a new value only to replace it' : 'Enter your credential…'}
-                      class="w-full rounded-lg border border-border bg-background px-3 py-2.5 pr-11 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-                      autocomplete="new-password"
-                    />
-                    <button
-                      type="button"
-                      onclick={() => (showApiKey = !showApiKey)}
-                      class="absolute right-2.5 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
-                      aria-label={showApiKey ? 'Hide credential' : 'Show credential'}
-                    >
-                      {#if showApiKey}
-                        <EyeOff class="h-4 w-4" />
-                      {:else}
-                        <Eye class="h-4 w-4" />
-                      {/if}
-                    </button>
-                  </div>
-                {:else}
-                  <p class="mt-3 text-sm text-muted-foreground">
-                    This provider runs locally. ApplyKit will connect without an API key or access token.
-                  </p>
-                {/if}
               </div>
-            </div>
-          </section>
+            </section>
+          {/if}
 
           <section class="rounded-xl border border-border bg-card p-4 sm:p-5">
             <div class="flex items-start gap-3">
-              <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                <ShieldCheck class="h-4 w-4" />
-              </div>
+              <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary"><ShieldCheck class="h-4 w-4" /></div>
               <div class="min-w-0 flex-1">
                 <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Verification</p>
                 <div class="mt-0.5 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                   <div>
-                    <h3 class="text-sm font-semibold">Test before saving</h3>
+                    <h3 class="text-sm font-semibold">Test the selected model</h3>
                     <p class="mt-1 text-xs text-muted-foreground">
-                      {#if testMode === 'stored'}
-                        Uses the credential and model already saved securely on the backend.
-                      {:else if selectedProvider?.local}
-                        Sends one minimal request to your local provider.
-                      {:else}
-                        Sends one minimal request with the credential entered above.
-                      {/if}
+                      {#if testMode === 'stored'}Uses the active credential stored securely on the backend.{:else if selectedProvider?.local}Sends one minimal request to the local provider.{:else}Sends one minimal request with the credential entered above.{/if}
                     </p>
                   </div>
-                  <button
-                    onclick={handleTest}
-                    disabled={testing || !canTest}
-                    class="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-border px-3.5 py-2 text-sm font-medium transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {#if testing}
-                      <Loader2 class="h-4 w-4 animate-spin" />
-                      Testing…
-                    {:else if testMode === 'stored'}
-                      Test saved connection
-                    {:else}
-                      Test connection
-                    {/if}
+                  <button onclick={handleTest} disabled={testing || !canTest} class="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-border px-3.5 py-2 text-sm font-medium transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50">
+                    {#if testing}<Loader2 class="h-4 w-4 animate-spin" />Testing…{:else if testMode === 'stored'}Test saved connection{:else}Test connection{/if}
                   </button>
                 </div>
-
                 {#if storedTestUsesOlderModel}
                   <div class="mt-3 flex items-start gap-2 rounded-lg border border-yellow-200 bg-yellow-50 px-3 py-2 text-xs text-yellow-800 dark:border-yellow-900 dark:bg-yellow-950/30 dark:text-yellow-300">
-                    <CircleAlert class="h-4 w-4 shrink-0" />
-                    The saved connection test uses the previously saved model. Save this model first to test it with the stored credential.
+                    <CircleAlert class="h-4 w-4 shrink-0" />Save this model first; the configured test currently uses the previously saved model.
                   </div>
                 {/if}
-
                 {#if testResult}
-                  <div class="mt-3 flex items-start gap-2 rounded-lg border px-3 py-2.5 text-sm {testResult.ok
-                    ? 'border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950/30 dark:text-green-300'
-                    : 'border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300'}">
-                    {#if testResult.ok}
-                      <CheckCircle class="mt-0.5 h-4 w-4 shrink-0" />
-                    {:else}
-                      <XCircle class="mt-0.5 h-4 w-4 shrink-0" />
-                    {/if}
-                    <div>
-                      <p class="font-medium">{testResult.ok ? 'Connection successful' : 'Connection failed'}</p>
-                      <p class="mt-0.5 text-xs opacity-90">{testResult.message}</p>
-                    </div>
+                  <div class="mt-3 flex items-start gap-2 rounded-lg border px-3 py-2.5 text-sm {testResult.ok ? 'border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950/30 dark:text-green-300' : 'border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300'}">
+                    {#if testResult.ok}<CheckCircle class="mt-0.5 h-4 w-4 shrink-0" />{:else}<XCircle class="mt-0.5 h-4 w-4 shrink-0" />{/if}
+                    <div><p class="font-medium">{testResult.ok ? 'Connection successful' : 'Connection failed'}</p><p class="mt-0.5 text-xs opacity-90">{testResult.message}</p></div>
                   </div>
                 {/if}
               </div>
@@ -604,52 +503,26 @@
 
           {#if saveError}
             <div class="flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
-              <XCircle class="mt-0.5 h-4 w-4 shrink-0" />
-              <span>{saveError}</span>
+              <XCircle class="mt-0.5 h-4 w-4 shrink-0" /><span>{saveError}</span>
             </div>
           {/if}
         </div>
 
         <footer class="border-t border-border bg-background/95 px-5 py-4 backdrop-blur sm:px-6">
           <div class="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <button
-              onclick={closeModal}
-              disabled={saving !== null || testing}
-              class="inline-flex items-center justify-center rounded-lg border border-border px-4 py-2.5 text-sm font-medium transition-colors hover:bg-accent disabled:opacity-50"
-            >
-              Cancel
-            </button>
-
+            <button onclick={closeModal} disabled={saving !== null || testing} class="inline-flex items-center justify-center rounded-lg border border-border px-4 py-2.5 text-sm font-medium transition-colors hover:bg-accent disabled:opacity-50">Cancel</button>
             <div class="flex flex-col-reverse gap-2 sm:flex-row">
               {#if !isActive}
-                <button
-                  onclick={() => handleSave(false)}
-                  disabled={saving !== null || testing || !canSave}
-                  class="inline-flex items-center justify-center gap-2 rounded-lg border border-border px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {#if saving === 'only'}
-                    <Loader2 class="h-4 w-4 animate-spin" />
-                  {/if}
-                  Save only
+                <button onclick={() => handleSave(false)} disabled={saving !== null || testing || !canSave} class="inline-flex items-center justify-center gap-2 rounded-lg border border-border px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50">
+                  {#if saving === 'only'}<Loader2 class="h-4 w-4 animate-spin" />{/if}Save only
                 </button>
               {/if}
-              <button
-                onclick={() => handleSave(true)}
-                disabled={saving !== null || testing || !canSave}
-                class="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {#if saving === 'activate'}
-                  <Loader2 class="h-4 w-4 animate-spin" />
-                {/if}
-                {primaryLabel}
+              <button onclick={() => handleSave(true)} disabled={saving !== null || testing || !canSave} class="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50">
+                {#if saving === 'activate'}<Loader2 class="h-4 w-4 animate-spin" />{/if}{primaryLabel}
               </button>
             </div>
           </div>
-          {#if !isActive}
-            <p class="mt-2 text-center text-[11px] text-muted-foreground sm:text-right">
-              Save only keeps the current active provider unchanged.
-            </p>
-          {/if}
+          {#if !isActive}<p class="mt-2 text-center text-[11px] text-muted-foreground sm:text-right">Save only keeps the current active provider unchanged.</p>{/if}
         </footer>
       {/if}
     </div>

--- a/frontend/src/lib/integration-api.ts
+++ b/frontend/src/lib/integration-api.ts
@@ -1,21 +1,142 @@
+import type {
+  CreateProviderCredentialRequest,
+  CredentialPolicyResponse,
+  CredentialStrategy,
+  ProviderCredentialInfo,
+  ProviderCredentialsResponse,
+  UpdateProviderCredentialRequest,
+} from '$lib/provider-credential-types';
 import type { TestConnectionResponse } from '$lib/types';
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000/api';
 
+async function requestJson<T>(
+  path: string,
+  options: RequestInit = {},
+): Promise<T> {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    let message = 'Credential request failed.';
+    try {
+      const payload = (await response.json()) as {
+        detail?: string;
+        error?: { message?: string };
+      };
+      message = payload.error?.message ?? payload.detail ?? message;
+    } catch {
+      // Keep the stable fallback instead of exposing an unreadable response body.
+    }
+    throw new Error(message);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+function providerPath(providerId: string): string {
+  return `/settings/integrations/${encodeURIComponent(providerId)}`;
+}
+
 export async function testConfiguredIntegration(
   providerId: string,
 ): Promise<TestConnectionResponse> {
-  const response = await fetch(
-    `${BASE_URL}/settings/integrations/${encodeURIComponent(providerId)}/test`,
+  return requestJson<TestConnectionResponse>(`${providerPath(providerId)}/test`, {
+    method: 'POST',
+  });
+}
+
+export async function getProviderCredentials(
+  providerId: string,
+): Promise<ProviderCredentialsResponse> {
+  return requestJson<ProviderCredentialsResponse>(
+    `${providerPath(providerId)}/credentials`,
+  );
+}
+
+export async function addProviderCredential(
+  providerId: string,
+  request: CreateProviderCredentialRequest,
+): Promise<ProviderCredentialInfo> {
+  return requestJson<ProviderCredentialInfo>(
+    `${providerPath(providerId)}/credentials`,
     {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
     },
   );
+}
 
-  if (!response.ok) {
-    throw new Error('Configured integration test request failed.');
-  }
+export async function updateProviderCredential(
+  providerId: string,
+  credentialId: number,
+  request: UpdateProviderCredentialRequest,
+): Promise<ProviderCredentialInfo> {
+  return requestJson<ProviderCredentialInfo>(
+    `${providerPath(providerId)}/credentials/${credentialId}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify(request),
+    },
+  );
+}
 
-  return response.json() as Promise<TestConnectionResponse>;
+export async function activateProviderCredential(
+  providerId: string,
+  credentialId: number,
+): Promise<ProviderCredentialInfo> {
+  return requestJson<ProviderCredentialInfo>(
+    `${providerPath(providerId)}/credentials/${credentialId}/activate`,
+    { method: 'PUT' },
+  );
+}
+
+export async function testProviderCredential(
+  providerId: string,
+  credentialId: number,
+): Promise<TestConnectionResponse> {
+  return requestJson<TestConnectionResponse>(
+    `${providerPath(providerId)}/credentials/${credentialId}/test`,
+    { method: 'POST' },
+  );
+}
+
+export async function deleteProviderCredential(
+  providerId: string,
+  credentialId: number,
+): Promise<ProviderCredentialsResponse> {
+  return requestJson<ProviderCredentialsResponse>(
+    `${providerPath(providerId)}/credentials/${credentialId}`,
+    { method: 'DELETE' },
+  );
+}
+
+export async function getCredentialPolicy(
+  providerId: string,
+): Promise<CredentialPolicyResponse> {
+  return requestJson<CredentialPolicyResponse>(
+    `${providerPath(providerId)}/credential-policy`,
+  );
+}
+
+export async function updateCredentialPolicy(
+  providerId: string,
+  strategy: CredentialStrategy,
+  maxAttempts: number,
+): Promise<CredentialPolicyResponse> {
+  return requestJson<CredentialPolicyResponse>(
+    `${providerPath(providerId)}/credential-policy`,
+    {
+      method: 'PUT',
+      body: JSON.stringify({
+        strategy,
+        max_attempts: maxAttempts,
+      }),
+    },
+  );
 }

--- a/frontend/src/lib/provider-credential-types.ts
+++ b/frontend/src/lib/provider-credential-types.ts
@@ -1,0 +1,49 @@
+import type { IntegrationInfo } from '$lib/types';
+
+export type CredentialStrategy = 'manual' | 'failover' | 'round_robin';
+
+export interface CredentialIntegrationInfo extends IntegrationInfo {
+  credential_count: number;
+  active_credential_id: number | null;
+  active_credential_label: string | null;
+  credential_strategy: CredentialStrategy;
+}
+
+export interface ProviderCredentialInfo {
+  id: number;
+  provider_id: string;
+  label: string;
+  masked_secret: string;
+  is_active: boolean;
+  is_enabled: boolean;
+  priority: number;
+  health_status: string;
+  cooldown_until: string | null;
+  last_tested_at: string | null;
+  last_used_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProviderCredentialsResponse {
+  provider_id: string;
+  credentials: ProviderCredentialInfo[];
+  max_credentials: number;
+}
+
+export interface CredentialPolicyResponse {
+  provider_id: string;
+  strategy: CredentialStrategy;
+  max_attempts: number;
+}
+
+export interface CreateProviderCredentialRequest {
+  label: string;
+  secret: string;
+  activate?: boolean;
+}
+
+export interface UpdateProviderCredentialRequest {
+  label?: string;
+  secret?: string;
+}

--- a/frontend/src/lib/provider-credentials.test.ts
+++ b/frontend/src/lib/provider-credentials.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  canUseAutomaticStrategy,
+  credentialHealthLabel,
+  credentialStrategyDescription,
+  credentialStrategyLabel,
+  enabledCredentialCount,
+} from '$lib/provider-credentials';
+import type { ProviderCredentialInfo } from '$lib/types';
+
+const credentials: ProviderCredentialInfo[] = [
+  {
+    id: 1,
+    provider_id: 'openai',
+    label: 'Personal',
+    masked_secret: 'sk-p••••••onal',
+    is_active: true,
+    is_enabled: true,
+    priority: 1,
+    health_status: 'healthy',
+    cooldown_until: null,
+    last_tested_at: null,
+    last_used_at: null,
+    created_at: '2026-08-02T00:00:00Z',
+    updated_at: '2026-08-02T00:00:00Z',
+  },
+  {
+    id: 2,
+    provider_id: 'openai',
+    label: 'Backup',
+    masked_secret: 'sk-b••••••ckup',
+    is_active: false,
+    is_enabled: true,
+    priority: 2,
+    health_status: 'rate_limited',
+    cooldown_until: '2026-08-02T00:05:00Z',
+    last_tested_at: null,
+    last_used_at: null,
+    created_at: '2026-08-02T00:00:00Z',
+    updated_at: '2026-08-02T00:00:00Z',
+  },
+];
+
+describe('credential strategy presentation', () => {
+  test('uses clear labels and descriptions', () => {
+    expect(credentialStrategyLabel('manual')).toBe('Manual');
+    expect(credentialStrategyLabel('failover')).toBe('Automatic failover');
+    expect(credentialStrategyLabel('round_robin')).toBe('Round robin');
+    expect(credentialStrategyDescription('failover')).toContain('unavailable');
+  });
+
+  test('automatic strategies require at least two enabled credentials', () => {
+    expect(enabledCredentialCount(credentials)).toBe(2);
+    expect(canUseAutomaticStrategy(credentials)).toBe(true);
+    expect(
+      canUseAutomaticStrategy([
+        credentials[0],
+        { ...credentials[1], is_enabled: false },
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe('credential health labels', () => {
+  test('explains common health states without exposing secrets', () => {
+    expect(credentialHealthLabel(credentials[0])).toBe('Healthy');
+    expect(credentialHealthLabel(credentials[1])).toBe('Rate limited · cooling down');
+    expect(
+      credentialHealthLabel({
+        ...credentials[0],
+        health_status: 'invalid',
+        is_enabled: false,
+      }),
+    ).toBe('Invalid · disabled');
+  });
+});

--- a/frontend/src/lib/provider-credentials.ts
+++ b/frontend/src/lib/provider-credentials.ts
@@ -1,0 +1,64 @@
+import type {
+  CredentialStrategy,
+  ProviderCredentialInfo,
+} from '$lib/provider-credential-types';
+
+export function credentialStrategyLabel(strategy: CredentialStrategy): string {
+  if (strategy === 'failover') return 'Automatic failover';
+  if (strategy === 'round_robin') return 'Round robin';
+  return 'Manual';
+}
+
+export function credentialStrategyDescription(strategy: CredentialStrategy): string {
+  if (strategy === 'failover') {
+    return 'Use the active credential first, then try another healthy credential when it is unavailable.';
+  }
+  if (strategy === 'round_robin') {
+    return 'Distribute new requests across healthy credentials in sequence.';
+  }
+  return 'Always use the credential marked as active.';
+}
+
+export function enabledCredentialCount(
+  credentials: ProviderCredentialInfo[],
+): number {
+  return credentials.filter((credential) => credential.is_enabled).length;
+}
+
+export function canUseAutomaticStrategy(
+  credentials: ProviderCredentialInfo[],
+): boolean {
+  return enabledCredentialCount(credentials) >= 2;
+}
+
+export function credentialHealthLabel(
+  credential: ProviderCredentialInfo,
+): string {
+  if (!credential.is_enabled || credential.health_status === 'invalid') {
+    return 'Invalid · disabled';
+  }
+  if (credential.health_status === 'rate_limited') {
+    return credential.cooldown_until
+      ? 'Rate limited · cooling down'
+      : 'Rate limited';
+  }
+  if (credential.health_status === 'degraded') return 'Temporarily unavailable';
+  if (credential.health_status === 'healthy') return 'Healthy';
+  if (credential.health_status === 'unhealthy') return 'Connection failed';
+  return 'Not tested';
+}
+
+export function credentialHealthTone(
+  credential: ProviderCredentialInfo,
+): 'neutral' | 'success' | 'warning' | 'danger' {
+  if (!credential.is_enabled || credential.health_status === 'invalid') return 'danger';
+  if (credential.health_status === 'healthy') return 'success';
+  if (
+    credential.health_status === 'rate_limited' ||
+    credential.health_status === 'degraded'
+  ) {
+    return 'warning';
+  }
+  if (credential.health_status === 'unhealthy') return 'danger';
+  return 'neutral';
+}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -14,13 +14,16 @@
     type CatalogProviderInfo,
   } from '$lib/llm-catalog';
   import {
+    credentialStrategyLabel,
+  } from '$lib/provider-credentials';
+  import type { CredentialIntegrationInfo } from '$lib/provider-credential-types';
+  import {
     groupIntegrations,
     integrationModelKind,
     settingsOverview,
     type IntegrationModelKind,
   } from '$lib/settings-integrations';
   import { toastState } from '$lib/toast.svelte';
-  import type { IntegrationInfo } from '$lib/types';
   import {
     Activity,
     BarChart3,
@@ -33,6 +36,7 @@
     Pencil,
     Plus,
     Settings,
+    ShieldCheck,
     Trash2,
     Zap,
   } from '@lucide/svelte';
@@ -41,7 +45,7 @@
   let modalProviderId = $state('');
   let modalModel = $state('');
   let modalApiKeyConfigured = $state(false);
-  let integrations: IntegrationInfo[] = $state([]);
+  let integrations: CredentialIntegrationInfo[] = $state([]);
   let providers: CatalogProviderInfo[] = $state([]);
   let loading = $state(true);
   let activating = $state('');
@@ -89,7 +93,7 @@
         getIntegrations(),
         getModels(),
       ]);
-      integrations = integrationsResponse.integrations;
+      integrations = integrationsResponse.integrations as CredentialIntegrationInfo[];
       providers = modelsResponse.providers as CatalogProviderInfo[];
     } catch {
       toastState.error('Failed to load AI integrations.');
@@ -102,7 +106,7 @@
     return providers.find((provider) => provider.id === providerId);
   }
 
-  function openEdit(integration: IntegrationInfo) {
+  function openEdit(integration: CredentialIntegrationInfo) {
     modalProviderId = integration.id;
     modalModel = integration.current_model ?? '';
     modalApiKeyConfigured = integration.api_key_configured;
@@ -128,13 +132,13 @@
     disconnecting = providerId;
     try {
       const response = await disconnectProvider(providerId);
-      integrations = response.integrations;
+      integrations = response.integrations as CredentialIntegrationInfo[];
       const nextStates = { ...testStates };
       delete nextStates[providerId];
       testStates = nextStates;
       testSummary = null;
       await invalidateAll();
-      toastState.success('Provider disconnected.');
+      toastState.success('Provider disconnected and credentials removed.');
     } catch {
       toastState.error('Failed to disconnect provider.');
     } finally {
@@ -189,37 +193,33 @@
   }
 
   function modelKindClass(kind: IntegrationModelKind): string {
-    if (kind === 'catalog') {
-      return 'bg-blue-100 text-blue-700 dark:bg-blue-950/60 dark:text-blue-300';
-    }
-    if (kind === 'custom') {
-      return 'bg-purple-100 text-purple-700 dark:bg-purple-950/60 dark:text-purple-300';
-    }
+    if (kind === 'catalog') return 'bg-blue-100 text-blue-700 dark:bg-blue-950/60 dark:text-blue-300';
+    if (kind === 'custom') return 'bg-purple-100 text-purple-700 dark:bg-purple-950/60 dark:text-purple-300';
     return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-950/60 dark:text-yellow-300';
   }
 
   const grouped = $derived(groupIntegrations(integrations));
+  const connected = $derived(grouped.connected as CredentialIntegrationInfo[]);
+  const available = $derived(grouped.available as CredentialIntegrationInfo[]);
   const overview = $derived(settingsOverview(integrations));
   const testableIntegrations = $derived(connectedIntegrations(integrations));
+  const credentialTotal = $derived(
+    integrations.reduce((total, integration) => total + (integration.credential_count ?? 0), 0),
+  );
 </script>
 
 <div class="mx-auto max-w-5xl space-y-8">
   <header class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
     <div>
       <h1 class="flex items-center gap-2 text-2xl font-bold tracking-tight">
-        <Settings class="h-6 w-6 text-primary" />
-        AI Settings
+        <Settings class="h-6 w-6 text-primary" />AI Settings
       </h1>
       <p class="mt-1 max-w-2xl text-sm text-muted-foreground">
-        Connect providers, choose the active model, and verify every integration from one place.
+        Connect providers, manage credentials, choose the active model, and verify every integration.
       </p>
     </div>
-    <a
-      href="/usage"
-      class="inline-flex w-fit items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm font-medium text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground"
-    >
-      <BarChart3 class="h-4 w-4" />
-      View usage
+    <a href="/usage" class="inline-flex w-fit items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm font-medium text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground">
+      <BarChart3 class="h-4 w-4" />View usage
     </a>
   </header>
 
@@ -227,110 +227,60 @@
     <section class="animate-pulse overflow-hidden rounded-2xl border border-border bg-card">
       <div class="h-40 bg-muted/50"></div>
       <div class="grid grid-cols-3 gap-px border-t border-border bg-border">
-        {#each [1, 2, 3] as _}
-          <div class="h-20 bg-card"></div>
-        {/each}
+        {#each [1, 2, 3] as _}<div class="h-20 bg-card"></div>{/each}
       </div>
     </section>
     <div class="overflow-hidden rounded-xl border border-border bg-card">
-      {#each [1, 2, 3] as _, index}
-        <div class="h-28 animate-pulse bg-muted/20 {index < 2 ? 'border-b border-border' : ''}"></div>
-      {/each}
+      {#each [1, 2, 3] as _, index}<div class="h-28 animate-pulse bg-muted/20 {index < 2 ? 'border-b border-border' : ''}"></div>{/each}
     </div>
   {:else}
     <section class="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
       <div class="grid gap-6 p-5 sm:p-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
         <div class="flex min-w-0 items-start gap-4">
           <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
-            {#if overview.active}
-              <Zap class="h-5 w-5" />
-            {:else}
-              <CircleAlert class="h-5 w-5" />
-            {/if}
+            {#if overview.active}<Zap class="h-5 w-5" />{:else}<CircleAlert class="h-5 w-5" />{/if}
           </div>
           <div class="min-w-0">
-            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-              Active configuration
-            </p>
+            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">Active configuration</p>
             {#if overview.active}
               <div class="mt-1 flex flex-wrap items-center gap-2">
                 <h2 class="text-lg font-semibold">{overview.active.label}</h2>
                 <span class="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-[11px] font-semibold text-green-700 dark:bg-green-950/60 dark:text-green-300">
-                  <span class="h-1.5 w-1.5 rounded-full bg-green-500"></span>
-                  Active
+                  <span class="h-1.5 w-1.5 rounded-full bg-green-500"></span>Active
                 </span>
               </div>
-              <code class="mt-1 block break-all text-sm text-muted-foreground">
-                {overview.active.current_model ?? 'No model selected'}
-              </code>
+              <code class="mt-1 block break-all text-sm text-muted-foreground">{overview.active.current_model ?? 'No model selected'}</code>
             {:else}
               <h2 class="mt-1 text-lg font-semibold">No active provider</h2>
-              <p class="mt-1 text-sm text-muted-foreground">
-                Connect a provider below, then set it as active to enable AI features.
-              </p>
+              <p class="mt-1 text-sm text-muted-foreground">Connect a provider below, then set it as active to enable AI features.</p>
             {/if}
           </div>
         </div>
-
         <div class="lg:text-right">
-          <button
-            onclick={handleTestAll}
-            disabled={testingAll || testableIntegrations.length === 0}
-            class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
-          >
-            {#if testingAll}
-              <Loader2 class="h-4 w-4 animate-spin" />
-              Testing all…
-            {:else}
-              <Activity class="h-4 w-4" />
-              Test all connected
-            {/if}
+          <button onclick={handleTestAll} disabled={testingAll || testableIntegrations.length === 0} class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto">
+            {#if testingAll}<Loader2 class="h-4 w-4 animate-spin" />Testing all…{:else}<Activity class="h-4 w-4" />Test all connected{/if}
           </button>
-          <p class="mt-2 max-w-sm text-xs text-muted-foreground lg:max-w-xs">
-            Sends one minimal request to each connected provider and may incur a small charge.
-          </p>
+          <p class="mt-2 max-w-sm text-xs text-muted-foreground lg:max-w-xs">Sends one minimal request to each connected provider and may incur a small charge.</p>
         </div>
       </div>
-
       <div class="grid gap-px border-t border-border bg-border sm:grid-cols-3">
+        <div class="bg-card px-5 py-4"><p class="text-2xl font-semibold">{overview.connectedCount}</p><p class="text-xs text-muted-foreground">Connected providers</p></div>
+        <div class="bg-card px-5 py-4"><p class="text-2xl font-semibold">{credentialTotal}</p><p class="text-xs text-muted-foreground">Credentials saved</p></div>
         <div class="bg-card px-5 py-4">
-          <p class="text-2xl font-semibold">{overview.connectedCount}</p>
-          <p class="text-xs text-muted-foreground">Connected providers</p>
-        </div>
-        <div class="bg-card px-5 py-4">
-          <p class="text-2xl font-semibold">{overview.credentialCount}</p>
-          <p class="text-xs text-muted-foreground">Credentials saved</p>
-        </div>
-        <div class="bg-card px-5 py-4">
-          {#if testSummary}
-            <p class="text-2xl font-semibold">{testSummary.passed}/{testSummary.total}</p>
-            <p class="text-xs text-muted-foreground">
-              Passed latest test{testSummary.failed ? ` · ${testSummary.failed} failed` : ''}
-            </p>
-          {:else}
-            <p class="text-2xl font-semibold">—</p>
-            <p class="text-xs text-muted-foreground">Not tested this session</p>
-          {/if}
+          {#if testSummary}<p class="text-2xl font-semibold">{testSummary.passed}/{testSummary.total}</p><p class="text-xs text-muted-foreground">Passed latest test{testSummary.failed ? ` · ${testSummary.failed} failed` : ''}</p>{:else}<p class="text-2xl font-semibold">—</p><p class="text-xs text-muted-foreground">Not tested this session</p>{/if}
         </div>
       </div>
     </section>
 
     <section class="space-y-4">
       <div class="flex flex-wrap items-end justify-between gap-3">
-        <div>
-          <h2 class="text-base font-semibold">Connected</h2>
-          <p class="text-sm text-muted-foreground">
-            Providers ready to use with their saved model and credential.
-          </p>
-        </div>
-        <span class="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
-          {grouped.connected.length} configured
-        </span>
+        <div><h2 class="text-base font-semibold">Connected</h2><p class="text-sm text-muted-foreground">Providers ready to use with their saved models and credentials.</p></div>
+        <span class="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">{connected.length} configured</span>
       </div>
 
-      {#if grouped.connected.length > 0}
+      {#if connected.length > 0}
         <div class="divide-y divide-border overflow-visible rounded-xl border border-border bg-card shadow-sm">
-          {#each grouped.connected as integration}
+          {#each connected as integration}
             {@const color = PROVIDER_COLORS[integration.id] ?? '#6b7280'}
             {@const mark = PROVIDER_MARKS[integration.id] ?? integration.label.slice(0, 2).toUpperCase()}
             {@const provider = providerFor(integration.id)}
@@ -339,62 +289,25 @@
             <article class="relative p-4 transition-colors hover:bg-accent/20 sm:p-5">
               <div class="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
                 <div class="flex min-w-0 items-start gap-3">
-                  <div
-                    class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-[11px] font-bold"
-                    style="background:{color}18; color:{color}"
-                    aria-hidden="true"
-                  >
-                    {mark}
-                  </div>
-
+                  <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-[11px] font-bold" style="background:{color}18; color:{color}" aria-hidden="true">{mark}</div>
                   <div class="min-w-0 flex-1">
                     <div class="flex flex-wrap items-center gap-2">
                       <h3 class="font-semibold">{integration.label}</h3>
-                      {#if integration.is_active}
-                        <span class="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
-                          <Zap class="h-2.5 w-2.5" />
-                          Active
-                        </span>
-                      {/if}
-                      {#if modelKind}
-                        <span class={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase ${modelKindClass(modelKind)}`}>
-                          {modelKindLabel(modelKind)}
-                        </span>
-                      {/if}
+                      {#if integration.is_active}<span class="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary"><Zap class="h-2.5 w-2.5" />Active</span>{/if}
+                      {#if modelKind}<span class={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase ${modelKindClass(modelKind)}`}>{modelKindLabel(modelKind)}</span>{/if}
+                      {#if !provider?.local}<span class="rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase text-muted-foreground">{credentialStrategyLabel(integration.credential_strategy)}</span>{/if}
                     </div>
-
-                    <code class="mt-1 block break-all text-sm font-medium text-foreground">
-                      {integration.current_model ?? 'No model selected'}
-                    </code>
-
+                    <code class="mt-1 block break-all text-sm font-medium text-foreground">{integration.current_model ?? 'No model selected'}</code>
                     {#if modelKind === 'unavailable'}
-                      <p class="mt-1 flex items-start gap-1.5 text-xs text-yellow-700 dark:text-yellow-300">
-                        <CircleAlert class="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                        <span>Model is no longer in the catalog — edit this provider to replace it.</span>
-                      </p>
+                      <p class="mt-1 flex items-start gap-1.5 text-xs text-yellow-700 dark:text-yellow-300"><CircleAlert class="mt-0.5 h-3.5 w-3.5 shrink-0" /><span>Model is no longer in the catalog — edit this provider to replace it.</span></p>
                     {/if}
-
                     <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
                       <span class="inline-flex min-w-0 items-center gap-1.5">
-                        {#if provider?.local}
-                          <CircleCheck class="h-3.5 w-3.5 shrink-0 text-blue-500" />
-                          Local · ready on this device
-                        {:else}
-                          <KeyRound class="h-3.5 w-3.5 shrink-0 text-green-500" />
-                          <span class="break-all">{integration.masked_api_key ?? 'Credential stored securely'}</span>
-                        {/if}
+                        {#if provider?.local}<CircleCheck class="h-3.5 w-3.5 shrink-0 text-blue-500" />Local · ready on this device{:else}<KeyRound class="h-3.5 w-3.5 shrink-0 text-green-500" />{integration.credential_count} credential{integration.credential_count === 1 ? '' : 's'} · Active key: {integration.active_credential_label ?? 'None'}{/if}
                       </span>
-
                       {#if testState}
                         <span class="inline-flex items-center gap-1.5 {testState.status === 'success' ? 'text-green-700 dark:text-green-300' : testState.status === 'failure' ? 'text-red-700 dark:text-red-300' : 'text-muted-foreground'}">
-                          {#if testState.status === 'testing'}
-                            <Loader2 class="h-3.5 w-3.5 shrink-0 animate-spin" />
-                          {:else if testState.status === 'success'}
-                            <CircleCheck class="h-3.5 w-3.5 shrink-0" />
-                          {:else}
-                            <CircleAlert class="h-3.5 w-3.5 shrink-0" />
-                          {/if}
-                          {testState.message}
+                          {#if testState.status === 'testing'}<Loader2 class="h-3.5 w-3.5 shrink-0 animate-spin" />{:else if testState.status === 'success'}<CircleCheck class="h-3.5 w-3.5 shrink-0" />{:else}<CircleAlert class="h-3.5 w-3.5 shrink-0" />{/if}{testState.message}
                         </span>
                       {/if}
                     </div>
@@ -406,95 +319,30 @@
                     {#if confirmingActivate === integration.id}
                       <div class="flex w-full flex-wrap items-center gap-2 rounded-lg border border-primary/20 bg-primary/5 p-2 lg:w-auto">
                         <span class="mr-auto text-xs">Set {integration.label} as active?</span>
-                        <button
-                          onclick={() => handleActivate(integration.id)}
-                          disabled={activating === integration.id}
-                          class="rounded-md bg-primary px-2.5 py-1.5 text-xs font-semibold text-primary-foreground disabled:opacity-50"
-                        >
-                          {activating === integration.id ? 'Switching…' : 'Confirm'}
-                        </button>
-                        <button
-                          onclick={() => (confirmingActivate = '')}
-                          class="rounded-md px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent"
-                        >
-                          Cancel
-                        </button>
+                        <button onclick={() => handleActivate(integration.id)} disabled={activating === integration.id} class="rounded-md bg-primary px-2.5 py-1.5 text-xs font-semibold text-primary-foreground disabled:opacity-50">{activating === integration.id ? 'Switching…' : 'Confirm'}</button>
+                        <button onclick={() => (confirmingActivate = '')} class="rounded-md px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent">Cancel</button>
                       </div>
                     {:else}
-                      <button
-                        onclick={() => (confirmingActivate = integration.id)}
-                        class="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 sm:flex-none"
-                      >
-                        <Zap class="h-3.5 w-3.5" />
-                        Set active
-                      </button>
+                      <button onclick={() => (confirmingActivate = integration.id)} class="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 sm:flex-none"><Zap class="h-3.5 w-3.5" />Set active</button>
                     {/if}
                   {/if}
-
-                  <button
-                    onclick={() => handleTestIntegration(integration.id)}
-                    disabled={testingAll || testState?.status === 'testing'}
-                    class="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-border px-3 py-2 text-sm font-medium transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 sm:flex-none"
-                  >
-                    {#if testState?.status === 'testing'}
-                      <Loader2 class="h-3.5 w-3.5 animate-spin" />
-                      Testing…
-                    {:else}
-                      <Activity class="h-3.5 w-3.5" />
-                      Test
-                    {/if}
+                  <button onclick={() => handleTestIntegration(integration.id)} disabled={testingAll || testState?.status === 'testing'} class="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-border px-3 py-2 text-sm font-medium transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 sm:flex-none">
+                    {#if testState?.status === 'testing'}<Loader2 class="h-3.5 w-3.5 animate-spin" />Testing…{:else}<Activity class="h-3.5 w-3.5" />Test{/if}
                   </button>
-
-                  <button
-                    onclick={() => openEdit(integration)}
-                    class="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-border px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground sm:flex-none"
-                  >
-                    <Pencil class="h-3.5 w-3.5" />
-                    Edit
-                  </button>
-
+                  <button onclick={() => openEdit(integration)} class="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-border px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground sm:flex-none"><Pencil class="h-3.5 w-3.5" />Edit</button>
                   {#if integration.api_key_configured && !integration.is_active && integration.id !== 'ollama'}
                     <details class="relative shrink-0">
-                      <summary
-                        class="flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded-lg border border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground [&::-webkit-details-marker]:hidden"
-                        aria-label={`More actions for ${integration.label}`}
-                      >
-                        <MoreHorizontal class="h-4 w-4" />
-                      </summary>
-                      <div class="absolute right-0 z-20 mt-2 w-60 rounded-lg border border-border bg-popover p-3 text-popover-foreground shadow-lg">
+                      <summary class="flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded-lg border border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground [&::-webkit-details-marker]:hidden" aria-label={`More actions for ${integration.label}`}><MoreHorizontal class="h-4 w-4" /></summary>
+                      <div class="absolute right-0 z-20 mt-2 w-64 rounded-lg border border-border bg-popover p-3 text-popover-foreground shadow-lg">
                         {#if confirmingDisconnect === integration.id}
-                          <p class="text-sm font-medium">Remove saved credential?</p>
-                          <p class="mt-1 text-xs text-muted-foreground">
-                            This provider will move back to Available providers.
-                          </p>
+                          <p class="text-sm font-medium">Disconnect {integration.label}?</p>
+                          <p class="mt-1 text-xs text-muted-foreground">All {integration.credential_count} saved credentials for this provider will be permanently removed.</p>
                           <div class="mt-3 flex gap-2">
-                            <button
-                              onclick={() => handleDisconnect(integration.id)}
-                              disabled={disconnecting === integration.id}
-                              class="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md bg-destructive px-2.5 py-1.5 text-xs font-semibold text-destructive-foreground disabled:opacity-50"
-                            >
-                              {#if disconnecting === integration.id}
-                                <Loader2 class="h-3 w-3 animate-spin" />
-                              {:else}
-                                <Trash2 class="h-3 w-3" />
-                              {/if}
-                              Remove
-                            </button>
-                            <button
-                              onclick={() => (confirmingDisconnect = '')}
-                              class="rounded-md border border-border px-2.5 py-1.5 text-xs hover:bg-accent"
-                            >
-                              Cancel
-                            </button>
+                            <button onclick={() => handleDisconnect(integration.id)} disabled={disconnecting === integration.id} class="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md bg-destructive px-2.5 py-1.5 text-xs font-semibold text-destructive-foreground disabled:opacity-50">{#if disconnecting === integration.id}<Loader2 class="h-3 w-3 animate-spin" />{:else}<Trash2 class="h-3 w-3" />{/if}Disconnect</button>
+                            <button onclick={() => (confirmingDisconnect = '')} class="rounded-md border border-border px-2.5 py-1.5 text-xs hover:bg-accent">Cancel</button>
                           </div>
                         {:else}
-                          <button
-                            onclick={() => (confirmingDisconnect = integration.id)}
-                            class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-destructive hover:bg-destructive/10"
-                          >
-                            <Trash2 class="h-4 w-4" />
-                            Remove credential
-                          </button>
+                          <button onclick={() => (confirmingDisconnect = integration.id)} class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-destructive hover:bg-destructive/10"><Trash2 class="h-4 w-4" />Disconnect and remove all keys</button>
                         {/if}
                       </div>
                     </details>
@@ -506,83 +354,30 @@
         </div>
       {:else}
         <div class="rounded-xl border border-dashed border-border bg-muted/20 px-6 py-10 text-center">
-          <div class="mx-auto flex h-11 w-11 items-center justify-center rounded-full bg-muted">
-            <Plus class="h-5 w-5 text-muted-foreground" />
-          </div>
+          <div class="mx-auto flex h-11 w-11 items-center justify-center rounded-full bg-muted"><Plus class="h-5 w-5 text-muted-foreground" /></div>
           <h3 class="mt-3 font-medium">No providers connected yet</h3>
-          <p class="mt-1 text-sm text-muted-foreground">
-            Choose a provider from the list below to configure your first AI model.
-          </p>
+          <p class="mt-1 text-sm text-muted-foreground">Choose a provider below to configure your first AI model.</p>
         </div>
       {/if}
     </section>
 
-    {#if grouped.available.length > 0}
+    {#if available.length > 0}
       <section class="space-y-4">
-        <div>
-          <h2 class="text-base font-semibold">Available providers</h2>
-          <p class="text-sm text-muted-foreground">
-            Add another provider now and switch between models whenever you need.
-          </p>
-        </div>
-
+        <div><h2 class="text-base font-semibold">Available providers</h2><p class="text-sm text-muted-foreground">Add another provider and switch between models whenever you need.</p></div>
         <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {#each grouped.available as integration}
+          {#each available as integration}
             {@const color = PROVIDER_COLORS[integration.id] ?? '#6b7280'}
             {@const mark = PROVIDER_MARKS[integration.id] ?? integration.label.slice(0, 2).toUpperCase()}
             {@const provider = providerFor(integration.id)}
             <article class="flex flex-col rounded-xl border border-border bg-card p-4 transition-colors hover:border-primary/30 hover:bg-accent/20">
               <div class="flex items-start gap-3">
-                <div
-                  class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-[11px] font-bold"
-                  style="background:{color}18; color:{color}"
-                  aria-hidden="true"
-                >
-                  {mark}
-                </div>
-                <div class="min-w-0 flex-1">
-                  <h3 class="font-medium">{integration.label}</h3>
-                  <p class="mt-0.5 text-xs text-muted-foreground">
-                    {#if provider?.local}
-                      Local · no API key
-                    {:else if provider?.auth_type === 'token'}
-                      Access token required
-                    {:else}
-                      API key required
-                    {/if}
-                  </p>
-                </div>
+                <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-[11px] font-bold" style="background:{color}18; color:{color}" aria-hidden="true">{mark}</div>
+                <div class="min-w-0 flex-1"><h3 class="font-medium">{integration.label}</h3><p class="mt-0.5 text-xs text-muted-foreground">{#if provider?.local}Local · no API key{:else if provider?.auth_type === 'token'}Access token required{:else}API key required{/if}</p></div>
               </div>
-
-              <p class="mt-4 flex-1 text-sm text-muted-foreground">
-                {#if provider?.local}
-                  Run supported models locally without sending a credential to ApplyKit.
-                {:else}
-                  Save a provider credential and select the model you want ApplyKit to use.
-                {/if}
-              </p>
-
+              <p class="mt-4 flex-1 text-sm text-muted-foreground">{#if provider?.local}Run supported models locally without sending a credential to ApplyKit.{:else}Add one or more credentials and select the model ApplyKit should use.{/if}</p>
               <div class="mt-4 flex items-center justify-between gap-3">
-                {#if provider?.credential_url}
-                  <a
-                    href={provider.credential_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
-                  >
-                    {credentialActionLabel(provider.auth_type)}
-                    <ExternalLink class="h-3 w-3" />
-                  </a>
-                {:else}
-                  <span class="text-xs text-muted-foreground">Ready to configure</span>
-                {/if}
-                <button
-                  onclick={() => openEdit(integration)}
-                  class="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
-                >
-                  <Plus class="h-3.5 w-3.5" />
-                  Connect
-                </button>
+                {#if provider?.credential_url}<a href={provider.credential_url} target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">{credentialActionLabel(provider.auth_type)}<ExternalLink class="h-3 w-3" /></a>{:else}<span class="text-xs text-muted-foreground">Ready to configure</span>{/if}
+                <button onclick={() => openEdit(integration)} class="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"><Plus class="h-3.5 w-3.5" />Connect</button>
               </div>
             </article>
           {/each}
@@ -592,9 +387,4 @@
   {/if}
 </div>
 
-<SettingsModal
-  bind:open={modalOpen}
-  initialProviderId={modalProviderId}
-  initialModel={modalModel}
-  initialApiKeyConfigured={modalApiKeyConfigured}
-/>
+<SettingsModal bind:open={modalOpen} initialProviderId={modalProviderId} initialModel={modalModel} initialApiKeyConfigured={modalApiKeyConfigured} />


### PR DESCRIPTION
## Summary
- add a full multi-credential manager inside the provider settings modal
- list masked credentials with label, active state, health, cooldown, priority, and last-used metadata
- add, rename, replace, test, activate, and remove individual credentials
- clear raw credential inputs after every completed request
- configure Manual, Automatic Failover, or Round Robin per provider
- require at least two enabled credentials before selecting an automatic strategy
- configure bounded automatic retry attempts from 2 to 5
- keep the simple one-credential flow for the global first-time settings modal
- show total credential count, active credential label, and selected strategy in the compact Settings list
- make disconnect semantics explicit when all provider credentials will be removed
- clear the active model when the final credential for its active provider is removed

## UX behavior
- Manual remains the default
- Automatic failover is marked Recommended
- Round robin is marked Advanced
- provider-level Test uses the active credential and selected policy at runtime
- per-credential Test validates one specific key
- secrets and encrypted values are never returned to the frontend

## Verification
- Frontend unit tests: success
- Svelte type-check: success
- production build: success
- Backend CI Python 3.12: success
- Backend CI Python 3.13: success
- 119 backend tests: success

No tag or release is included.