### PR TITLE
feat: simplify provider settings modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,96 +6,28 @@
 [![Python](https://img.shields.io/badge/Python-3.12-blue)](https://python.org)
 [![SvelteKit](https://img.shields.io/badge/SvelteKit-2-orange)](https://kit.svelte.dev)
 
-**Self-hosted, local-first CV and cover letter generator powered by AI.**
-Your data stays on your machine — no cloud, no account, no subscription.
+**Self-hosted, local-first tools for creating tailored CVs, cover letters, and job applications with AI.**
 
-> ⚠️ **Self-hosted only.** ApplyKit is designed to run locally or on your own server. It has no authentication — do not expose it to the public internet without adding your own auth layer.
+ApplyKit stores profiles, generated documents, application history, and provider credentials on infrastructure you control. No account or subscription is required.
 
----
+> **Self-hosted only.** ApplyKit has no built-in authentication. Keep it on localhost or protect remote deployments with an authentication proxy such as Cloudflare Access, Authelia, or Nginx basic auth.
 
-## Features
+## Highlights
 
-- **Multi-profile support** — create separate profiles for different roles (e.g. "Software Engineer", "Product Manager"), each with its own history and color
-- **AI CV generation** — rewrites bullet points and summary to be ATS-optimized for a specific job description
-- **AI cover letter generation** — writes a tailored cover letter from your profile + job description in seconds
-- **CV import** — paste or upload an existing PDF/DOCX and AI extracts your profile automatically
-- **Job URL scraper** — paste a job posting URL and AI extracts the description
-- **Fit analysis** — see how well your profile matches a job description with match score, strengths, gaps, and red flags
-- **Smart Apply** — paste a URL, auto-parse job details, and generate a tailored CV + cover letter in one flow
-- **Job application tracker** — Kanban board for tracking applications through Applied → Interviewing → Offer → Rejected
-- **History** — every generated CV and cover letter is saved, browsable, and filterable by profile
-- **PDF export** — download as PDF or use browser print (A4 format)
-- **LLM-agnostic** — works with Gemini, OpenAI, Anthropic, or any local model via Ollama
-- **Works without an API key** — CV generation falls back to your raw profile data if no LLM is configured
-- **Dark mode** — full dark theme support
-
----
-
-## How It Works
-
-```
-Browser (localhost:5173)
-       │
-       ▼
-  SvelteKit Frontend
-  - Profile editor (multi-profile)
-  - CV preview & export
-  - Cover letter editor
-  - Fit analysis
-  - Job tracker (Kanban)
-  - History browser
-       │  HTTP (REST API)
-       ▼
-  FastAPI Backend (localhost:8000)
-  - Profile CRUD (SQLite, multi-profile)
-  - CV import (PDF/DOCX/text → LLM extraction)
-  - ATS CV enhancement (LLM)
-  - Cover letter generation (LLM)
-  - Fit score analysis (LLM)
-  - Job URL scraping (Jina + Crawl4AI)
-  - PDF export (WeasyPrint)
-  - Generation history
-       │
-       ▼
-  LiteLLM → any LLM provider (Gemini, OpenAI, Anthropic, Ollama...)
-```
-
----
-
-## Stack
-
-| Layer | Technology |
-|-------|-----------|
-| Frontend | SvelteKit 2 + Svelte 5 (runes) + TypeScript |
-| Styling | Tailwind CSS v4 + shadcn-svelte |
-| Backend | FastAPI + Python 3.12 |
-| Database | SQLite via SQLAlchemy 2.0 + Alembic |
-| AI | LiteLLM (configured via UI Settings) |
-| PDF | WeasyPrint (server-side) + browser print (client-side) |
-| CV parsing | pdfplumber (PDF), python-docx (DOCX) |
-| Job scraping | Jina Reader (primary) + Crawl4AI (fallback) + LLM parsing |
-| Package managers | uv (Python), Bun (JavaScript) |
-
----
-
-## Prerequisites
-
-- [uv](https://docs.astral.sh/uv/) — Python package manager
-- [Bun](https://bun.sh/) — JavaScript runtime
-- **WeasyPrint system dependencies** (for PDF generation):
-  - Ubuntu/Debian: `apt-get install libcairo2 libpango-1.0-0 libgdk-pixbuf2.0-0 libffi7 shared-mime-info`
-  - macOS: `brew install cairo pango gdk-pixbuf`
-  - Windows: Included in the WeasyPrint pip package
-- An LLM API key (optional — required for AI features):
-  - [Google AI Studio](https://aistudio.google.com/) for Gemini (recommended, has a generous free tier)
-  - [OpenAI](https://platform.openai.com/), [Anthropic](https://console.anthropic.com/), or any [LiteLLM-supported provider](https://docs.litellm.ai/docs/providers)
-  - Or [Ollama](https://ollama.com/) for fully local, offline usage
-
----
+- Multiple role-specific profiles
+- CV import from PDF, DOCX, or pasted text
+- ATS-focused CV enhancement and PDF export
+- Tailored cover letters with streaming output
+- Job URL parsing, fit analysis, and Smart Apply
+- Kanban application tracker and generation history
+- Token, cost, latency, and error usage reporting
+- Curated models for Gemini, OpenAI, Anthropic, DeepSeek, Groq, Mistral, Hugging Face, OpenRouter, xAI, and Ollama
+- Multiple encrypted credentials per provider
+- Manual selection, automatic failover, and round-robin credential routing
 
 ## Quick Start
 
-### Option A — Docker (recommended)
+### Docker
 
 ```bash
 git clone https://github.com/wihlarkop/applykit.git
@@ -103,351 +35,127 @@ cd applykit
 docker compose up --build
 ```
 
-Open **http://localhost:3000** — your data is stored in a Docker volume and persists across restarts.
+Open `http://localhost:3000`.
 
-### Option B — Manual
+The backend is available at `http://localhost:8000`, and persistent data is stored in the Docker volume `applykit_applykit-data`.
+
+### Manual development setup
+
+Requirements: [uv](https://docs.astral.sh/uv/) and [Bun](https://bun.sh/).
 
 ```bash
-# 1. Clone
 git clone https://github.com/wihlarkop/applykit.git
 cd applykit
-
-# 2. Configure
 cp backend/.env.example backend/.env
-
-# 3. Install dependencies
 make install
-
-# 4. Run database migrations
 make migrate
-
-# 5. Start (two separate terminals)
-make backend    # http://localhost:8000
-make frontend   # http://localhost:5173
 ```
 
-Open **http://localhost:5173** — you'll be guided through setup on first launch.
-
----
-
-## Docker
-
-### Default setup
+Start the backend and frontend in separate terminals:
 
 ```bash
-docker compose up --build
+make backend     # http://localhost:8000
+make frontend    # http://localhost:5173
 ```
 
-- Frontend: `http://localhost:3000`
-- Backend API: `http://localhost:8000`
-- SQLite data: persisted in a named Docker volume (`applykit_applykit-data`)
+## AI Providers and Credentials
 
-### Deploying to a remote server
+Open **AI Settings** from the gear icon to:
 
-If you're running on a server instead of localhost, set `VITE_API_BASE_URL` to your domain before building:
+- connect and test providers;
+- choose a catalog or supported custom model;
+- save multiple labeled credentials such as Personal, Work, and Backup;
+- choose the active credential manually;
+- enable **Automatic failover** for conservative retries;
+- enable **Round robin** to distribute requests across healthy credentials.
 
-```bash
-VITE_API_BASE_URL=https://api.yourdomain.com/api docker compose up --build
+Manual routing is the default. Automatic modes require at least two enabled credentials and allow 2–5 attempts per operation. Streaming requests are never retried after output has started.
+
+Ollama does not require an API key. Some non-AI features also remain usable without configuring a provider.
+
+## Credential Security and Backups
+
+Provider secrets are encrypted before being stored in the database. The API and frontend only receive masked values.
+
+For local installations, ApplyKit creates:
+
+```text
+backend/.applykit/credential.key
 ```
 
-Or edit the `args` block in `docker-compose.yml`:
+Back up this file together with `backend/applykit.db`. Encrypted credentials cannot be recovered without the same key.
 
-```yaml
-args:
-  VITE_API_BASE_URL: https://api.yourdomain.com/api
-```
-
-> `VITE_API_BASE_URL` is baked into the frontend at build time — the browser uses it to reach the backend. It must be publicly reachable from the user's machine.
-
-### Backing up your data
-
-SQLite is stored in a Docker volume. To export it:
+Docker stores both the SQLite database and encryption key in `/data`, so back up the complete volume:
 
 ```bash
 docker run --rm \
   -v applykit_applykit-data:/data \
-  -v $(pwd):/backup \
+  -v "$(pwd)":/backup \
   alpine tar czf /backup/applykit-backup.tar.gz /data
 ```
 
-### Useful Docker commands
+For managed deployments, set a persistent Fernet key instead of relying on a generated file:
 
-```bash
-docker compose up --build        # Build and start
-docker compose up -d             # Start in background
-docker compose down              # Stop
-docker compose logs -f backend   # Follow backend logs
-docker compose exec backend uv run alembic upgrade head  # Run migrations manually
+```env
+CREDENTIAL_ENCRYPTION_KEY=<persistent-fernet-key>
+MAX_PROVIDER_CREDENTIALS=20
 ```
 
----
-
-## Setup (Manual)
-
-### 1. Clone the repository
-
-```bash
-git clone https://github.com/your-username/applykit.git
-cd applykit
-```
-
-### 2. Configure the backend
-
-```bash
-cd backend
-cp .env.example .env
-```
-
-### 3. Install backend dependencies
-
-```bash
-uv sync
-```
-
-### 4. Run database migrations
-
-```bash
-uv run alembic upgrade head
-```
-
-### 5. Start the backend
-
-```bash
-uv run main.py
-# API: http://localhost:8000
-# Swagger UI: http://localhost:8000/docs
-```
-
-### 6. Install and start the frontend
-
-```bash
-cd ../frontend
-bun install
-bun run dev
-# Frontend: http://localhost:5173
-```
-
----
-
-## Makefile Commands
-
-```bash
-make install        # Install all dependencies (backend + frontend)
-make migrate        # Run database migrations
-make backend        # Start backend server (http://localhost:8000)
-make frontend       # Start frontend dev server (http://localhost:5173)
-make lint           # Lint frontend TypeScript/Svelte
-make migrate-new MSG="description"  # Create a new migration
-make migrate-down                   # Roll back the last migration
-make help           # Show all commands
-```
-
----
+Never rotate or delete the encryption key without first migrating the stored credentials.
 
 ## Configuration
 
-### Database
-
-Edit `backend/.env` to change the database path:
+Common backend variables in `backend/.env`:
 
 ```env
 DATABASE_URL=sqlite:///./applykit.db
+CORS_ORIGINS=["http://localhost:5173"]
+CREDENTIAL_KEY_FILE=.applykit/credential.key
+MAX_PROVIDER_CREDENTIALS=20
 ```
 
-SQLite is the default and requires no additional setup. PostgreSQL is on the roadmap.
+For a remote frontend build, set the browser-reachable API URL:
 
-### LLM Settings
+```bash
+VITE_API_BASE_URL=https://api.example.com/api docker compose up --build
+```
 
-LLM configuration (provider, API key, model) is managed via the **Settings** page in the UI — no need to edit `.env` manually.
+## Stack
 
-Click the **Settings** icon (gear) in the top navigation to connect a provider. You can connect multiple providers and switch between them at any time.
+- **Frontend:** SvelteKit 2, Svelte 5, TypeScript, Tailwind CSS
+- **Backend:** FastAPI, Python 3.12, SQLAlchemy, Alembic
+- **Database:** SQLite by default
+- **AI:** LiteLLM
+- **PDF:** WeasyPrint
+- **Scraping:** direct ATS APIs, Jina Reader, and Crawl4AI fallback
 
-> **No API key?** The app still works. CV generation falls back to your raw profile data without AI enhancement. Import, cover letter generation, and fit analysis require an LLM to be configured.
+## Useful Commands
 
----
+```bash
+make install
+make migrate
+make backend
+make frontend
+make lint
 
-## Usage
+docker compose up --build
+docker compose logs -f backend
+docker compose exec backend uv run alembic upgrade head
+```
 
-### 1. Create a profile
+## Supported Job Sources
 
-On first launch you'll be guided through setup. Fill in:
-- Personal info (name, email, location, LinkedIn, GitHub)
-- Work experience with bullet points
-- Education, skills, projects, certifications
-
-Or use **AI Sync** (sparkle button on the profile page) to upload an existing CV and auto-fill everything instantly.
-
-### 2. Generate a CV
-
-1. Go to **Generate CV**
-2. Optionally paste a job description — the AI will tailor bullet points to match its keywords
-3. Click **Generate ATS CV**
-4. Preview, then **Download PDF** or **Print**
-
-### 3. Write a cover letter
-
-1. Go to **Cover Letter**
-2. Fill in company name (optional), job description, and any emphasis notes
-3. Click **Write Cover Letter**
-4. Copy, download as PDF, or print
-
-### 4. Analyze job fit
-
-Paste a job description in the Cover Letter page and click **Analyze Fit** to see:
-- Match score (0–100%)
-- Strengths and gaps
-- Missing keywords
-- Red flags
-- Suggested emphasis for your cover letter
-
-### 5. Smart Apply
-
-1. Go to **Smart Apply**
-2. Paste a job posting URL — ApplyKit scrapes it automatically
-3. Review the extracted job details
-4. Generate a tailored CV + cover letter in one click
-
-### 6. Track applications
-
-Go to **Tracker** to add jobs, drag cards between stages, and link generated CVs and cover letters to each application.
-
-### 7. Browse history
-
-Go to **History** to see every generated CV and cover letter. Filter by profile, search, sort by match score, and preview or re-download any entry.
-
----
-
-## Smart Apply — Supported Job Boards
-
-### ATS Platforms (Direct API — Fastest)
-
-| Platform | Status |
-|----------|--------|
-| Greenhouse | ✅ Supported |
-| Lever | ✅ Supported |
-| Ashby | ✅ Supported |
-| JazzHR | 📋 Planned |
-| BambooHR | 📋 Planned |
-| Workday | 📋 Planned (requires browser automation) |
-
-### Generic Websites
-
-For boards without direct API support, Smart Apply uses Jina to scrape the page and an LLM to extract structured fields. This works on most job sites.
-
----
-
-## Security
-
-ApplyKit has **no built-in authentication**. It is designed to run:
-- On `localhost` for personal use (default)
-- On a private server with network-level access control
-
-**Do not expose ApplyKit to the public internet** without putting an auth proxy (e.g. Authelia, Nginx basic auth, Cloudflare Access) in front of it.
-
-All LLM API keys are stored in your local SQLite database and never leave your machine.
-
----
-
-## Roadmap
-
-Items marked ✅ are shipped. Items marked 📋 are planned.
-
-### Core App
-| Status | Feature |
-|--------|---------|
-| ✅ | Multi-profile support |
-| ✅ | ATS CV generation with job description tailoring |
-| ✅ | AI cover letter generation |
-| ✅ | CV import from PDF/DOCX |
-| ✅ | Fit score analysis (match %, strengths, gaps, red flags) |
-| ✅ | Job URL scraper (Greenhouse, Lever, Ashby + generic) |
-| ✅ | Smart Apply (URL → CV + CL in one flow) |
-| ✅ | Job application tracker (Kanban) |
-| ✅ | Generation history with search and filters |
-| ✅ | PDF export (WeasyPrint server-side + browser print) |
-| ✅ | LLM usage log with token/cost tracking |
-| ✅ | Docker Compose — one-command install |
-| 📋 | Docker: nginx reverse proxy so frontend + backend share port 80 |
-| 📋 | Docker: multi-arch builds (arm64 for Apple Silicon / Raspberry Pi) |
-| 📋 | Docker: pre-built images on GitHub Container Registry (ghcr.io) |
-| 📋 | PostgreSQL support |
-| ✅ | Real-time CV split-screen preview |
-| 📋 | One-click portfolio site generator |
-
-### AI Providers
-| Status | Provider |
-|--------|---------|
-| ✅ | Gemini (Google AI Studio) |
-| ✅ | OpenAI |
-| ✅ | Anthropic |
-| ✅ | Ollama (local, offline) |
-| ✅ | Any LiteLLM-compatible provider |
-| ✅ | Connect / disconnect providers from UI |
-| ✅ | Switch active provider with confirmation |
-
-### UX & Polish
-| Status | Feature |
-|--------|---------|
-| ✅ | Dark mode |
-| ✅ | Mobile-responsive layout |
-| ✅ | Toast notifications |
-| ✅ | Skeleton loading states |
-| ✅ | Onboarding flow |
-| ✅ | Profile color + icon picker |
-| ✅ | Confirm before overwriting profile via import |
-| ✅ | Warn when profile switch clears in-progress cover letter |
-| ✅ | Inline delete confirmation (no accidental deletions) |
-| ✅ | Tracker error state and no-results message |
-| ✅ | Fit analysis retry button |
-| ✅ | Red flags visually distinct from cons |
-| ✅ | Profile badge on CV history cards |
-| ✅ | Usage table mobile responsive |
-| 📋 | Keyboard shortcuts |
-| 📋 | Bulk export history |
-
-### Future Ideas
-| Feature | Description |
-|---------|-------------|
-| LinkedIn optimizer | AI-generated headlines and About sections |
-| Multi-language CV | One-click translation of the full profile |
-| Outreach generator | LinkedIn cold messages, recruiter emails, follow-ups |
-| Interview coach | Practice elevator pitch with voice feedback (Web Speech API) |
-| Browser extension | One-click Smart Apply from any job board |
-
----
+ApplyKit has direct parsing for Greenhouse, Lever, and Ashby. Other accessible job pages use the generic scraping and LLM extraction flow.
 
 ## Contributing
 
-Contributions are welcome! Here's how to get started:
+Focused pull requests are welcome. Follow the existing FastAPI and Svelte 5 patterns, add tests for behavior changes, and keep the local-first design intact.
 
-1. **Fork** the repository and create a branch: `git checkout -b feat/your-feature`
-2. **Set up** locally following the Quick Start guide above
-3. **Install pre-commit hooks** (one-time setup):
-   ```bash
-   bun install
-   bun x lefthook install
-   ```
-   This wires up automatic linting and formatting on every `git commit`. Requires [uv](https://docs.astral.sh/uv/) to be installed.
-4. **Make your changes** — keep PRs focused on a single feature or fix
-5. **Test** your changes manually (run both backend and frontend)
-6. **Submit a PR** with a clear description of what changed and why
-
-### Good first issues
-
-- Adding support for a new ATS platform in Smart Apply
-- Improving PDF export styling
-- Adding keyboard shortcuts
-- Translating the UI
-
-### Guidelines
-
-- Keep the self-hosted, local-first philosophy — no mandatory cloud services
-- Don't add authentication logic to the core app (out of scope)
-- Follow existing code style: Svelte 5 runes, Tailwind CSS, FastAPI patterns
-- For large features, open an issue first to discuss the approach
-
----
+```bash
+bun install
+bun x lefthook install
+```
 
 ## License
 
-MIT — see [LICENSE](LICENSE)
+MIT — see [LICENSE](LICENSE).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - applykit-data:/data
     environment:
       DATABASE_URL: sqlite:////data/applykit.db
+      CREDENTIAL_KEY_FILE: /data/credential.key
       CORS_ORIGINS: '["http://localhost:3000"]'
     restart: unless-stopped
 
@@ -26,5 +27,5 @@ services:
 
 volumes:
   applykit-data:
-    # SQLite database is stored here and persists across container restarts and rebuilds.
-    # To back up your data: docker run --rm -v applykit_applykit-data:/data -v $(pwd):/backup alpine tar czf /backup/applykit-backup.tar.gz /data
+    # SQLite and the credential encryption key are stored here.
+    # Back up the whole volume so encrypted credentials remain recoverable.

--- a/frontend/src/lib/components/ProviderCredentialsPanel.svelte
+++ b/frontend/src/lib/components/ProviderCredentialsPanel.svelte
@@ -13,20 +13,13 @@
     canUseAutomaticStrategy,
     credentialHealthLabel,
     credentialHealthTone,
-    credentialStrategyDescription,
-    credentialStrategyLabel,
   } from '$lib/provider-credentials';
-  import type {
-    CredentialPolicyResponse,
-    CredentialStrategy,
-    ProviderCredentialInfo,
-  } from '$lib/provider-credential-types';
+  import type { ProviderCredentialInfo } from '$lib/provider-credential-types';
   import type { TestConnectionResponse } from '$lib/types';
   import { errorMessage } from '$lib/utils';
   import {
     Activity,
     Check,
-    ChevronDown,
     CircleAlert,
     CircleCheck,
     ExternalLink,
@@ -34,10 +27,10 @@
     EyeOff,
     KeyRound,
     Loader2,
+    MoreHorizontal,
     Pencil,
     Plus,
     RefreshCw,
-    ShieldCheck,
     Trash2,
     X,
   } from '@lucide/svelte';
@@ -59,11 +52,6 @@
   type EditMode = 'rename' | 'replace' | 'remove' | null;
 
   let credentials: ProviderCredentialInfo[] = $state([]);
-  let policy: CredentialPolicyResponse = $state({
-    provider_id: '',
-    strategy: 'manual',
-    max_attempts: 2,
-  });
   let maxCredentials = $state(20);
   let loading = $state(true);
   let panelError = $state('');
@@ -79,7 +67,6 @@
   let editSecretVisible = $state(false);
   let testResults: Record<number, TestConnectionResponse> = $state({});
 
-  const automaticAvailable = $derived(canUseAutomaticStrategy(credentials));
   const enabledCount = $derived(
     credentials.filter((credential) => credential.is_enabled).length,
   );
@@ -94,13 +81,9 @@
     panelError = '';
     closeEditor();
     try {
-      const [credentialsResponse, policyResponse] = await Promise.all([
-        getProviderCredentials(providerId),
-        getCredentialPolicy(providerId),
-      ]);
-      credentials = credentialsResponse.credentials;
-      maxCredentials = credentialsResponse.max_credentials;
-      policy = policyResponse;
+      const response = await getProviderCredentials(providerId);
+      credentials = response.credentials;
+      maxCredentials = response.max_credentials;
     } catch (error) {
       panelError = errorMessage(error, 'Failed to load provider credentials.');
     } finally {
@@ -161,7 +144,10 @@
     if (!editMode || editMode === 'remove') return;
     const value = editValue.trim();
     if (!value) {
-      panelError = editMode === 'rename' ? 'Enter a credential label.' : 'Enter a replacement credential.';
+      panelError =
+        editMode === 'rename'
+          ? 'Enter a credential label.'
+          : 'Enter a replacement credential.';
       return;
     }
 
@@ -235,8 +221,11 @@
       delete nextResults[credential.id];
       testResults = nextResults;
 
-      if (!canUseAutomaticStrategy(credentials) && policy.strategy !== 'manual') {
-        policy = await updateCredentialPolicy(providerId, 'manual', 2);
+      if (!canUseAutomaticStrategy(credentials)) {
+        const policy = await getCredentialPolicy(providerId);
+        if (policy.strategy !== 'manual') {
+          await updateCredentialPolicy(providerId, 'manual', 2);
+        }
       }
       await notifyChanged();
     } catch (error) {
@@ -246,63 +235,34 @@
     }
   }
 
-  async function handleStrategy(strategy: CredentialStrategy) {
-    if (strategy !== 'manual' && !automaticAvailable) return;
-    operation = 'policy';
-    panelError = '';
-    try {
-      policy = await updateCredentialPolicy(
-        providerId,
-        strategy,
-        strategy === 'manual' ? 2 : policy.max_attempts,
-      );
-      await notifyChanged();
-    } catch (error) {
-      panelError = errorMessage(error, 'Failed to update credential strategy.');
-    } finally {
-      operation = '';
-    }
-  }
-
-  async function handleMaxAttempts(value: number) {
-    if (policy.strategy === 'manual') return;
-    operation = 'policy';
-    panelError = '';
-    try {
-      policy = await updateCredentialPolicy(providerId, policy.strategy, value);
-      await notifyChanged();
-    } catch (error) {
-      panelError = errorMessage(error, 'Failed to update retry limit.');
-    } finally {
-      operation = '';
-    }
-  }
-
   function toneClass(credential: ProviderCredentialInfo): string {
     const tone = credentialHealthTone(credential);
-    if (tone === 'success') return 'bg-green-100 text-green-700 dark:bg-green-950/60 dark:text-green-300';
-    if (tone === 'warning') return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-950/60 dark:text-yellow-300';
-    if (tone === 'danger') return 'bg-red-100 text-red-700 dark:bg-red-950/60 dark:text-red-300';
+    if (tone === 'success') {
+      return 'bg-green-100 text-green-700 dark:bg-green-950/60 dark:text-green-300';
+    }
+    if (tone === 'warning') {
+      return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-950/60 dark:text-yellow-300';
+    }
+    if (tone === 'danger') {
+      return 'bg-red-100 text-red-700 dark:bg-red-950/60 dark:text-red-300';
+    }
     return 'bg-muted text-muted-foreground';
   }
 </script>
 
-<section class="rounded-xl border border-border bg-card p-4 sm:p-5">
-  <div class="flex flex-wrap items-start justify-between gap-3">
-    <div class="flex min-w-0 items-start gap-3">
-      <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-        <KeyRound class="h-4 w-4" />
+<div class="space-y-4">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+    <div>
+      <div class="flex items-center gap-2">
+        <KeyRound class="h-4 w-4 text-primary" />
+        <h3 class="text-base font-semibold">Credentials</h3>
       </div>
-      <div>
-        <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Credentials</p>
-        <h3 class="mt-0.5 text-sm font-semibold">Manage access to {providerLabel}</h3>
-        <p class="mt-1 text-xs text-muted-foreground">
-          {credentials.length} of {maxCredentials} saved · {enabledCount} enabled
-        </p>
-      </div>
+      <p class="mt-1 text-sm text-muted-foreground">
+        {credentials.length} of {maxCredentials} saved · {enabledCount} enabled for {providerLabel}
+      </p>
     </div>
 
-    <div class="flex items-center gap-2">
+    <div class="flex flex-wrap items-center gap-2">
       {#if credentialUrl}
         <a
           href={credentialUrl}
@@ -318,33 +278,44 @@
         type="button"
         onclick={() => (addOpen = !addOpen)}
         disabled={credentials.length >= maxCredentials || operation !== ''}
-        class="inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-2 text-xs font-semibold hover:bg-accent disabled:opacity-50"
+        class="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
       >
-        {#if addOpen}<X class="h-3.5 w-3.5" />Cancel{:else}<Plus class="h-3.5 w-3.5" />Add credential{/if}
+        {#if addOpen}
+          <X class="h-3.5 w-3.5" /> Cancel
+        {:else}
+          <Plus class="h-3.5 w-3.5" /> Add credential
+        {/if}
       </button>
     </div>
   </div>
 
+  {#if panelError}
+    <div class="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+      <CircleAlert class="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      {panelError}
+    </div>
+  {/if}
+
   {#if loading}
-    <div class="mt-4 flex min-h-24 items-center justify-center gap-2 rounded-lg bg-muted/30 text-sm text-muted-foreground">
+    <div class="flex min-h-40 items-center justify-center gap-2 text-sm text-muted-foreground">
       <Loader2 class="h-4 w-4 animate-spin" />
       Loading credentials…
     </div>
   {:else}
     {#if addOpen}
-      <div class="mt-4 rounded-lg border border-primary/20 bg-primary/5 p-3">
-        <div class="grid gap-3 sm:grid-cols-[minmax(0,0.7fr)_minmax(0,1.3fr)]">
-          <label class="space-y-1 text-xs font-medium">
+      <div class="rounded-xl border border-primary/20 bg-primary/5 p-4">
+        <div class="grid gap-3 sm:grid-cols-[minmax(0,0.65fr)_minmax(0,1.35fr)]">
+          <label class="space-y-1.5 text-xs font-medium">
             Label
             <input
               bind:value={newLabel}
               maxlength="80"
               placeholder="Personal, Work, Backup…"
               autocomplete="off"
-              class="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+              class="w-full rounded-lg border border-border bg-background px-3 py-2.5 text-sm"
             />
           </label>
-          <label class="space-y-1 text-xs font-medium">
+          <label class="space-y-1.5 text-xs font-medium">
             {authType === 'token' ? 'Access token' : 'API key'}
             <div class="relative">
               <input
@@ -352,7 +323,7 @@
                 bind:value={newSecret}
                 autocomplete="new-password"
                 placeholder="Paste credential…"
-                class="w-full rounded-md border border-border bg-background px-3 py-2 pr-10 text-sm"
+                class="w-full rounded-lg border border-border bg-background px-3 py-2.5 pr-10 text-sm"
               />
               <button
                 type="button"
@@ -360,25 +331,41 @@
                 class="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                 aria-label={newSecretVisible ? 'Hide credential' : 'Show credential'}
               >
-                {#if newSecretVisible}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
+                {#if newSecretVisible}
+                  <EyeOff class="h-4 w-4" />
+                {:else}
+                  <Eye class="h-4 w-4" />
+                {/if}
               </button>
             </div>
           </label>
         </div>
-        {#if credentials.length > 0}
-          <label class="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
-            <input type="checkbox" bind:checked={activateNew} class="h-4 w-4 rounded border-border" />
-            Make this the active credential
-          </label>
-        {/if}
-        <div class="mt-3 flex justify-end">
+        <div class="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          {#if credentials.length > 0}
+            <label class="flex items-center gap-2 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                bind:checked={activateNew}
+                class="h-4 w-4 rounded border-border"
+              />
+              Make this the active credential
+            </label>
+          {:else}
+            <span class="text-xs text-muted-foreground">
+              The first credential becomes active automatically.
+            </span>
+          {/if}
           <button
             type="button"
             onclick={handleAdd}
             disabled={operation !== '' || !newLabel.trim() || !newSecret.trim()}
-            class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-xs font-semibold text-primary-foreground disabled:opacity-50"
+            class="inline-flex items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-semibold text-primary-foreground disabled:opacity-50"
           >
-            {#if operation === 'add'}<Loader2 class="h-3.5 w-3.5 animate-spin" />{:else}<Plus class="h-3.5 w-3.5" />{/if}
+            {#if operation === 'add'}
+              <Loader2 class="h-3.5 w-3.5 animate-spin" />
+            {:else}
+              <Plus class="h-3.5 w-3.5" />
+            {/if}
             Save credential
           </button>
         </div>
@@ -386,36 +373,41 @@
     {/if}
 
     {#if credentials.length > 0}
-      <div class="mt-4 divide-y divide-border overflow-hidden rounded-lg border border-border">
+      <div class="divide-y divide-border overflow-visible rounded-xl border border-border bg-background">
         {#each credentials as credential}
-          <article class="bg-background p-3">
-            <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
-              <div class="min-w-0 flex-1">
+          <article class="p-4">
+            <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+              <div class="min-w-0">
                 <div class="flex flex-wrap items-center gap-2">
                   <span class="text-sm font-semibold">{credential.label}</span>
                   {#if credential.is_active}
                     <span class="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase text-primary">
-                      <Check class="h-2.5 w-2.5" />Active
+                      <Check class="h-2.5 w-2.5" /> Active
                     </span>
                   {/if}
                   <span class={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${toneClass(credential)}`}>
                     {credentialHealthLabel(credential)}
                   </span>
                 </div>
-                <code class="mt-1 block break-all text-xs text-muted-foreground">{credential.masked_secret}</code>
+                <code class="mt-1 block break-all text-xs text-muted-foreground">
+                  {credential.masked_secret}
+                </code>
                 <p class="mt-1 text-[11px] text-muted-foreground">
-                  Priority {credential.priority}
-                  {#if credential.last_used_at} · Last used {new Date(credential.last_used_at).toLocaleString()}{/if}
+                  {#if credential.last_used_at}
+                    Last used {new Date(credential.last_used_at).toLocaleString()}
+                  {:else}
+                    Never used
+                  {/if}
                 </p>
               </div>
 
-              <div class="flex flex-wrap items-center gap-1.5">
+              <div class="flex flex-wrap items-center gap-2 lg:justify-end">
                 {#if !credential.is_active && credential.is_enabled}
                   <button
                     type="button"
                     onclick={() => handleActivate(credential)}
                     disabled={operation !== ''}
-                    class="rounded-md border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-accent disabled:opacity-50"
+                    class="rounded-lg bg-primary px-3 py-2 text-xs font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
                   >
                     {operation === `activate:${credential.id}` ? 'Activating…' : 'Set active'}
                   </button>
@@ -424,60 +416,143 @@
                   type="button"
                   onclick={() => handleTest(credential)}
                   disabled={operation !== '' || !credential.is_enabled}
-                  class="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-accent disabled:opacity-50"
+                  class="inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-2 text-xs font-medium hover:bg-accent disabled:opacity-50"
                 >
-                  {#if operation === `test:${credential.id}`}<Loader2 class="h-3 w-3 animate-spin" />{:else}<Activity class="h-3 w-3" />{/if}
+                  {#if operation === `test:${credential.id}`}
+                    <Loader2 class="h-3.5 w-3.5 animate-spin" />
+                  {:else}
+                    <Activity class="h-3.5 w-3.5" />
+                  {/if}
                   Test
                 </button>
-                <button type="button" onclick={() => beginEdit(credential, 'rename')} disabled={operation !== ''} class="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50" aria-label={`Rename ${credential.label}`}><Pencil class="h-3.5 w-3.5" /></button>
-                <button type="button" onclick={() => beginEdit(credential, 'replace')} disabled={operation !== ''} class="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50" aria-label={`Replace ${credential.label}`}><RefreshCw class="h-3.5 w-3.5" /></button>
-                <button type="button" onclick={() => beginEdit(credential, 'remove')} disabled={operation !== ''} class="rounded-md p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:opacity-50" aria-label={`Remove ${credential.label}`}><Trash2 class="h-3.5 w-3.5" /></button>
+                <button
+                  type="button"
+                  onclick={() => beginEdit(credential, 'rename')}
+                  disabled={operation !== ''}
+                  class="inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-2 text-xs font-medium hover:bg-accent disabled:opacity-50"
+                >
+                  <Pencil class="h-3.5 w-3.5" /> Rename
+                </button>
+                <button
+                  type="button"
+                  onclick={() => beginEdit(credential, 'replace')}
+                  disabled={operation !== ''}
+                  class="inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-2 text-xs font-medium hover:bg-accent disabled:opacity-50"
+                >
+                  <RefreshCw class="h-3.5 w-3.5" /> Replace
+                </button>
+                <details class="relative">
+                  <summary
+                    class="flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded-lg border border-border text-muted-foreground hover:bg-accent hover:text-foreground [&::-webkit-details-marker]:hidden"
+                    aria-label={`More actions for ${credential.label}`}
+                  >
+                    <MoreHorizontal class="h-4 w-4" />
+                  </summary>
+                  <div class="absolute right-0 z-30 mt-2 w-44 rounded-lg border border-border bg-popover p-1.5 text-popover-foreground shadow-lg">
+                    <button
+                      type="button"
+                      onclick={() => beginEdit(credential, 'remove')}
+                      disabled={operation !== ''}
+                      class="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                    >
+                      <Trash2 class="h-3.5 w-3.5" /> Remove credential
+                    </button>
+                  </div>
+                </details>
               </div>
             </div>
 
             {#if testResults[credential.id]}
-              <div class="mt-2 flex items-start gap-2 rounded-md px-2.5 py-2 text-xs {testResults[credential.id].ok ? 'bg-green-50 text-green-700 dark:bg-green-950/30 dark:text-green-300' : 'bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-300'}">
-                {#if testResults[credential.id].ok}<CircleCheck class="mt-0.5 h-3.5 w-3.5 shrink-0" />{:else}<CircleAlert class="mt-0.5 h-3.5 w-3.5 shrink-0" />{/if}
+              <div class="mt-3 flex items-start gap-2 rounded-lg px-3 py-2 text-xs {testResults[credential.id].ok ? 'bg-green-50 text-green-700 dark:bg-green-950/30 dark:text-green-300' : 'bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-300'}">
+                {#if testResults[credential.id].ok}
+                  <CircleCheck class="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                {:else}
+                  <CircleAlert class="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                {/if}
                 {testResults[credential.id].message}
               </div>
             {/if}
 
             {#if editingId === credential.id}
-              <div class="mt-3 rounded-md border border-border bg-muted/30 p-3">
+              <div class="mt-3 rounded-lg border border-border bg-muted/30 p-3">
                 {#if editMode === 'remove'}
                   <p class="text-sm font-medium">Remove “{credential.label}”?</p>
                   <p class="mt-1 text-xs text-muted-foreground">
-                    The secret cannot be recovered. {credential.is_active && credentials.length > 1 ? 'The next enabled credential becomes active.' : ''}
+                    The secret cannot be recovered.
+                    {credential.is_active && credentials.length > 1
+                      ? ' The next enabled credential becomes active.'
+                      : ''}
                   </p>
                   <div class="mt-3 flex justify-end gap-2">
-                    <button type="button" onclick={closeEditor} class="rounded-md border border-border px-3 py-1.5 text-xs hover:bg-accent">Cancel</button>
-                    <button type="button" onclick={() => handleRemove(credential)} disabled={operation !== ''} class="inline-flex items-center gap-1.5 rounded-md bg-destructive px-3 py-1.5 text-xs font-semibold text-destructive-foreground disabled:opacity-50">
-                      {#if operation === `remove:${credential.id}`}<Loader2 class="h-3 w-3 animate-spin" />{:else}<Trash2 class="h-3 w-3" />{/if}
+                    <button
+                      type="button"
+                      onclick={closeEditor}
+                      class="rounded-lg border border-border px-3 py-2 text-xs hover:bg-accent"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onclick={() => handleRemove(credential)}
+                      disabled={operation !== ''}
+                      class="inline-flex items-center gap-1.5 rounded-lg bg-destructive px-3 py-2 text-xs font-semibold text-destructive-foreground disabled:opacity-50"
+                    >
+                      {#if operation === `remove:${credential.id}`}
+                        <Loader2 class="h-3.5 w-3.5 animate-spin" />
+                      {:else}
+                        <Trash2 class="h-3.5 w-3.5" />
+                      {/if}
                       Remove
                     </button>
                   </div>
                 {:else}
-                  <label class="space-y-1 text-xs font-medium">
-                    {editMode === 'rename' ? 'Credential label' : `New ${authType === 'token' ? 'access token' : 'API key'}`}
+                  <label class="space-y-1.5 text-xs font-medium">
+                    {editMode === 'rename'
+                      ? 'Credential label'
+                      : `New ${authType === 'token' ? 'access token' : 'API key'}`}
                     <div class="relative">
                       <input
                         type={editMode === 'replace' && !editSecretVisible ? 'password' : 'text'}
                         bind:value={editValue}
                         maxlength={editMode === 'rename' ? 80 : 4096}
                         autocomplete={editMode === 'replace' ? 'new-password' : 'off'}
-                        class="w-full rounded-md border border-border bg-background px-3 py-2 {editMode === 'replace' ? 'pr-10' : ''} text-sm"
+                        class="w-full rounded-lg border border-border bg-background px-3 py-2.5 {editMode === 'replace' ? 'pr-10' : ''} text-sm"
                       />
                       {#if editMode === 'replace'}
-                        <button type="button" onclick={() => (editSecretVisible = !editSecretVisible)} class="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground" aria-label={editSecretVisible ? 'Hide credential' : 'Show credential'}>
-                          {#if editSecretVisible}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
+                        <button
+                          type="button"
+                          onclick={() => (editSecretVisible = !editSecretVisible)}
+                          class="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                          aria-label={editSecretVisible ? 'Hide credential' : 'Show credential'}
+                        >
+                          {#if editSecretVisible}
+                            <EyeOff class="h-4 w-4" />
+                          {:else}
+                            <Eye class="h-4 w-4" />
+                          {/if}
                         </button>
                       {/if}
                     </div>
                   </label>
                   <div class="mt-3 flex justify-end gap-2">
-                    <button type="button" onclick={closeEditor} class="rounded-md border border-border px-3 py-1.5 text-xs hover:bg-accent">Cancel</button>
-                    <button type="button" onclick={() => handleEdit(credential)} disabled={operation !== '' || !editValue.trim()} class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground disabled:opacity-50">
-                      {#if operation === `${editMode}:${credential.id}`}<Loader2 class="h-3 w-3 animate-spin" />{:else}<Check class="h-3 w-3" />{/if}
+                    <button
+                      type="button"
+                      onclick={closeEditor}
+                      class="rounded-lg border border-border px-3 py-2 text-xs hover:bg-accent"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onclick={() => handleEdit(credential)}
+                      disabled={operation !== '' || !editValue.trim()}
+                      class="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-semibold text-primary-foreground disabled:opacity-50"
+                    >
+                      {#if operation === `${editMode}:${credential.id}`}
+                        <Loader2 class="h-3.5 w-3.5 animate-spin" />
+                      {:else}
+                        <Check class="h-3.5 w-3.5" />
+                      {/if}
                       Save
                     </button>
                   </div>
@@ -488,79 +563,13 @@
         {/each}
       </div>
     {:else}
-      <div class="mt-4 rounded-lg border border-dashed border-border bg-muted/20 px-4 py-8 text-center">
+      <div class="rounded-xl border border-dashed border-border bg-muted/20 px-4 py-10 text-center">
         <KeyRound class="mx-auto h-5 w-5 text-muted-foreground" />
         <p class="mt-2 text-sm font-medium">No credentials saved</p>
-        <p class="mt-1 text-xs text-muted-foreground">Add the first credential to connect this provider.</p>
+        <p class="mt-1 text-xs text-muted-foreground">
+          Add the first credential to connect this provider.
+        </p>
       </div>
     {/if}
-
-    <div class="mt-5 border-t border-border pt-5">
-      <div class="flex items-start gap-3">
-        <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-          <ShieldCheck class="h-4 w-4" />
-        </div>
-        <div class="min-w-0 flex-1">
-          <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Credential strategy</p>
-          <h3 class="mt-0.5 text-sm font-semibold">Choose how ApplyKit selects a key</h3>
-        </div>
-      </div>
-
-      <div class="mt-3 grid gap-2">
-        {#each ['manual', 'failover', 'round_robin'] as strategy}
-          {@const typedStrategy = strategy as CredentialStrategy}
-          {@const automatic = typedStrategy !== 'manual'}
-          <button
-            type="button"
-            onclick={() => handleStrategy(typedStrategy)}
-            disabled={operation !== '' || (automatic && !automaticAvailable)}
-            class="flex items-start gap-3 rounded-lg border p-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50 {policy.strategy === typedStrategy ? 'border-primary bg-primary/5' : 'border-border hover:bg-accent/40'}"
-          >
-            <span class="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border {policy.strategy === typedStrategy ? 'border-primary bg-primary' : 'border-muted-foreground/50'}">
-              {#if policy.strategy === typedStrategy}<span class="h-1.5 w-1.5 rounded-full bg-primary-foreground"></span>{/if}
-            </span>
-            <span class="min-w-0 flex-1">
-              <span class="flex flex-wrap items-center gap-2 text-sm font-semibold">
-                {credentialStrategyLabel(typedStrategy)}
-                {#if typedStrategy === 'failover'}<span class="rounded bg-green-100 px-1.5 py-0.5 text-[9px] font-semibold uppercase text-green-700 dark:bg-green-950/60 dark:text-green-300">Recommended</span>{/if}
-                {#if typedStrategy === 'round_robin'}<span class="rounded bg-muted px-1.5 py-0.5 text-[9px] font-semibold uppercase text-muted-foreground">Advanced</span>{/if}
-              </span>
-              <span class="mt-0.5 block text-xs text-muted-foreground">{credentialStrategyDescription(typedStrategy)}</span>
-              {#if automatic && !automaticAvailable}<span class="mt-1 block text-[11px] text-yellow-700 dark:text-yellow-300">Requires at least two enabled credentials.</span>{/if}
-            </span>
-            {#if operation === 'policy' && policy.strategy !== typedStrategy}<Loader2 class="mt-0.5 h-4 w-4 animate-spin text-muted-foreground" />{/if}
-          </button>
-        {/each}
-      </div>
-
-      {#if policy.strategy !== 'manual'}
-        <label class="mt-3 flex items-center justify-between gap-3 rounded-lg bg-muted/40 px-3 py-2.5 text-xs">
-          <span>
-            <span class="font-semibold">Maximum attempts</span>
-            <span class="mt-0.5 block text-muted-foreground">Includes the first credential. Lower values reduce duplicate cost risk.</span>
-          </span>
-          <div class="relative shrink-0">
-            <select
-              value={policy.max_attempts}
-              onchange={(event) => handleMaxAttempts(Number(event.currentTarget.value))}
-              disabled={operation !== ''}
-              class="appearance-none rounded-md border border-border bg-background py-1.5 pl-3 pr-8 text-sm font-medium"
-            >
-              {#each [2, 3, 4, 5] as attemptCount}
-                <option value={attemptCount}>{attemptCount}</option>
-              {/each}
-            </select>
-            <ChevronDown class="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-          </div>
-        </label>
-      {/if}
-    </div>
   {/if}
-
-  {#if panelError}
-    <div class="mt-3 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
-      <CircleAlert class="mt-0.5 h-3.5 w-3.5 shrink-0" />
-      {panelError}
-    </div>
-  {/if}
-</section>
+</div>

--- a/frontend/src/lib/components/SettingsModal.svelte
+++ b/frontend/src/lib/components/SettingsModal.svelte
@@ -5,8 +5,10 @@
   import ModelSelector from '$lib/components/ModelSelector.svelte';
   import ProviderCredentialsPanel from '$lib/components/ProviderCredentialsPanel.svelte';
   import {
+    getCredentialPolicy,
     getProviderCredentials,
     testConfiguredIntegration,
+    updateCredentialPolicy,
   } from '$lib/integration-api';
   import {
     credentialActionLabel,
@@ -14,6 +16,20 @@
     isCustomModel,
     type CatalogProviderInfo,
   } from '$lib/llm-catalog';
+  import {
+    canUseAutomaticStrategy,
+    credentialStrategyDescription,
+    credentialStrategyLabel,
+  } from '$lib/provider-credentials';
+  import type {
+    CredentialStrategy,
+    ProviderCredentialInfo,
+  } from '$lib/provider-credential-types';
+  import {
+    defaultSettingsTab,
+    footerActionForTab,
+    type ProviderSettingsTab,
+  } from '$lib/settings-modal-tabs';
   import {
     connectionTestMode,
     modalMode,
@@ -24,6 +40,7 @@
   import type { TestConnectionResponse } from '$lib/types';
   import { errorMessage } from '$lib/utils';
   import {
+    Activity,
     CheckCircle,
     CircleAlert,
     ExternalLink,
@@ -31,6 +48,7 @@
     EyeOff,
     KeyRound,
     Loader2,
+    Route,
     Server,
     ShieldCheck,
     Sparkles,
@@ -64,6 +82,13 @@
   let activeModel = $state('');
   let saving = $state<'activate' | 'only' | null>(null);
   let hasStoredCredential = $state(false);
+  let activeTab: ProviderSettingsTab = $state('model');
+  let credentialSummary: ProviderCredentialInfo[] = $state([]);
+  let routingStrategy: CredentialStrategy = $state('manual');
+  let routingMaxAttempts = $state(2);
+  let savedRoutingStrategy: CredentialStrategy = $state('manual');
+  let savedRoutingMaxAttempts = $state(2);
+  let savingRouting = $state(false);
 
   const selectedProvider = $derived(
     providers.find((provider) => provider.id === selectedProviderId),
@@ -121,6 +146,13 @@
           (!managesCredentialVault && apiKey.trim())),
     ),
   );
+  const automaticRoutingAvailable = $derived(
+    canUseAutomaticStrategy(credentialSummary),
+  );
+  const routingDirty = $derived(
+    routingStrategy !== savedRoutingStrategy ||
+      routingMaxAttempts !== savedRoutingMaxAttempts,
+  );
 
   $effect(() => {
     if (!open) return;
@@ -150,16 +182,31 @@
     return false;
   }
 
-  async function refreshCredentialState() {
-    if (!selectedProvider?.requires_api_key || !selectedProviderId) {
+  async function refreshCredentialState(providerId = selectedProviderId) {
+    const provider = providers.find((item) => item.id === providerId);
+    if (!provider?.requires_api_key) {
       hasStoredCredential = false;
+      credentialSummary = [];
+      routingStrategy = 'manual';
+      routingMaxAttempts = 2;
+      savedRoutingStrategy = 'manual';
+      savedRoutingMaxAttempts = 2;
       return;
     }
+
     try {
-      const response = await getProviderCredentials(selectedProviderId);
-      hasStoredCredential = response.credentials.some(
+      const [credentialsResponse, policyResponse] = await Promise.all([
+        getProviderCredentials(providerId),
+        getCredentialPolicy(providerId),
+      ]);
+      credentialSummary = credentialsResponse.credentials;
+      hasStoredCredential = credentialsResponse.credentials.some(
         (credential) => credential.is_active && credential.is_enabled,
       );
+      routingStrategy = policyResponse.strategy;
+      routingMaxAttempts = policyResponse.max_attempts;
+      savedRoutingStrategy = policyResponse.strategy;
+      savedRoutingMaxAttempts = policyResponse.max_attempts;
       await invalidateAll();
     } catch {
       hasStoredCredential = initialApiKeyConfigured;
@@ -189,13 +236,21 @@
         selectedProviderId = initialProviderId;
         selectedModel = initialModel || provider?.models[0]?.value || '';
         customMode = isCustomModel(provider, selectedModel);
-        if (provider?.requires_api_key) await refreshCredentialState();
+        if (provider?.requires_api_key) {
+          await refreshCredentialState(initialProviderId);
+        }
+        activeTab = defaultSettingsTab({
+          isExistingProvider: true,
+          requiresCredential: Boolean(provider?.requires_api_key),
+        });
       } else if (settingsResponse.model && selectExistingModel(settingsResponse.model)) {
         hasStoredCredential = settingsResponse.api_key_configured;
+        activeTab = 'model';
       } else if (providers.length > 0) {
         selectedProviderId = providers[0].id;
         selectedModel = providers[0].models[0]?.value ?? '';
         hasStoredCredential = false;
+        activeTab = 'model';
       }
     } catch {
       saveError = 'Failed to load settings.';
@@ -211,6 +266,8 @@
     customMode = false;
     apiKey = '';
     hasStoredCredential = false;
+    credentialSummary = [];
+    activeTab = 'model';
     testResult = null;
     saveError = '';
   }
@@ -223,6 +280,12 @@
       : selectedProvider.models[0]?.value ?? '';
     testResult = null;
     saveError = '';
+  }
+
+  function selectTab(tab: ProviderSettingsTab) {
+    activeTab = tab;
+    saveError = '';
+    testResult = null;
   }
 
   async function handleTest() {
@@ -260,11 +323,7 @@
     }
 
     const keyToSave = managesCredentialVault ? null : apiKey.trim() || null;
-    if (
-      selectedProvider?.requires_api_key &&
-      !keyToSave &&
-      !hasStoredCredential
-    ) {
+    if (selectedProvider?.requires_api_key && !keyToSave && !hasStoredCredential) {
       saveError = 'Add a credential before saving this provider.';
       return;
     }
@@ -280,9 +339,9 @@
       toastState.success(
         activate
           ? isActive
-            ? 'Provider settings updated.'
+            ? 'Model settings updated.'
             : 'Saved and set as active model.'
-          : 'Provider saved without changing the active model.',
+          : 'Model saved without changing the active provider.',
       );
       open = false;
       await invalidateAll();
@@ -298,8 +357,36 @@
     }
   }
 
+  async function handleSaveRouting() {
+    if (!selectedProvider || !routingDirty) return;
+    if (routingStrategy !== 'manual' && !automaticRoutingAvailable) {
+      saveError = 'Automatic routing requires at least two enabled credentials.';
+      return;
+    }
+
+    savingRouting = true;
+    saveError = '';
+    try {
+      const response = await updateCredentialPolicy(
+        selectedProvider.id,
+        routingStrategy,
+        routingStrategy === 'manual' ? 2 : routingMaxAttempts,
+      );
+      routingStrategy = response.strategy;
+      routingMaxAttempts = response.max_attempts;
+      savedRoutingStrategy = response.strategy;
+      savedRoutingMaxAttempts = response.max_attempts;
+      toastState.success('Credential routing updated.');
+      await invalidateAll();
+    } catch (error) {
+      saveError = errorMessage(error, 'Failed to update credential routing.');
+    } finally {
+      savingRouting = false;
+    }
+  }
+
   function closeModal() {
-    if (saving || testing) return;
+    if (saving || testing || savingRouting) return;
     apiKey = '';
     showApiKey = false;
     open = false;
@@ -323,206 +410,488 @@
     aria-labelledby="provider-settings-title"
   >
     <div
-      class="flex max-h-[94vh] w-full max-w-3xl flex-col overflow-hidden rounded-t-2xl border border-border bg-background shadow-2xl sm:max-h-[calc(100vh-2rem)] sm:rounded-2xl"
+      class="flex max-h-[96vh] w-full max-w-4xl flex-col overflow-hidden rounded-t-2xl border border-border bg-background shadow-2xl sm:max-h-[calc(100vh-2rem)] sm:rounded-2xl"
       onclick={(event) => event.stopPropagation()}
       role="presentation"
     >
-      <header class="flex items-start justify-between gap-4 border-b border-border px-5 py-4 sm:px-6 sm:py-5">
-        <div class="min-w-0">
-          <div class="flex flex-wrap items-center gap-2">
-            <h2 id="provider-settings-title" class="text-lg font-semibold tracking-tight">{title}</h2>
-            {#if !loading && selectedProvider}
-              {#if isActive}
-                <span class="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-700 dark:bg-green-950/60 dark:text-green-300">
-                  <span class="h-1.5 w-1.5 rounded-full bg-green-500"></span>Active
-                </span>
-              {:else if hasStoredCredential}
-                <span class="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-700 dark:bg-blue-950/60 dark:text-blue-300">
-                  <CheckCircle class="h-3 w-3" />Connected
-                </span>
-              {:else}
-                <span class="rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Not configured</span>
+      <header class="flex items-start justify-between gap-4 border-b border-border px-5 py-4 sm:px-6">
+        <div class="flex min-w-0 items-start gap-3">
+          <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <Sparkles class="h-5 w-5" />
+          </div>
+          <div class="min-w-0">
+            <div class="flex flex-wrap items-center gap-2">
+              <h2 id="provider-settings-title" class="text-lg font-semibold tracking-tight">
+                {title}
+              </h2>
+              {#if !loading && selectedProvider}
+                {#if isActive}
+                  <span class="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-700 dark:bg-green-950/60 dark:text-green-300">
+                    <span class="h-1.5 w-1.5 rounded-full bg-green-500"></span>
+                    Active
+                  </span>
+                {:else if hasStoredCredential}
+                  <span class="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-700 dark:bg-blue-950/60 dark:text-blue-300">
+                    <CheckCircle class="h-3 w-3" /> Connected
+                  </span>
+                {:else}
+                  <span class="rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Not configured
+                  </span>
+                {/if}
               {/if}
+            </div>
+            {#if managesCredentialVault}
+              <p class="mt-1 text-sm text-muted-foreground">
+                {credentialSummary.length} credential{credentialSummary.length === 1 ? '' : 's'} ·
+                {credentialStrategyLabel(savedRoutingStrategy)} strategy
+              </p>
+            {:else}
+              <p class="mt-1 text-sm text-muted-foreground">
+                Choose a provider and model, verify access, then save.
+              </p>
             {/if}
           </div>
-          <p class="mt-1 text-sm text-muted-foreground">Choose a model, manage credentials, verify the connection, then save.</p>
         </div>
-        <button onclick={closeModal} disabled={saving !== null || testing} class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50" aria-label="Close provider settings">
+        <button
+          onclick={closeModal}
+          disabled={saving !== null || testing || savingRouting}
+          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+          aria-label="Close provider settings"
+        >
           <X class="h-4 w-4" />
         </button>
       </header>
 
+      {#if managesCredentialVault}
+        <nav class="sticky top-0 z-10 flex border-b border-border bg-background px-5 sm:px-6" aria-label="Provider settings sections">
+          <button
+            type="button"
+            onclick={() => selectTab('model')}
+            aria-selected={activeTab === 'model'}
+            class="inline-flex items-center gap-2 border-b-2 px-3 py-3 text-sm font-medium transition-colors {activeTab === 'model' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
+          >
+            <Sparkles class="h-4 w-4" /> Model
+          </button>
+          <button
+            type="button"
+            onclick={() => selectTab('credentials')}
+            aria-selected={activeTab === 'credentials'}
+            class="inline-flex items-center gap-2 border-b-2 px-3 py-3 text-sm font-medium transition-colors {activeTab === 'credentials' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
+          >
+            <KeyRound class="h-4 w-4" /> Credentials
+            <span class="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+              {credentialSummary.length}
+            </span>
+          </button>
+          <button
+            type="button"
+            onclick={() => selectTab('routing')}
+            aria-selected={activeTab === 'routing'}
+            class="inline-flex items-center gap-2 border-b-2 px-3 py-3 text-sm font-medium transition-colors {activeTab === 'routing' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
+          >
+            <Route class="h-4 w-4" /> Routing
+          </button>
+        </nav>
+      {/if}
+
       {#if loading}
-        <div class="flex min-h-72 flex-1 items-center justify-center gap-2 text-muted-foreground">
-          <Loader2 class="h-5 w-5 animate-spin" />Loading provider settings…
+        <div class="flex min-h-80 flex-1 items-center justify-center gap-2 text-muted-foreground">
+          <Loader2 class="h-5 w-5 animate-spin" />
+          Loading provider settings…
         </div>
       {:else}
-        <div class="flex-1 space-y-5 overflow-y-auto px-5 py-5 sm:px-6">
-          {#if source === 'env'}
-            <div class="flex items-start gap-3 rounded-xl border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800 dark:border-blue-900 dark:bg-blue-950/30 dark:text-blue-300">
+        <div class="flex-1 overflow-y-auto px-5 py-5 sm:px-6">
+          {#if source === 'env' && activeTab === 'model'}
+            <div class="mb-5 flex items-start gap-3 rounded-xl border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800 dark:border-blue-900 dark:bg-blue-950/30 dark:text-blue-300">
               <CircleAlert class="mt-0.5 h-4 w-4 shrink-0" />
-              <span>ApplyKit currently uses configuration from <code class="font-mono">.env</code>. Saving here will override it with the database configuration.</span>
+              <span>
+                ApplyKit currently uses configuration from <code class="font-mono">.env</code>.
+                Saving here will override it with database settings.
+              </span>
             </div>
           {/if}
 
-          <section class="rounded-xl border border-border bg-card p-4 sm:p-5">
-            <div class="flex items-start gap-3">
-              <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary"><Server class="h-4 w-4" /></div>
-              <div class="min-w-0 flex-1">
-                <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Provider</p>
-                <h3 class="mt-0.5 text-sm font-semibold">Choose where ApplyKit sends AI requests</h3>
-                {#if !initialProviderId}
-                  <select value={selectedProviderId} onchange={(event) => onProviderChange(event.currentTarget.value)} class="mt-3 w-full rounded-lg border border-border bg-background px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-primary/30" aria-label="AI provider">
-                    {#each providers as provider}<option value={provider.id}>{provider.label}</option>{/each}
-                  </select>
-                {:else}
-                  <div class="mt-3 flex items-center justify-between gap-3 rounded-lg bg-muted/50 px-3 py-2.5">
-                    <div>
-                      <p class="text-sm font-medium">{selectedProvider?.label}</p>
-                      <p class="text-xs text-muted-foreground">
-                        {#if selectedProvider?.local}Local provider · no credential required{:else if selectedProvider?.auth_type === 'token'}Access token authentication{:else}API key authentication{/if}
-                      </p>
-                    </div>
-                    {#if selectedProvider?.local}<span class="rounded bg-blue-100 px-2 py-1 text-[10px] font-semibold uppercase text-blue-700 dark:bg-blue-950 dark:text-blue-300">Local</span>{/if}
+          {#if activeTab === 'model'}
+            <div class="mx-auto max-w-2xl space-y-7">
+              {#if !initialProviderId}
+                <section>
+                  <div class="flex items-center gap-2">
+                    <Server class="h-4 w-4 text-primary" />
+                    <h3 class="text-base font-semibold">Provider</h3>
                   </div>
-                {/if}
-              </div>
-            </div>
-          </section>
+                  <p class="mt-1 text-sm text-muted-foreground">
+                    Choose where ApplyKit sends AI requests.
+                  </p>
+                  <select
+                    value={selectedProviderId}
+                    onchange={(event) => onProviderChange(event.currentTarget.value)}
+                    class="mt-3 w-full rounded-xl border border-border bg-background px-3 py-3 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+                    aria-label="AI provider"
+                  >
+                    {#each providers as provider}
+                      <option value={provider.id}>{provider.label}</option>
+                    {/each}
+                  </select>
+                </section>
+                <div class="border-t border-border"></div>
+              {/if}
 
-          <section class="rounded-xl border border-border bg-card p-4 sm:p-5">
-            <div class="flex items-start gap-3">
-              <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary"><Sparkles class="h-4 w-4" /></div>
-              <div class="min-w-0 flex-1">
+              <section>
                 <div class="flex flex-wrap items-start justify-between gap-3">
                   <div>
-                    <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Model</p>
-                    <h3 class="mt-0.5 text-sm font-semibold">Select the model for this provider</h3>
+                    <div class="flex items-center gap-2">
+                      <Sparkles class="h-4 w-4 text-primary" />
+                      <h3 class="text-base font-semibold">Model</h3>
+                    </div>
+                    <p class="mt-1 text-sm text-muted-foreground">
+                      Select the model used for this provider.
+                    </p>
                   </div>
                   {#if selectedProvider?.supports_custom_models}
-                    <button type="button" onclick={toggleCustomMode} class="text-xs font-medium text-primary hover:underline">{customMode ? 'Choose from catalog' : 'Use custom model ID'}</button>
+                    <button
+                      type="button"
+                      onclick={toggleCustomMode}
+                      class="text-xs font-medium text-primary hover:underline"
+                    >
+                      {customMode ? 'Choose from catalog' : 'Use custom model ID'}
+                    </button>
                   {/if}
                 </div>
+
                 <div class="mt-3">
                   {#if customMode}
-                    <input bind:value={selectedModel} placeholder={`${selectedProvider?.id ?? 'provider'}/model-name`} maxlength="200" spellcheck="false" autocomplete="off" class="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-sm outline-none focus:ring-2 focus:ring-primary/30" />
+                    <input
+                      bind:value={selectedModel}
+                      placeholder={`${selectedProvider?.id ?? 'provider'}/model-name`}
+                      maxlength="200"
+                      spellcheck="false"
+                      autocomplete="off"
+                      class="w-full rounded-xl border border-border bg-background px-3 py-3 font-mono text-sm outline-none focus:ring-2 focus:ring-primary/30"
+                    />
                     <div class="mt-2 flex flex-wrap items-center justify-between gap-2">
-                      <span class="rounded bg-purple-100 px-2 py-1 text-[10px] font-semibold uppercase text-purple-700 dark:bg-purple-950 dark:text-purple-300">Custom model</span>
+                      <span class="rounded bg-purple-100 px-2 py-1 text-[10px] font-semibold uppercase text-purple-700 dark:bg-purple-950 dark:text-purple-300">
+                        Custom model
+                      </span>
                       <span class="text-xs text-muted-foreground">Use the full LiteLLM model ID.</span>
                     </div>
-                    {#if customModelError}<p class="mt-2 text-xs text-red-600 dark:text-red-400">{customModelError}</p>{/if}
+                    {#if customModelError}
+                      <p class="mt-2 text-xs text-red-600 dark:text-red-400">
+                        {customModelError}
+                      </p>
+                    {/if}
                   {:else}
-                    <ModelSelector models={selectedProvider?.models ?? []} bind:value={selectedModel} unavailableValue={unavailableCurrentModel ? initialModel : ''} />
+                    <ModelSelector
+                      models={selectedProvider?.models ?? []}
+                      bind:value={selectedModel}
+                      unavailableValue={unavailableCurrentModel ? initialModel : ''}
+                    />
                   {/if}
                 </div>
+
                 {#if unavailableCurrentModel && selectedModel === initialModel}
                   <div class="mt-3 flex items-start gap-2 rounded-lg border border-yellow-200 bg-yellow-50 px-3 py-2.5 text-xs text-yellow-800 dark:border-yellow-900 dark:bg-yellow-950/30 dark:text-yellow-300">
-                    <CircleAlert class="h-4 w-4 shrink-0" />Select an active catalog model to replace this unavailable model.
+                    <CircleAlert class="h-4 w-4 shrink-0" />
+                    Select an active catalog model to replace this unavailable model.
                   </div>
                 {:else if selectedModelInfo}
                   <div class="mt-3 flex flex-wrap gap-1.5">
-                    <span class="rounded bg-blue-100 px-2 py-1 text-[10px] font-semibold uppercase text-blue-700 dark:bg-blue-950 dark:text-blue-300">Catalog</span>
-                    {#if selectedModelInfo.status !== 'stable'}<span class="rounded bg-yellow-100 px-2 py-1 text-[10px] font-semibold uppercase text-yellow-800 dark:bg-yellow-950 dark:text-yellow-300">{selectedModelInfo.status}</span>{/if}
-                    {#if selectedModelInfo.free_tier}<span class="rounded bg-green-100 px-2 py-1 text-[10px] font-semibold uppercase text-green-700 dark:bg-green-950 dark:text-green-300">Free tier</span>{/if}
-                    {#each selectedModelInfo.traits as trait}<span class="rounded bg-muted px-2 py-1 text-[10px] uppercase text-muted-foreground">{trait.replaceAll('_', ' ')}</span>{/each}
+                    <span class="rounded bg-blue-100 px-2 py-1 text-[10px] font-semibold uppercase text-blue-700 dark:bg-blue-950 dark:text-blue-300">
+                      Catalog
+                    </span>
+                    {#if selectedModelInfo.status !== 'stable'}
+                      <span class="rounded bg-yellow-100 px-2 py-1 text-[10px] font-semibold uppercase text-yellow-800 dark:bg-yellow-950 dark:text-yellow-300">
+                        {selectedModelInfo.status}
+                      </span>
+                    {/if}
+                    {#if selectedModelInfo.free_tier}
+                      <span class="rounded bg-green-100 px-2 py-1 text-[10px] font-semibold uppercase text-green-700 dark:bg-green-950 dark:text-green-300">
+                        Free tier
+                      </span>
+                    {/if}
+                    {#each selectedModelInfo.traits as trait}
+                      <span class="rounded bg-muted px-2 py-1 text-[10px] uppercase text-muted-foreground">
+                        {trait.replaceAll('_', ' ')}
+                      </span>
+                    {/each}
                   </div>
                 {/if}
-              </div>
-            </div>
-          </section>
+              </section>
 
-          {#if managesCredentialVault && selectedProvider}
+              {#if !managesCredentialVault}
+                <div class="border-t border-border"></div>
+                <section>
+                  <div class="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <div class="flex items-center gap-2">
+                        <KeyRound class="h-4 w-4 text-primary" />
+                        <h3 class="text-base font-semibold">
+                          {selectedProvider?.requires_api_key
+                            ? selectedProvider.auth_type === 'token'
+                              ? 'Access token'
+                              : 'API key'
+                            : 'Local access'}
+                        </h3>
+                      </div>
+                      <p class="mt-1 text-sm text-muted-foreground">
+                        {selectedProvider?.requires_api_key
+                          ? 'Enter the first credential for this provider.'
+                          : 'This provider runs locally and does not need a credential.'}
+                      </p>
+                    </div>
+                    {#if selectedProvider?.credential_url}
+                      <a
+                        href={selectedProvider.credential_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+                      >
+                        {credentialActionLabel(selectedProvider.auth_type)}
+                        <ExternalLink class="h-3 w-3" />
+                      </a>
+                    {/if}
+                  </div>
+
+                  {#if selectedProvider?.requires_api_key}
+                    <div class="relative mt-3">
+                      <input
+                        type={showApiKey ? 'text' : 'password'}
+                        bind:value={apiKey}
+                        placeholder="Enter your credential…"
+                        class="w-full rounded-xl border border-border bg-background px-3 py-3 pr-11 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+                        autocomplete="new-password"
+                      />
+                      <button
+                        type="button"
+                        onclick={() => (showApiKey = !showApiKey)}
+                        class="absolute right-2.5 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+                        aria-label={showApiKey ? 'Hide credential' : 'Show credential'}
+                      >
+                        {#if showApiKey}
+                          <EyeOff class="h-4 w-4" />
+                        {:else}
+                          <Eye class="h-4 w-4" />
+                        {/if}
+                      </button>
+                    </div>
+                  {/if}
+                </section>
+              {/if}
+
+              <div class="border-t border-border"></div>
+              <section>
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <div class="flex items-center gap-2">
+                      <ShieldCheck class="h-4 w-4 text-primary" />
+                      <h3 class="text-base font-semibold">Test model connection</h3>
+                    </div>
+                    <p class="mt-1 text-sm text-muted-foreground">
+                      {#if testMode === 'stored'}
+                        Uses the active credential stored securely on the backend.
+                      {:else if selectedProvider?.local}
+                        Sends one minimal request to the local provider.
+                      {:else}
+                        Sends one minimal request with the credential entered above.
+                      {/if}
+                    </p>
+                  </div>
+                  <button
+                    onclick={handleTest}
+                    disabled={testing || !canTest}
+                    class="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-border px-3.5 py-2 text-sm font-medium transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {#if testing}
+                      <Loader2 class="h-4 w-4 animate-spin" /> Testing…
+                    {:else}
+                      <Activity class="h-4 w-4" /> Test connection
+                    {/if}
+                  </button>
+                </div>
+
+                {#if storedTestUsesOlderModel}
+                  <div class="mt-3 flex items-start gap-2 rounded-lg border border-yellow-200 bg-yellow-50 px-3 py-2 text-xs text-yellow-800 dark:border-yellow-900 dark:bg-yellow-950/30 dark:text-yellow-300">
+                    <CircleAlert class="h-4 w-4 shrink-0" />
+                    Save this model first; the test currently uses the previously saved model.
+                  </div>
+                {/if}
+
+                {#if testResult}
+                  <div class="mt-3 flex items-start gap-2 rounded-lg border px-3 py-2.5 text-sm {testResult.ok ? 'border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950/30 dark:text-green-300' : 'border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300'}">
+                    {#if testResult.ok}
+                      <CheckCircle class="mt-0.5 h-4 w-4 shrink-0" />
+                    {:else}
+                      <XCircle class="mt-0.5 h-4 w-4 shrink-0" />
+                    {/if}
+                    <div>
+                      <p class="font-medium">
+                        {testResult.ok ? 'Connection successful' : 'Connection failed'}
+                      </p>
+                      <p class="mt-0.5 text-xs opacity-90">{testResult.message}</p>
+                    </div>
+                  </div>
+                {/if}
+              </section>
+            </div>
+          {:else if activeTab === 'credentials' && selectedProvider}
             <ProviderCredentialsPanel
               providerId={selectedProvider.id}
               providerLabel={selectedProvider.label}
               credentialUrl={selectedProvider.credential_url}
               authType={selectedProvider.auth_type}
-              onChanged={refreshCredentialState}
+              onChanged={() => refreshCredentialState(selectedProvider.id)}
             />
-          {:else}
-            <section class="rounded-xl border border-border bg-card p-4 sm:p-5">
-              <div class="flex items-start gap-3">
-                <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary"><KeyRound class="h-4 w-4" /></div>
-                <div class="min-w-0 flex-1">
-                  <div class="flex flex-wrap items-start justify-between gap-3">
-                    <div>
-                      <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Credential</p>
-                      <h3 class="mt-0.5 text-sm font-semibold">{selectedProvider?.requires_api_key ? selectedProvider.auth_type === 'token' ? 'Provide an access token' : 'Provide an API key' : 'No credential required'}</h3>
-                    </div>
-                    {#if selectedProvider?.credential_url}
-                      <a href={selectedProvider.credential_url} target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">
-                        {credentialActionLabel(selectedProvider.auth_type)}<ExternalLink class="h-3 w-3" />
-                      </a>
-                    {/if}
-                  </div>
-                  {#if selectedProvider?.requires_api_key}
-                    <div class="relative mt-3">
-                      <input type={showApiKey ? 'text' : 'password'} bind:value={apiKey} placeholder="Enter your credential…" class="w-full rounded-lg border border-border bg-background px-3 py-2.5 pr-11 text-sm outline-none focus:ring-2 focus:ring-primary/30" autocomplete="new-password" />
-                      <button type="button" onclick={() => (showApiKey = !showApiKey)} class="absolute right-2.5 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground" aria-label={showApiKey ? 'Hide credential' : 'Show credential'}>
-                        {#if showApiKey}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
-                      </button>
-                    </div>
-                  {:else}
-                    <p class="mt-3 text-sm text-muted-foreground">This local provider does not require an API key.</p>
-                  {/if}
+          {:else if activeTab === 'routing'}
+            <div class="mx-auto max-w-2xl space-y-5">
+              <div>
+                <div class="flex items-center gap-2">
+                  <Route class="h-4 w-4 text-primary" />
+                  <h3 class="text-base font-semibold">Credential routing</h3>
                 </div>
+                <p class="mt-1 text-sm text-muted-foreground">
+                  Choose how ApplyKit selects a credential for each request.
+                </p>
               </div>
-            </section>
+
+              <div class="grid gap-3">
+                {#each ['manual', 'failover', 'round_robin'] as strategy}
+                  {@const typedStrategy = strategy as CredentialStrategy}
+                  {@const automatic = typedStrategy !== 'manual'}
+                  <button
+                    type="button"
+                    onclick={() => (routingStrategy = typedStrategy)}
+                    disabled={automatic && !automaticRoutingAvailable}
+                    class="flex items-start gap-3 rounded-xl border p-4 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50 {routingStrategy === typedStrategy ? 'border-primary bg-primary/5' : 'border-border hover:bg-accent/40'}"
+                  >
+                    <span class="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border {routingStrategy === typedStrategy ? 'border-primary bg-primary' : 'border-muted-foreground/50'}">
+                      {#if routingStrategy === typedStrategy}
+                        <span class="h-1.5 w-1.5 rounded-full bg-primary-foreground"></span>
+                      {/if}
+                    </span>
+                    <span class="min-w-0 flex-1">
+                      <span class="flex flex-wrap items-center gap-2 text-sm font-semibold">
+                        {credentialStrategyLabel(typedStrategy)}
+                        {#if typedStrategy === 'failover'}
+                          <span class="rounded bg-green-100 px-1.5 py-0.5 text-[9px] font-semibold uppercase text-green-700 dark:bg-green-950/60 dark:text-green-300">
+                            Recommended
+                          </span>
+                        {/if}
+                        {#if typedStrategy === 'round_robin'}
+                          <span class="rounded bg-muted px-1.5 py-0.5 text-[9px] font-semibold uppercase text-muted-foreground">
+                            Advanced
+                          </span>
+                        {/if}
+                      </span>
+                      <span class="mt-1 block text-xs text-muted-foreground">
+                        {credentialStrategyDescription(typedStrategy)}
+                      </span>
+                      {#if automatic && !automaticRoutingAvailable}
+                        <span class="mt-1 block text-[11px] text-yellow-700 dark:text-yellow-300">
+                          Requires at least two enabled credentials.
+                        </span>
+                      {/if}
+                    </span>
+                  </button>
+                {/each}
+              </div>
+
+              {#if routingStrategy !== 'manual'}
+                <label class="flex items-center justify-between gap-4 rounded-xl border border-border bg-muted/30 px-4 py-3 text-sm">
+                  <span>
+                    <span class="font-semibold">Maximum attempts</span>
+                    <span class="mt-0.5 block text-xs text-muted-foreground">
+                      Includes the first credential. Lower values reduce duplicate cost risk.
+                    </span>
+                  </span>
+                  <select
+                    bind:value={routingMaxAttempts}
+                    class="rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium"
+                  >
+                    {#each [2, 3, 4, 5] as attemptCount}
+                      <option value={attemptCount}>{attemptCount}</option>
+                    {/each}
+                  </select>
+                </label>
+              {/if}
+            </div>
           {/if}
 
-          <section class="rounded-xl border border-border bg-card p-4 sm:p-5">
-            <div class="flex items-start gap-3">
-              <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary"><ShieldCheck class="h-4 w-4" /></div>
-              <div class="min-w-0 flex-1">
-                <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Verification</p>
-                <div class="mt-0.5 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                  <div>
-                    <h3 class="text-sm font-semibold">Test the selected model</h3>
-                    <p class="mt-1 text-xs text-muted-foreground">
-                      {#if testMode === 'stored'}Uses the active credential stored securely on the backend.{:else if selectedProvider?.local}Sends one minimal request to the local provider.{:else}Sends one minimal request with the credential entered above.{/if}
-                    </p>
-                  </div>
-                  <button onclick={handleTest} disabled={testing || !canTest} class="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-border px-3.5 py-2 text-sm font-medium transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50">
-                    {#if testing}<Loader2 class="h-4 w-4 animate-spin" />Testing…{:else if testMode === 'stored'}Test saved connection{:else}Test connection{/if}
-                  </button>
-                </div>
-                {#if storedTestUsesOlderModel}
-                  <div class="mt-3 flex items-start gap-2 rounded-lg border border-yellow-200 bg-yellow-50 px-3 py-2 text-xs text-yellow-800 dark:border-yellow-900 dark:bg-yellow-950/30 dark:text-yellow-300">
-                    <CircleAlert class="h-4 w-4 shrink-0" />Save this model first; the configured test currently uses the previously saved model.
-                  </div>
-                {/if}
-                {#if testResult}
-                  <div class="mt-3 flex items-start gap-2 rounded-lg border px-3 py-2.5 text-sm {testResult.ok ? 'border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950/30 dark:text-green-300' : 'border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300'}">
-                    {#if testResult.ok}<CheckCircle class="mt-0.5 h-4 w-4 shrink-0" />{:else}<XCircle class="mt-0.5 h-4 w-4 shrink-0" />{/if}
-                    <div><p class="font-medium">{testResult.ok ? 'Connection successful' : 'Connection failed'}</p><p class="mt-0.5 text-xs opacity-90">{testResult.message}</p></div>
-                  </div>
-                {/if}
-              </div>
-            </div>
-          </section>
-
           {#if saveError}
-            <div class="flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
-              <XCircle class="mt-0.5 h-4 w-4 shrink-0" /><span>{saveError}</span>
+            <div class="mx-auto mt-5 flex max-w-2xl items-start gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+              <XCircle class="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{saveError}</span>
             </div>
           {/if}
         </div>
 
         <footer class="border-t border-border bg-background/95 px-5 py-4 backdrop-blur sm:px-6">
-          <div class="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <button onclick={closeModal} disabled={saving !== null || testing} class="inline-flex items-center justify-center rounded-lg border border-border px-4 py-2.5 text-sm font-medium transition-colors hover:bg-accent disabled:opacity-50">Cancel</button>
-            <div class="flex flex-col-reverse gap-2 sm:flex-row">
-              {#if !isActive}
-                <button onclick={() => handleSave(false)} disabled={saving !== null || testing || !canSave} class="inline-flex items-center justify-center gap-2 rounded-lg border border-border px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50">
-                  {#if saving === 'only'}<Loader2 class="h-4 w-4 animate-spin" />{/if}Save only
-                </button>
-              {/if}
-              <button onclick={() => handleSave(true)} disabled={saving !== null || testing || !canSave} class="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50">
-                {#if saving === 'activate'}<Loader2 class="h-4 w-4 animate-spin" />{/if}{primaryLabel}
+          {#if activeTab === 'credentials'}
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p class="text-xs text-muted-foreground">
+                Credential changes are saved immediately.
+              </p>
+              <button
+                onclick={closeModal}
+                class="inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90"
+              >
+                {footerActionForTab('credentials')}
               </button>
             </div>
-          </div>
-          {#if !isActive}<p class="mt-2 text-center text-[11px] text-muted-foreground sm:text-right">Save only keeps the current active provider unchanged.</p>{/if}
+          {:else if activeTab === 'routing'}
+            <div class="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <button
+                onclick={closeModal}
+                disabled={savingRouting}
+                class="inline-flex items-center justify-center rounded-lg border border-border px-4 py-2.5 text-sm font-medium hover:bg-accent disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onclick={handleSaveRouting}
+                disabled={savingRouting || !routingDirty || (routingStrategy !== 'manual' && !automaticRoutingAvailable)}
+                class="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {#if savingRouting}
+                  <Loader2 class="h-4 w-4 animate-spin" />
+                {/if}
+                {footerActionForTab('routing')}
+              </button>
+            </div>
+          {:else}
+            <div class="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <button
+                onclick={closeModal}
+                disabled={saving !== null || testing}
+                class="inline-flex items-center justify-center rounded-lg border border-border px-4 py-2.5 text-sm font-medium transition-colors hover:bg-accent disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <div class="flex flex-col-reverse gap-2 sm:flex-row">
+                {#if !isActive}
+                  <button
+                    onclick={() => handleSave(false)}
+                    disabled={saving !== null || testing || !canSave}
+                    class="inline-flex items-center justify-center gap-2 rounded-lg border border-border px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {#if saving === 'only'}
+                      <Loader2 class="h-4 w-4 animate-spin" />
+                    {/if}
+                    Save only
+                  </button>
+                {/if}
+                <button
+                  onclick={() => handleSave(true)}
+                  disabled={saving !== null || testing || !canSave}
+                  class="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {#if saving === 'activate'}
+                    <Loader2 class="h-4 w-4 animate-spin" />
+                  {/if}
+                  {isActive ? footerActionForTab('model') : primaryLabel}
+                </button>
+              </div>
+            </div>
+          {/if}
         </footer>
       {/if}
     </div>

--- a/frontend/src/lib/settings-modal-tabs.test.ts
+++ b/frontend/src/lib/settings-modal-tabs.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  defaultSettingsTab,
+  footerActionForTab,
+  type ProviderSettingsTab,
+} from './settings-modal-tabs';
+
+describe('provider settings modal tabs', () => {
+  test('connected remote providers open on credentials', () => {
+    expect(defaultSettingsTab({ isExistingProvider: true, requiresCredential: true })).toBe(
+      'credentials',
+    );
+  });
+
+  test('new and local providers open on model', () => {
+    expect(defaultSettingsTab({ isExistingProvider: false, requiresCredential: true })).toBe(
+      'model',
+    );
+    expect(defaultSettingsTab({ isExistingProvider: true, requiresCredential: false })).toBe(
+      'model',
+    );
+  });
+
+  test('each tab has a clear footer action', () => {
+    const cases: Array<[ProviderSettingsTab, string]> = [
+      ['model', 'Save model changes'],
+      ['credentials', 'Done'],
+      ['routing', 'Save routing settings'],
+    ];
+
+    for (const [tab, label] of cases) {
+      expect(footerActionForTab(tab)).toBe(label);
+    }
+  });
+});

--- a/frontend/src/lib/settings-modal-tabs.ts
+++ b/frontend/src/lib/settings-modal-tabs.ts
@@ -1,0 +1,14 @@
+export type ProviderSettingsTab = 'model' | 'credentials' | 'routing';
+
+export function defaultSettingsTab(input: {
+  isExistingProvider: boolean;
+  requiresCredential: boolean;
+}): ProviderSettingsTab {
+  return input.isExistingProvider && input.requiresCredential ? 'credentials' : 'model';
+}
+
+export function footerActionForTab(tab: ProviderSettingsTab): string {
+  if (tab === 'credentials') return 'Done';
+  if (tab === 'routing') return 'Save routing settings';
+  return 'Save model changes';
+}


### PR DESCRIPTION
## Summary
- redesign the provider settings modal around focused Model, Credentials, and Routing tabs
- open connected remote providers directly on Credentials
- keep first-time and local-provider setup focused on Model
- widen the modal and remove repeated nested cards
- use clearer text actions for Test, Rename, Replace, and Set active
- move destructive credential removal into a secondary menu with confirmation
- save credential changes immediately and make routing changes explicit through Save routing settings
- keep Save only and Save & set active behavior for model changes
- add unit coverage for tab defaults and footer actions
- replace the outdated long README with concise setup, feature, provider, credential, security, backup, and development guidance
- persist Docker's generated credential encryption key inside the `/data` volume so backups include both the database and decryption material

## Verification
- Frontend unit tests: success
- Svelte type-check: success
- production build: success

No tag or release is included.