### PR TITLE
feat: add Community frontend authentication

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -11,9 +11,6 @@ on:
       - 'frontend/**'
       - '.github/workflows/ci-frontend.yml'
 
-permissions:
-  contents: write
-
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -23,28 +20,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Set up bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - name: Resolve auth dependencies
-        run: bun add @zxcvbn-ts/core @zxcvbn-ts/language-common @zxcvbn-ts/language-en
-
-      - name: Commit dependency lock
-        working-directory: .
-        run: |
-          if git diff --quiet -- frontend/package.json frontend/bun.lock; then
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add frontend/package.json frontend/bun.lock
-          git commit -m "build: add password strength dependencies"
-          git push origin HEAD:${{ github.head_ref }}
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Unit tests
         run: bun run test

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -11,6 +11,9 @@ on:
       - 'frontend/**'
       - '.github/workflows/ci-frontend.yml'
 
+permissions:
+  contents: write
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -20,14 +23,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Set up bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - name: Resolve auth dependencies
+        run: bun add @zxcvbn-ts/core @zxcvbn-ts/language-common @zxcvbn-ts/language-en
+
+      - name: Commit dependency lock
+        working-directory: .
+        run: |
+          if git diff --quiet -- frontend/package.json frontend/bun.lock; then
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add frontend/package.json frontend/bun.lock
+          git commit -m "build: add password strength dependencies"
+          git push origin HEAD:${{ github.head_ref }}
 
       - name: Unit tests
         run: bun run test

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ AUTH_MODE=password  # single-owner protected mode
 
 Protected mode secures the whole installation and every career profile with one owner password. It does not create separate accounts for individual profiles.
 
-The backend foundation is available in this release. The matching browser setup and login screens are delivered by the frontend authentication follow-up.
+When password mode is enabled, the browser redirects an unclaimed installation to `/setup` and an existing protected installation to `/login`. The normal local flow remains unchanged when authentication is disabled.
 
 ### First owner setup
 
@@ -84,7 +84,7 @@ uv run alembic upgrade head
 uv run main.py
 ```
 
-An unclaimed installation prints a one-time setup token. The token:
+Open ApplyKit, paste the one-time token into the setup page, and create the owner password. The token:
 
 - expires after 30 minutes;
 - is stored only as a hash;
@@ -98,6 +98,7 @@ Owner passwords must contain 12–128 characters. Passphrases are supported with
 - Normal sessions expire 7 days after login.
 - **Remember this device** sessions expire after 30 days.
 - Expiry is absolute and does not extend with activity.
+- The browser warns during the final five minutes and can reauthenticate in a separate tab.
 - Session and CSRF token hashes are stored in SQLite; raw session tokens stay in cookies.
 - Session cookies are `HttpOnly` and `SameSite=Lax`.
 - Mutating requests require a session-bound CSRF token and an allowed `Origin`.
@@ -105,6 +106,8 @@ Owner passwords must contain 12–128 characters. Passphrases are supported with
 - Logout revokes the current session. Password reset revokes every session.
 
 Only health checks and the required setup/login endpoints remain public. Application data, AI settings, credentials, and API documentation require authentication in protected mode.
+
+Password changes and signing out other devices are available under **Settings → Security**. ApplyKit displays only the count of other active sessions and does not collect device, IP, or location details for this view.
 
 ### Remote HTTPS deployment
 
@@ -126,7 +129,7 @@ Do not expose protected mode through public plain HTTP. ApplyKit logs a warning 
 
 ### Forgotten password
 
-There is no email recovery or recovery key. Reset the password from the machine running ApplyKit:
+There is no email recovery or recovery key. The login page shows these same recovery commands, which must be run from the machine hosting ApplyKit:
 
 ```bash
 # Docker

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For localhost over HTTP:
 COOKIE_SECURE=false
 ```
 
-For any remote HTTPS deployment:
+For remote protected mode, serve the frontend and API from the same hostname. A reverse proxy can expose the frontend at `/` and forward `/api` to the backend. This is required so the browser can read the CSRF cookie and send it with mutation requests.
 
 ```env
 AUTH_MODE=password
@@ -125,7 +125,13 @@ COOKIE_SECURE=true
 CORS_ORIGINS=["https://applykit.example.com"]
 ```
 
-Do not expose protected mode through public plain HTTP. ApplyKit logs a warning when password mode starts with `COOKIE_SECURE=false`.
+Build the frontend with the same-origin API path:
+
+```bash
+VITE_API_BASE_URL=https://applykit.example.com/api docker compose up --build
+```
+
+Do not place the browser UI at `app.example.com` while using a host-only API cookie from `api.example.com`. Do not expose protected mode through public plain HTTP. ApplyKit logs a warning when password mode starts with `COOKIE_SECURE=false`.
 
 ### Forgotten password
 
@@ -213,11 +219,7 @@ CREDENTIAL_KEY_FILE=.applykit/credential.key
 MAX_PROVIDER_CREDENTIALS=20
 ```
 
-For a remote frontend build, set the browser-reachable API URL:
-
-```bash
-VITE_API_BASE_URL=https://api.example.com/api docker compose up --build
-```
+For a remote frontend build, use the browser-reachable same-host API URL described under protected mode.
 
 ## Stack
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -7,6 +7,9 @@
       "dependencies": {
         "@lucide/svelte": "^0.577.0",
         "@types/canvas-confetti": "^1.9.0",
+        "@zxcvbn-ts/core": "^4.1.2",
+        "@zxcvbn-ts/language-common": "^4.1.3",
+        "@zxcvbn-ts/language-en": "^4.1.1",
         "bits-ui": "^2.16.3",
         "canvas-confetti": "^1.9.4",
         "clsx": "^2.1.1",
@@ -222,6 +225,14 @@
 
     "@typescript-eslint/types": ["@typescript-eslint/types@8.57.0", "", {}, "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg=="],
 
+    "@zxcvbn-ts/core": ["@zxcvbn-ts/core@4.1.2", "", { "dependencies": { "fastest-levenshtein": "1.0.16" } }, "sha512-RQmxWB3AMI+HGQErQdUv6Aq32aQhp6xOxrfgCP0+T9MsLZoP3xtLHuT8O8VojsUxdmQVZfJlYkYb1A0wOwIS+Q=="],
+
+    "@zxcvbn-ts/dictionary-compression": ["@zxcvbn-ts/dictionary-compression@3.0.1", "", {}, "sha512-p3KyPzxGc3vWSap5hHA6SllbUCmh7s+NtpGyC3qEWrxYJT9t9TUAzjPm48Okipo+UUyPQfDlIvTcs9JRShBFiQ=="],
+
+    "@zxcvbn-ts/language-common": ["@zxcvbn-ts/language-common@4.1.3", "", { "dependencies": { "@zxcvbn-ts/dictionary-compression": "^3.0.1" } }, "sha512-g2bg4skmlJG9aJqC/nWziZzgYpSe/f3rKeGobrkdFiOrfZVFqqzUgC6BUQWuX54Sua9j0Jxxt+1bf4f/Mal1Kg=="],
+
+    "@zxcvbn-ts/language-en": ["@zxcvbn-ts/language-en@4.1.1", "", { "dependencies": { "@zxcvbn-ts/dictionary-compression": "^3.0.1" } }, "sha512-6UdzuBd3Uex8TKubohcn+uXRVAH34Zjs2eCfT4hQVo9zeTy7AkQRQfdV4OnHR5hQfW/XBrK/AGTZk7VBWh7wwQ=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
@@ -269,6 +280,8 @@
     "esrap": ["esrap@2.2.4", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15", "@typescript-eslint/types": "^8.2.0" } }, "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg=="],
 
     "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "fastest-levenshtein": ["fastest-levenshtein@1.0.16", "", {}, "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,9 @@
   "dependencies": {
     "@lucide/svelte": "^0.577.0",
     "@types/canvas-confetti": "^1.9.0",
+    "@zxcvbn-ts/core": "^4.1.2",
+    "@zxcvbn-ts/language-common": "^4.1.3",
+    "@zxcvbn-ts/language-en": "^4.1.1",
     "bits-ui": "^2.16.3",
     "canvas-confetti": "^1.9.4",
     "clsx": "^2.1.1",

--- a/frontend/src/lib/api-client.test.ts
+++ b/frontend/src/lib/api-client.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+
+import { apiFetch, onUnauthorized } from './api-client';
+
+
+describe('apiFetch', () => {
+    test('includes credentials and preserves caller headers', async () => {
+        let captured: RequestInit | undefined;
+        const fetchFn = async (_input: RequestInfo | URL, init?: RequestInit) => {
+            captured = init;
+            return new Response('{}', { status: 200 });
+        };
+
+        await apiFetch('/test', {
+            method: 'GET',
+            headers: { 'X-Custom': 'value' },
+        }, fetchFn as typeof fetch, '');
+
+        expect(captured?.credentials).toBe('include');
+        expect(new Headers(captured?.headers).get('X-Custom')).toBe('value');
+        expect(new Headers(captured?.headers).get('X-CSRF-Token')).toBeNull();
+    });
+
+    test('adds CSRF to unsafe methods without replacing headers', async () => {
+        let captured: RequestInit | undefined;
+        const fetchFn = async (_input: RequestInfo | URL, init?: RequestInit) => {
+            captured = init;
+            return new Response('{}', { status: 200 });
+        };
+
+        await apiFetch('/test', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{}',
+        }, fetchFn as typeof fetch, 'applykit_csrf=csrf-value');
+
+        const headers = new Headers(captured?.headers);
+        expect(headers.get('Content-Type')).toBe('application/json');
+        expect(headers.get('X-CSRF-Token')).toBe('csrf-value');
+    });
+
+    test('notifies once on 401 and never replays the request', async () => {
+        let fetchCount = 0;
+        let unauthorizedCount = 0;
+        const unsubscribe = onUnauthorized(() => unauthorizedCount++);
+        const fetchFn = async () => {
+            fetchCount++;
+            return new Response('{}', { status: 401 });
+        };
+
+        const response = await apiFetch('/test', { method: 'POST' }, fetchFn as typeof fetch, '');
+        unsubscribe();
+
+        expect(response.status).toBe(401);
+        expect(fetchCount).toBe(1);
+        expect(unauthorizedCount).toBe(1);
+    });
+});

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,0 +1,38 @@
+import { isUnsafeMethod, readCookie } from './auth-utils';
+
+type UnauthorizedHandler = () => void;
+const unauthorizedHandlers = new Set<UnauthorizedHandler>();
+
+export function onUnauthorized(handler: UnauthorizedHandler): () => void {
+    unauthorizedHandlers.add(handler);
+    return () => unauthorizedHandlers.delete(handler);
+}
+
+function notifyUnauthorized(): void {
+    for (const handler of unauthorizedHandlers) handler();
+}
+
+export async function apiFetch(
+    input: RequestInfo | URL,
+    init: RequestInit = {},
+    fetchFn: typeof fetch = fetch,
+    cookieSource?: string,
+): Promise<Response> {
+    const method = (init.method ?? 'GET').toUpperCase();
+    const headers = new Headers(init.headers);
+
+    if (isUnsafeMethod(method)) {
+        const csrf = readCookie('applykit_csrf', cookieSource);
+        if (csrf) headers.set('X-CSRF-Token', csrf);
+    }
+
+    const response = await fetchFn(input, {
+        ...init,
+        method,
+        headers,
+        credentials: 'include',
+    });
+
+    if (response.status === 401) notifyUnauthorized();
+    return response;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -35,29 +35,25 @@ import type {
     UpdateApplicationRequest,
     UpdateSettingsRequest,
 } from './types';
+import { apiFetch } from './api-client';
 import { parseApiError } from './api-error';
 import { buildQs } from './utils';
 
-// ---------------------------------------------------------------------------
-// Base URL — override via VITE_API_BASE_URL env variable for non-localhost envs
-// ---------------------------------------------------------------------------
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000/api';
-
-// ---------------------------------------------------------------------------
-// Core fetch helpers
-// ---------------------------------------------------------------------------
 
 async function throwApiError(res: Response, fallbackMessage: string): Promise<never> {
     const payload: unknown = await res.json().catch(() => undefined);
     throw parseApiError(payload, fallbackMessage, res.status);
 }
 
-/** JSON request/response for the vast majority of API calls. */
-async function request<T>(path: string, options: RequestInit = {}, fetchFn: typeof fetch = fetch): Promise<T> {
-    const res = await fetchFn(`${BASE_URL}${path}`, {
-        headers: { 'Content-Type': 'application/json', ...options.headers },
-        ...options,
-    });
+async function request<T>(
+    path: string,
+    options: RequestInit = {},
+    fetchFn: typeof fetch = fetch,
+): Promise<T> {
+    const headers = new Headers(options.headers);
+    if (!headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
+    const res = await apiFetch(`${BASE_URL}${path}`, { ...options, headers }, fetchFn);
 
     if (!res.ok) {
         await throwApiError(res, 'Something went wrong. Please try again.');
@@ -70,18 +66,16 @@ async function request<T>(path: string, options: RequestInit = {}, fetchFn: type
     return res.json() as Promise<T>;
 }
 
-/** FormData upload — used for file and text CV imports. */
 async function requestForm<T>(path: string, body: FormData): Promise<T> {
-    const res = await fetch(`${BASE_URL}${path}`, { method: 'POST', body });
+    const res = await apiFetch(`${BASE_URL}${path}`, { method: 'POST', body });
     if (!res.ok) {
         await throwApiError(res, 'Failed to import your CV. Please check the file and try again.');
     }
     return res.json() as Promise<T>;
 }
 
-/** Blob download — used for PDF generation endpoints. */
 async function requestBlob(path: string, options: RequestInit): Promise<Blob> {
-    const res = await fetch(`${BASE_URL}${path}`, {
+    const res = await apiFetch(`${BASE_URL}${path}`, {
         headers: { 'Content-Type': 'application/json' },
         ...options,
     });
@@ -91,9 +85,13 @@ async function requestBlob(path: string, options: RequestInit): Promise<Blob> {
     return res.blob();
 }
 
-// ---------------------------------------------------------------------------
-// Profile
-// ---------------------------------------------------------------------------
+function requestStream(path: string, body: unknown): Promise<Response> {
+    return apiFetch(`${BASE_URL}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+}
 
 export const listProfiles = (fetchFn?: typeof fetch) =>
     request<ProfileListResponse>('/profiles', {}, fetchFn);
@@ -113,16 +111,8 @@ export const deleteProfile = (profileId: number, fetchFn?: typeof fetch) =>
 export const getOnboardingStatus = (fetchFn?: typeof fetch) =>
     request<OnboardingStatusResponse>('/onboarding', {}, fetchFn);
 
-// ---------------------------------------------------------------------------
-// Status
-// ---------------------------------------------------------------------------
-
 export const getStatus = (fetchFn?: typeof fetch) =>
     request<StatusResponse>('/status', {}, fetchFn);
-
-// ---------------------------------------------------------------------------
-// Import CV
-// ---------------------------------------------------------------------------
 
 export const importCvFile = (file: File) => {
     const form = new FormData();
@@ -136,10 +126,6 @@ export const importCvText = (text: string) => {
     return requestForm<ProfileData>('/import/cv', form);
 };
 
-// ---------------------------------------------------------------------------
-// Generate CV
-// ---------------------------------------------------------------------------
-
 export const generateCv = (data: GenerateCvRequest) =>
     request<GenerateCvResponse>('/generate/cv', { method: 'POST', body: JSON.stringify(data) });
 
@@ -147,15 +133,7 @@ export const generateCvPdf = (data: CvPdfRequest) =>
     requestBlob('/generate/cv/pdf', { method: 'POST', body: JSON.stringify(data) });
 
 export const generateCvStream = (data: GenerateCvRequest): Promise<Response> =>
-    fetch(`${BASE_URL}/generate/cv/stream`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-    });
-
-// ---------------------------------------------------------------------------
-// Generate Cover Letter
-// ---------------------------------------------------------------------------
+    requestStream('/generate/cv/stream', data);
 
 export const generateCoverLetter = (data: CoverLetterRequest) =>
     request<CoverLetterResponse>('/generate/cover-letter', {
@@ -164,18 +142,10 @@ export const generateCoverLetter = (data: CoverLetterRequest) =>
     });
 
 export const generateCoverLetterStream = (data: CoverLetterRequest): Promise<Response> =>
-    fetch(`${BASE_URL}/generate/cover-letter`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-    });
+    requestStream('/generate/cover-letter', data);
 
 export const generateCoverLetterPdf = (data: CoverLetterPdfRequest) =>
     requestBlob('/generate/cover-letter/pdf', { method: 'POST', body: JSON.stringify(data) });
-
-// ---------------------------------------------------------------------------
-// Generate Bullets / Summary (streaming endpoints)
-// ---------------------------------------------------------------------------
 
 export const generateBulletsStream = (
     profile_id: number,
@@ -183,24 +153,21 @@ export const generateBulletsStream = (
     role: string,
     bullets: string[],
     mode: 'improve' | 'reorganize',
-    extra_context?: string
-): Promise<Response> =>
-    fetch(`${BASE_URL}/generate/bullets`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ profile_id, company, role, bullets, mode, extra_context }),
-    });
+    extra_context?: string,
+): Promise<Response> => requestStream('/generate/bullets', {
+    profile_id,
+    company,
+    role,
+    bullets,
+    mode,
+    extra_context,
+});
 
-export const generateSummaryStream = (profile_id: number, tone: string, extra_context?: string): Promise<Response> =>
-    fetch(`${BASE_URL}/generate/summary`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ profile_id, tone, extra_context }),
-    });
-
-// ---------------------------------------------------------------------------
-// Scrape
-// ---------------------------------------------------------------------------
+export const generateSummaryStream = (
+    profile_id: number,
+    tone: string,
+    extra_context?: string,
+): Promise<Response> => requestStream('/generate/summary', { profile_id, tone, extra_context });
 
 export const scrapeJob = (url: string) =>
     request<ScrapeJobResponse>('/scrape/job', { method: 'POST', body: JSON.stringify({ url }) });
@@ -209,21 +176,18 @@ export const scrapeAnalyze = (data: { url?: string; text?: string }) =>
     request<ScrapeAnalyzeResponse>('/scrape/analyze', { method: 'POST', body: JSON.stringify(data) });
 
 export const parseJobDescription = (text: string) =>
-    request<{ company_name: string | null; role_title: string | null; location: string | null; salary: string | null }>('/scrape/parse', { method: 'POST', body: JSON.stringify({ text }) });
-
-// ---------------------------------------------------------------------------
-// Fit Analysis
-// ---------------------------------------------------------------------------
+    request<{
+        company_name: string | null;
+        role_title: string | null;
+        location: string | null;
+        salary: string | null;
+    }>('/scrape/parse', { method: 'POST', body: JSON.stringify({ text }) });
 
 export const analyzeFit = (profile_id: number, job_description: string) =>
     request<FitAnalysisResponse>('/analyze/fit', {
         method: 'POST',
         body: JSON.stringify({ profile_id, job_description }),
     });
-
-// ---------------------------------------------------------------------------
-// CV History
-// ---------------------------------------------------------------------------
 
 export const getCvHistory = (filters: CvHistoryFilters = {}) =>
     request<GeneratedCVListResponse>(`/history/cv${buildQs(filters)}`);
@@ -246,10 +210,6 @@ export const bulkDeleteCvs = (ids: number[]) =>
         body: JSON.stringify({ ids }),
     });
 
-// ---------------------------------------------------------------------------
-// Cover Letter History
-// ---------------------------------------------------------------------------
-
 export const getCoverLetterHistory = (filters: CoverLetterHistoryFilters = {}) =>
     request<GeneratedCoverLetterListResponse>(`/history/cover-letter${buildQs(filters)}`);
 
@@ -271,10 +231,6 @@ export const bulkDeleteCoverLetters = (ids: number[]) =>
         body: JSON.stringify({ ids }),
     });
 
-// ---------------------------------------------------------------------------
-// Settings
-// ---------------------------------------------------------------------------
-
 export const getSettings = () =>
     request<SettingsResponse>('/settings');
 
@@ -291,14 +247,13 @@ export const getIntegrations = () =>
     request<IntegrationsResponse>('/settings/integrations');
 
 export const activateProvider = (provider_id: string) =>
-    request<SettingsResponse>('/settings/activate', { method: 'PUT', body: JSON.stringify({ provider_id }) });
+    request<SettingsResponse>('/settings/activate', {
+        method: 'PUT',
+        body: JSON.stringify({ provider_id }),
+    });
 
 export const disconnectProvider = (provider_id: string) =>
     request<IntegrationsResponse>(`/settings/integrations/${provider_id}`, { method: 'DELETE' });
-
-// ---------------------------------------------------------------------------
-// Applications
-// ---------------------------------------------------------------------------
 
 export const listApplications = (filters: ApplicationFilters = {}) =>
     request<ApplicationListResponse>(`/applications${buildQs(filters)}`);
@@ -310,14 +265,13 @@ export const getApplication = (id: number) =>
     request<ApplicationEntry>(`/applications/${id}`);
 
 export const updateApplication = (id: number, data: UpdateApplicationRequest) =>
-    request<ApplicationEntry>(`/applications/${id}`, { method: 'PATCH', body: JSON.stringify(data) });
+    request<ApplicationEntry>(`/applications/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+    });
 
 export const deleteApplication = (id: number) =>
     request<{ deleted: number }>(`/applications/${id}`, { method: 'DELETE' });
-
-// ---------------------------------------------------------------------------
-// LLM Usage
-// ---------------------------------------------------------------------------
 
 export const getLlmUsage = (filters?: LlmUsageFilters) => {
     const params = filters ? buildQs(filters) : '';

--- a/frontend/src/lib/auth-api-lockout.test.ts
+++ b/frontend/src/lib/auth-api-lockout.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'bun:test';
+
+import { loginOwner } from './auth-api';
+
+
+test('login surfaces backend lockout retry timing', async () => {
+    const fetchFn = async () => new Response(JSON.stringify({
+        error: {
+            code: 'AUTH_LOCKED',
+            message: 'Too many attempts. Try again later.',
+            details: { retry_after_seconds: 61 },
+        },
+    }), {
+        status: 429,
+        headers: { 'Content-Type': 'application/json' },
+    });
+
+    await expect(loginOwner(
+        { password: 'wrong password', remember_device: false },
+        fetchFn as typeof fetch,
+    )).rejects.toMatchObject({
+        message: 'Too many attempts. Try again in 2 minutes.',
+        code: 'AUTH_LOCKED',
+        status: 429,
+    });
+});

--- a/frontend/src/lib/auth-api.test.ts
+++ b/frontend/src/lib/auth-api.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+    changeOwnerPassword,
+    getAuthStatus,
+    getSecuritySummary,
+    loginOwner,
+    logoutOwner,
+    revokeOtherSessions,
+    setupOwner,
+} from './auth-api';
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+
+describe('auth API', () => {
+    test('includes credentials for status requests', async () => {
+        let request: RequestInit | undefined;
+        const fetchFn = async (_input: RequestInfo | URL, init?: RequestInit) => {
+            request = init;
+            return jsonResponse({
+                auth_mode: 'password',
+                setup_required: false,
+                authenticated: false,
+                session_expires_at: null,
+            });
+        };
+
+        await getAuthStatus(fetchFn as typeof fetch);
+        expect(request?.credentials).toBe('include');
+        expect(request?.method).toBe('GET');
+    });
+
+    test('sends setup and login payloads exactly as the backend expects', async () => {
+        const calls: Array<{ url: string; init?: RequestInit }> = [];
+        const fetchFn = async (input: RequestInfo | URL, init?: RequestInit) => {
+            calls.push({ url: String(input), init });
+            return jsonResponse({
+                authenticated: true,
+                remember_device: false,
+                session_expires_at: '2026-08-09T10:00:00Z',
+            }, calls.length === 1 ? 201 : 200);
+        };
+
+        await setupOwner({ setup_token: 'token', password: 'secure passphrase' }, fetchFn as typeof fetch);
+        await loginOwner({ password: 'secure passphrase', remember_device: true }, fetchFn as typeof fetch);
+
+        expect(JSON.parse(String(calls[0].init?.body))).toEqual({
+            setup_token: 'token',
+            password: 'secure passphrase',
+        });
+        expect(JSON.parse(String(calls[1].init?.body))).toEqual({
+            password: 'secure passphrase',
+            remember_device: true,
+        });
+    });
+
+    test('adds the CSRF header to unsafe authenticated operations', async () => {
+        const calls: RequestInit[] = [];
+        const fetchFn = async (_input: RequestInfo | URL, init?: RequestInit) => {
+            calls.push(init ?? {});
+            return init?.method === 'POST' && calls.length === 1
+                ? new Response(null, { status: 204 })
+                : jsonResponse(calls.length === 2
+                    ? { other_sessions: 2 }
+                    : calls.length === 3
+                        ? { authenticated: true, remember_device: false, session_expires_at: '2026-08-09T10:00:00Z' }
+                        : { revoked_sessions: 2 });
+        };
+
+        await logoutOwner(fetchFn as typeof fetch, 'csrf-value');
+        await getSecuritySummary(fetchFn as typeof fetch);
+        await changeOwnerPassword(
+            { current_password: 'old passphrase', new_password: 'new secure passphrase' },
+            fetchFn as typeof fetch,
+            'csrf-value',
+        );
+        await revokeOtherSessions(fetchFn as typeof fetch, 'csrf-value');
+
+        expect(new Headers(calls[0].headers).get('X-CSRF-Token')).toBe('csrf-value');
+        expect(new Headers(calls[1].headers).get('X-CSRF-Token')).toBeNull();
+        expect(new Headers(calls[2].headers).get('X-CSRF-Token')).toBe('csrf-value');
+        expect(new Headers(calls[3].headers).get('X-CSRF-Token')).toBe('csrf-value');
+    });
+
+    test('throws the existing sanitized API error type', async () => {
+        const fetchFn = async () => jsonResponse({
+            error: { code: 'AUTH_INVALID', message: 'Invalid password.', details: {} },
+        }, 401);
+
+        await expect(loginOwner({ password: 'wrong', remember_device: false }, fetchFn as typeof fetch))
+            .rejects.toMatchObject({ message: 'Invalid password.', code: 'AUTH_INVALID', status: 401 });
+    });
+});

--- a/frontend/src/lib/auth-api.ts
+++ b/frontend/src/lib/auth-api.ts
@@ -1,0 +1,94 @@
+import { parseApiError } from './api-error';
+import type {
+    AuthenticatedSession,
+    AuthStatus,
+    RevokeSessionsResponse,
+    SecuritySummary,
+} from './auth-types';
+import { readCookie } from './auth-utils';
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000/api';
+
+async function authRequest<T>(
+    path: string,
+    options: RequestInit = {},
+    fetchFn: typeof fetch = fetch,
+    csrfToken?: string | null,
+): Promise<T> {
+    const method = (options.method ?? 'GET').toUpperCase();
+    const headers = new Headers(options.headers);
+    if (options.body !== undefined && !headers.has('Content-Type')) {
+        headers.set('Content-Type', 'application/json');
+    }
+    if (!['GET', 'HEAD', 'OPTIONS'].includes(method)) {
+        const token = csrfToken ?? readCookie('applykit_csrf');
+        if (token) headers.set('X-CSRF-Token', token);
+    }
+
+    const response = await fetchFn(`${BASE_URL}${path}`, {
+        ...options,
+        method,
+        headers,
+        credentials: 'include',
+    });
+
+    if (!response.ok) {
+        const payload: unknown = await response.json().catch(() => undefined);
+        throw parseApiError(payload, 'Authentication request failed.', response.status);
+    }
+
+    if (response.status === 204 || response.headers.get('content-length') === '0') {
+        return undefined as T;
+    }
+    return response.json() as Promise<T>;
+}
+
+export const getAuthStatus = (fetchFn?: typeof fetch) =>
+    authRequest<AuthStatus>('/auth/status', {}, fetchFn);
+
+export const setupOwner = (
+    input: { setup_token: string; password: string },
+    fetchFn?: typeof fetch,
+) => authRequest<AuthenticatedSession>(
+    '/auth/setup',
+    { method: 'POST', body: JSON.stringify(input) },
+    fetchFn,
+);
+
+export const loginOwner = (
+    input: { password: string; remember_device: boolean },
+    fetchFn?: typeof fetch,
+) => authRequest<AuthenticatedSession>(
+    '/auth/login',
+    { method: 'POST', body: JSON.stringify(input) },
+    fetchFn,
+);
+
+export const logoutOwner = (
+    fetchFn?: typeof fetch,
+    csrfToken?: string | null,
+) => authRequest<void>('/auth/logout', { method: 'POST' }, fetchFn, csrfToken);
+
+export const changeOwnerPassword = (
+    input: { current_password: string; new_password: string },
+    fetchFn?: typeof fetch,
+    csrfToken?: string | null,
+) => authRequest<AuthenticatedSession>(
+    '/auth/change-password',
+    { method: 'POST', body: JSON.stringify(input) },
+    fetchFn,
+    csrfToken,
+);
+
+export const getSecuritySummary = (fetchFn?: typeof fetch) =>
+    authRequest<SecuritySummary>('/auth/security', {}, fetchFn);
+
+export const revokeOtherSessions = (
+    fetchFn?: typeof fetch,
+    csrfToken?: string | null,
+) => authRequest<RevokeSessionsResponse>(
+    '/auth/sessions/revoke-others',
+    { method: 'POST' },
+    fetchFn,
+    csrfToken,
+);

--- a/frontend/src/lib/auth-api.ts
+++ b/frontend/src/lib/auth-api.ts
@@ -1,4 +1,5 @@
 import { parseApiError } from './api-error';
+import { authenticationErrorMessage } from './auth-error';
 import type {
     AuthenticatedSession,
     AuthStatus,
@@ -34,7 +35,9 @@ async function authRequest<T>(
 
     if (!response.ok) {
         const payload: unknown = await response.json().catch(() => undefined);
-        throw parseApiError(payload, 'Authentication request failed.', response.status);
+        const error = parseApiError(payload, 'Authentication request failed.', response.status);
+        error.message = authenticationErrorMessage(error, error.message);
+        throw error;
     }
 
     if (response.status === 204 || response.headers.get('content-length') === '0') {

--- a/frontend/src/lib/auth-error.test.ts
+++ b/frontend/src/lib/auth-error.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+
+import { ApiError } from './api-error';
+import { authenticationErrorMessage } from './auth-error';
+
+
+describe('authenticationErrorMessage', () => {
+    test('shows backend retry timing for authentication lockouts', () => {
+        const error = new ApiError(
+            'Too many attempts. Try again later.',
+            'AUTH_LOCKED',
+            { retry_after_seconds: 901 },
+            429,
+        );
+
+        expect(authenticationErrorMessage(error, 'Sign in failed.'))
+            .toBe('Too many attempts. Try again in 16 minutes.');
+    });
+
+    test('uses sanitized API messages and stable fallbacks', () => {
+        expect(authenticationErrorMessage(new Error('Invalid password.'), 'Sign in failed.'))
+            .toBe('Invalid password.');
+        expect(authenticationErrorMessage('unexpected', 'Sign in failed.'))
+            .toBe('Sign in failed.');
+    });
+});

--- a/frontend/src/lib/auth-error.ts
+++ b/frontend/src/lib/auth-error.ts
@@ -1,0 +1,18 @@
+import { ApiError } from './api-error';
+
+function retryAfterSeconds(details: unknown): number | null {
+    if (typeof details !== 'object' || details === null || Array.isArray(details)) return null;
+    const value = (details as Record<string, unknown>).retry_after_seconds;
+    return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+export function authenticationErrorMessage(error: unknown, fallback: string): string {
+    if (error instanceof ApiError && error.code === 'AUTH_LOCKED') {
+        const seconds = retryAfterSeconds(error.details);
+        if (seconds !== null) {
+            const minutes = Math.max(1, Math.ceil(seconds / 60));
+            return `Too many attempts. Try again in ${minutes} minute${minutes === 1 ? '' : 's'}.`;
+        }
+    }
+    return error instanceof Error && error.message ? error.message : fallback;
+}

--- a/frontend/src/lib/auth-routing.test.ts
+++ b/frontend/src/lib/auth-routing.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveAuthDestination } from './auth-routing';
+import type { AuthStatus } from './auth-types';
+
+const disabled: AuthStatus = {
+    auth_mode: 'disabled',
+    setup_required: false,
+    authenticated: true,
+    session_expires_at: null,
+};
+
+const setupRequired: AuthStatus = {
+    auth_mode: 'password',
+    setup_required: true,
+    authenticated: false,
+    session_expires_at: null,
+};
+
+const loggedOut: AuthStatus = {
+    auth_mode: 'password',
+    setup_required: false,
+    authenticated: false,
+    session_expires_at: null,
+};
+
+const loggedIn: AuthStatus = {
+    auth_mode: 'password',
+    setup_required: false,
+    authenticated: true,
+    session_expires_at: '2026-08-09T10:00:00Z',
+};
+
+
+describe('resolveAuthDestination', () => {
+    test('preserves the disabled local flow but hides security settings', () => {
+        expect(resolveAuthDestination(disabled, '/', '')).toBeNull();
+        expect(resolveAuthDestination(disabled, '/settings/security', '')).toBe('/settings');
+        expect(resolveAuthDestination(disabled, '/login', '')).toBe('/');
+    });
+
+    test('routes an unclaimed installation to setup', () => {
+        expect(resolveAuthDestination(setupRequired, '/tracker', '?status=applied'))
+            .toBe('/setup?returnTo=%2Ftracker%3Fstatus%3Dapplied');
+        expect(resolveAuthDestination(setupRequired, '/setup', '')).toBeNull();
+        expect(resolveAuthDestination(setupRequired, '/login', '')).toBe('/setup');
+    });
+
+    test('routes a claimed logged-out installation to login', () => {
+        expect(resolveAuthDestination(loggedOut, '/tracker', '?status=applied'))
+            .toBe('/login?returnTo=%2Ftracker%3Fstatus%3Dapplied');
+        expect(resolveAuthDestination(loggedOut, '/login', '?returnTo=%2Ftracker')).toBeNull();
+        expect(resolveAuthDestination(loggedOut, '/setup', '')).toBe('/login');
+    });
+
+    test('redirects authenticated users away from auth routes safely', () => {
+        expect(resolveAuthDestination(loggedIn, '/login', '?returnTo=%2Fhistory')).toBe('/history');
+        expect(resolveAuthDestination(loggedIn, '/setup', '?returnTo=https%3A%2F%2Fevil.example')).toBe('/');
+        expect(resolveAuthDestination(loggedIn, '/tracker', '')).toBeNull();
+    });
+
+    test('allows the special reauth login page for an authenticated session', () => {
+        expect(resolveAuthDestination(loggedIn, '/login', '?reauth=1')).toBeNull();
+    });
+});

--- a/frontend/src/lib/auth-routing.ts
+++ b/frontend/src/lib/auth-routing.ts
@@ -1,0 +1,42 @@
+import type { AuthStatus } from './auth-types';
+import { sanitizeReturnTo } from './auth-utils';
+
+const AUTH_ROUTES = new Set(['/login', '/setup']);
+
+function currentDestination(pathname: string, search: string): string {
+    return sanitizeReturnTo(`${pathname}${search}`);
+}
+
+function encodedReturnTo(pathname: string, search: string): string {
+    return encodeURIComponent(currentDestination(pathname, search));
+}
+
+export function resolveAuthDestination(
+    status: AuthStatus,
+    pathname: string,
+    search: string,
+): string | null {
+    const params = new URLSearchParams(search);
+    const isAuthRoute = AUTH_ROUTES.has(pathname);
+
+    if (status.auth_mode === 'disabled') {
+        if (pathname === '/settings/security') return '/settings';
+        return isAuthRoute ? '/' : null;
+    }
+
+    if (status.setup_required) {
+        if (pathname === '/setup') return null;
+        if (pathname === '/login') return '/setup';
+        return `/setup?returnTo=${encodedReturnTo(pathname, search)}`;
+    }
+
+    if (!status.authenticated) {
+        if (pathname === '/login') return null;
+        if (pathname === '/setup') return '/login';
+        return `/login?returnTo=${encodedReturnTo(pathname, search)}`;
+    }
+
+    if (pathname === '/login' && params.get('reauth') === '1') return null;
+    if (isAuthRoute) return sanitizeReturnTo(params.get('returnTo'));
+    return null;
+}

--- a/frontend/src/lib/auth-state-core.test.ts
+++ b/frontend/src/lib/auth-state-core.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createAuthStateCore } from './auth-state-core';
+
+
+describe('auth state core', () => {
+    test('represents disabled mode as authenticated without a session expiry', () => {
+        const state = createAuthStateCore();
+        state.applyStatus({
+            auth_mode: 'disabled',
+            setup_required: false,
+            authenticated: true,
+            session_expires_at: null,
+        });
+
+        expect(state.authMode).toBe('disabled');
+        expect(state.authenticated).toBeTrue();
+        expect(state.sessionExpiresAt).toBeNull();
+        expect(state.checking).toBeFalse();
+    });
+
+    test('tracks setup-required and unauthenticated password mode', () => {
+        const state = createAuthStateCore();
+        state.applyStatus({
+            auth_mode: 'password',
+            setup_required: true,
+            authenticated: false,
+            session_expires_at: null,
+        });
+
+        expect(state.setupRequired).toBeTrue();
+        expect(state.authenticated).toBeFalse();
+    });
+
+    test('applies a new session after login or password change', () => {
+        const state = createAuthStateCore();
+        state.applySession({
+            authenticated: true,
+            remember_device: true,
+            session_expires_at: '2026-09-01T10:00:00Z',
+        });
+
+        expect(state.authMode).toBe('password');
+        expect(state.setupRequired).toBeFalse();
+        expect(state.authenticated).toBeTrue();
+        expect(state.sessionExpiresAt).toBe('2026-09-01T10:00:00Z');
+    });
+
+    test('clears and expires sessions without changing password mode', () => {
+        const state = createAuthStateCore();
+        state.applySession({
+            authenticated: true,
+            remember_device: false,
+            session_expires_at: '2026-08-09T10:00:00Z',
+        });
+        state.markExpired();
+
+        expect(state.authMode).toBe('password');
+        expect(state.authenticated).toBeFalse();
+        expect(state.sessionExpiresAt).toBeNull();
+
+        state.clearSession();
+        expect(state.authenticated).toBeFalse();
+    });
+});

--- a/frontend/src/lib/auth-state-core.ts
+++ b/frontend/src/lib/auth-state-core.ts
@@ -1,0 +1,57 @@
+import type { AuthenticatedSession, AuthMode, AuthStatus } from './auth-types';
+
+export interface AuthStateCore {
+    authMode: AuthMode;
+    setupRequired: boolean;
+    authenticated: boolean;
+    sessionExpiresAt: string | null;
+    checking: boolean;
+    applyStatus(status: AuthStatus): void;
+    applySession(session: AuthenticatedSession): void;
+    clearSession(): void;
+    markExpired(): void;
+    setChecking(value: boolean): void;
+}
+
+export function createAuthStateCore(): AuthStateCore {
+    return {
+        authMode: 'disabled',
+        setupRequired: false,
+        authenticated: true,
+        sessionExpiresAt: null,
+        checking: true,
+
+        applyStatus(status) {
+            this.authMode = status.auth_mode;
+            this.setupRequired = status.setup_required;
+            this.authenticated = status.auth_mode === 'disabled' || status.authenticated;
+            this.sessionExpiresAt = status.session_expires_at;
+            this.checking = false;
+        },
+
+        applySession(session) {
+            this.authMode = 'password';
+            this.setupRequired = false;
+            this.authenticated = session.authenticated;
+            this.sessionExpiresAt = session.session_expires_at;
+            this.checking = false;
+        },
+
+        clearSession() {
+            if (this.authMode === 'password') this.authenticated = false;
+            this.sessionExpiresAt = null;
+            this.checking = false;
+        },
+
+        markExpired() {
+            this.authMode = 'password';
+            this.authenticated = false;
+            this.sessionExpiresAt = null;
+            this.checking = false;
+        },
+
+        setChecking(value) {
+            this.checking = value;
+        },
+    };
+}

--- a/frontend/src/lib/auth-state.svelte.ts
+++ b/frontend/src/lib/auth-state.svelte.ts
@@ -1,0 +1,68 @@
+import { getAuthStatus } from './auth-api';
+import { onUnauthorized } from './api-client';
+import type { AuthenticatedSession, AuthMode, AuthStatus } from './auth-types';
+
+function createAuthState() {
+    let authMode = $state<AuthMode>('disabled');
+    let setupRequired = $state(false);
+    let authenticated = $state(true);
+    let sessionExpiresAt = $state<string | null>(null);
+    let checking = $state(true);
+
+    function applyStatus(status: AuthStatus): void {
+        authMode = status.auth_mode;
+        setupRequired = status.setup_required;
+        authenticated = status.auth_mode === 'disabled' || status.authenticated;
+        sessionExpiresAt = status.session_expires_at;
+        checking = false;
+    }
+
+    function applySession(session: AuthenticatedSession): void {
+        authMode = 'password';
+        setupRequired = false;
+        authenticated = true;
+        sessionExpiresAt = session.session_expires_at;
+        checking = false;
+    }
+
+    function clearSession(): void {
+        if (authMode === 'password') authenticated = false;
+        sessionExpiresAt = null;
+        checking = false;
+    }
+
+    async function refresh(fetchFn?: typeof fetch): Promise<AuthStatus> {
+        checking = true;
+        try {
+            const status = await getAuthStatus(fetchFn);
+            applyStatus(status);
+            return status;
+        } finally {
+            checking = false;
+        }
+    }
+
+    function markExpired(): void {
+        authMode = 'password';
+        authenticated = false;
+        sessionExpiresAt = null;
+        checking = false;
+    }
+
+    onUnauthorized(clearSession);
+
+    return {
+        get authMode() { return authMode; },
+        get setupRequired() { return setupRequired; },
+        get authenticated() { return authenticated; },
+        get sessionExpiresAt() { return sessionExpiresAt; },
+        get checking() { return checking; },
+        applyStatus,
+        applySession,
+        clearSession,
+        refresh,
+        markExpired,
+    };
+}
+
+export const authState = createAuthState();

--- a/frontend/src/lib/auth-types.ts
+++ b/frontend/src/lib/auth-types.ts
@@ -1,0 +1,22 @@
+export type AuthMode = 'disabled' | 'password';
+
+export interface AuthStatus {
+    auth_mode: AuthMode;
+    setup_required: boolean;
+    authenticated: boolean;
+    session_expires_at: string | null;
+}
+
+export interface AuthenticatedSession {
+    authenticated: true;
+    remember_device: boolean;
+    session_expires_at: string;
+}
+
+export interface SecuritySummary {
+    other_sessions: number;
+}
+
+export interface RevokeSessionsResponse {
+    revoked_sessions: number;
+}

--- a/frontend/src/lib/auth-utils.test.ts
+++ b/frontend/src/lib/auth-utils.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+    isUnsafeMethod,
+    passwordFormEligible,
+    readCookie,
+    sanitizeReturnTo,
+    sessionRemainingMs,
+    shouldShowExpiryWarning,
+} from './auth-utils';
+
+
+describe('sanitizeReturnTo', () => {
+    test('keeps safe internal paths including query strings', () => {
+        expect(sanitizeReturnTo('/tracker?status=applied')).toBe('/tracker?status=applied');
+    });
+
+    test('rejects external, protocol-relative, and auth-loop destinations', () => {
+        expect(sanitizeReturnTo('https://evil.example')).toBe('/');
+        expect(sanitizeReturnTo('//evil.example')).toBe('/');
+        expect(sanitizeReturnTo('/login')).toBe('/');
+        expect(sanitizeReturnTo('/setup?token=secret')).toBe('/');
+        expect(sanitizeReturnTo(null)).toBe('/');
+    });
+
+    test('rejects values whose decoded path becomes external-looking', () => {
+        expect(sanitizeReturnTo('/%2F%2Fevil.example')).toBe('/');
+    });
+});
+
+
+describe('readCookie', () => {
+    test('reads and decodes the requested cookie', () => {
+        expect(readCookie('applykit_csrf', 'other=1; applykit_csrf=hello%20world')).toBe('hello world');
+    });
+
+    test('returns null for missing or malformed values', () => {
+        expect(readCookie('applykit_csrf', 'other=1')).toBeNull();
+        expect(readCookie('applykit_csrf', 'applykit_csrf=%E0%A4%A')).toBeNull();
+    });
+});
+
+
+describe('isUnsafeMethod', () => {
+    test('treats only mutation methods as unsafe', () => {
+        expect(isUnsafeMethod('GET')).toBeFalse();
+        expect(isUnsafeMethod('HEAD')).toBeFalse();
+        expect(isUnsafeMethod('OPTIONS')).toBeFalse();
+        expect(isUnsafeMethod('POST')).toBeTrue();
+        expect(isUnsafeMethod('patch')).toBeTrue();
+        expect(isUnsafeMethod(undefined)).toBeFalse();
+    });
+});
+
+
+describe('passwordFormEligible', () => {
+    test('accepts matching passwords from 12 through 128 characters', () => {
+        expect(passwordFormEligible('a'.repeat(12), 'a'.repeat(12))).toBeTrue();
+        expect(passwordFormEligible('a'.repeat(128), 'a'.repeat(128))).toBeTrue();
+    });
+
+    test('rejects invalid lengths, mismatch, and a required empty token', () => {
+        expect(passwordFormEligible('a'.repeat(11), 'a'.repeat(11))).toBeFalse();
+        expect(passwordFormEligible('a'.repeat(129), 'a'.repeat(129))).toBeFalse();
+        expect(passwordFormEligible('a'.repeat(12), 'b'.repeat(12))).toBeFalse();
+        expect(passwordFormEligible('a'.repeat(12), 'a'.repeat(12), '')).toBeFalse();
+        expect(passwordFormEligible('a'.repeat(12), 'a'.repeat(12), 'token')).toBeTrue();
+    });
+});
+
+
+describe('session expiry helpers', () => {
+    const now = Date.parse('2026-08-02T10:00:00Z');
+
+    test('returns remaining milliseconds without extending the session', () => {
+        expect(sessionRemainingMs('2026-08-02T10:05:00Z', now)).toBe(300_000);
+        expect(sessionRemainingMs('2026-08-02T09:59:00Z', now)).toBe(-60_000);
+        expect(sessionRemainingMs(null, now)).toBeNull();
+    });
+
+    test('shows the warning only during the final positive five minutes', () => {
+        expect(shouldShowExpiryWarning('2026-08-02T10:05:00Z', now)).toBeTrue();
+        expect(shouldShowExpiryWarning('2026-08-02T10:05:00.001Z', now)).toBeFalse();
+        expect(shouldShowExpiryWarning('2026-08-02T10:00:00Z', now)).toBeFalse();
+    });
+});

--- a/frontend/src/lib/auth-utils.ts
+++ b/frontend/src/lib/auth-utils.ts
@@ -1,0 +1,75 @@
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+const AUTH_LOOP_PATHS = new Set(['/login', '/setup']);
+const MIN_PASSWORD_LENGTH = 12;
+const MAX_PASSWORD_LENGTH = 128;
+const EXPIRY_WARNING_MS = 5 * 60 * 1000;
+
+
+export function sanitizeReturnTo(value: string | null | undefined): string {
+    if (!value || !value.startsWith('/') || value.startsWith('//')) return '/';
+
+    try {
+        const decoded = decodeURIComponent(value);
+        if (decoded.startsWith('//') || decoded.includes('://')) return '/';
+
+        const url = new URL(value, 'http://applykit.local');
+        if (url.origin !== 'http://applykit.local') return '/';
+        if (AUTH_LOOP_PATHS.has(url.pathname)) return '/';
+        return `${url.pathname}${url.search}${url.hash}`;
+    } catch {
+        return '/';
+    }
+}
+
+
+export function readCookie(name: string, cookieSource?: string): string | null {
+    const source = cookieSource ?? (typeof document === 'undefined' ? '' : document.cookie);
+    for (const item of source.split(';')) {
+        const [rawName, ...rawValueParts] = item.trim().split('=');
+        if (rawName !== name) continue;
+        try {
+            return decodeURIComponent(rawValueParts.join('='));
+        } catch {
+            return null;
+        }
+    }
+    return null;
+}
+
+
+export function isUnsafeMethod(method?: string): boolean {
+    if (!method) return false;
+    return !SAFE_METHODS.has(method.toUpperCase());
+}
+
+
+export function passwordFormEligible(
+    password: string,
+    confirmation: string,
+    tokenRequired?: string,
+): boolean {
+    return password.length >= MIN_PASSWORD_LENGTH
+        && password.length <= MAX_PASSWORD_LENGTH
+        && password === confirmation
+        && (tokenRequired === undefined || tokenRequired.trim().length > 0);
+}
+
+
+export function sessionRemainingMs(
+    expiresAt: string | null,
+    nowMs: number = Date.now(),
+): number | null {
+    if (!expiresAt) return null;
+    const expiryMs = Date.parse(expiresAt);
+    if (!Number.isFinite(expiryMs)) return null;
+    return expiryMs - nowMs;
+}
+
+
+export function shouldShowExpiryWarning(
+    expiresAt: string | null,
+    nowMs: number = Date.now(),
+): boolean {
+    const remaining = sessionRemainingMs(expiresAt, nowMs);
+    return remaining !== null && remaining > 0 && remaining <= EXPIRY_WARNING_MS;
+}

--- a/frontend/src/lib/components/AuthShell.svelte
+++ b/frontend/src/lib/components/AuthShell.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+
+  let {
+    title,
+    description,
+    children,
+  } = $props<{
+    title: string;
+    description: string;
+    children: import('svelte').Snippet;
+  }>();
+</script>
+
+<div class="relative flex min-h-screen items-center justify-center bg-muted/40 px-4 py-10">
+  <div class="absolute right-4 top-4">
+    <ThemeToggle />
+  </div>
+
+  <div class="w-full max-w-md">
+    <div class="mb-6 text-center">
+      <a href="/" class="text-xl font-bold tracking-tight text-foreground">ApplyKit</a>
+      <h1 class="mt-5 text-2xl font-bold tracking-tight">{title}</h1>
+      <p class="mt-2 text-sm leading-6 text-muted-foreground">{description}</p>
+    </div>
+
+    <section class="rounded-2xl border border-border bg-card p-6 shadow-sm sm:p-7">
+      {@render children()}
+    </section>
+  </div>
+</div>

--- a/frontend/src/lib/components/PasswordStrength.svelte
+++ b/frontend/src/lib/components/PasswordStrength.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { ZxcvbnFactory } from '@zxcvbn-ts/core';
+  import { adjacencyGraphs, dictionary as commonDictionary } from '@zxcvbn-ts/language-common';
+  import { dictionary as englishDictionary, translations } from '@zxcvbn-ts/language-en';
+
+  let { password } = $props<{ password: string }>();
+
+  const checker = new ZxcvbnFactory({
+    translations,
+    graphs: adjacencyGraphs,
+    dictionary: {
+      ...commonDictionary,
+      ...englishDictionary,
+    },
+  });
+
+  const result = $derived(password ? checker.check(password) : null);
+  const score = $derived(result?.score ?? 0);
+  const labels = ['Very weak', 'Weak', 'Fair', 'Strong', 'Very strong'];
+  const label = $derived(password ? labels[score] : 'Enter at least 12 characters');
+</script>
+
+<div class="space-y-2" aria-live="polite">
+  <div class="flex gap-1" aria-hidden="true">
+    {#each [1, 2, 3, 4] as segment}
+      <span class="h-1.5 flex-1 rounded-full {password && score >= segment ? 'bg-primary' : 'bg-muted'}"></span>
+    {/each}
+  </div>
+  <div class="flex items-start justify-between gap-3 text-xs text-muted-foreground">
+    <span>{label}</span>
+    <span>{password.length}/128</span>
+  </div>
+  {#if result?.feedback?.warning}
+    <p class="text-xs text-muted-foreground">{result.feedback.warning}</p>
+  {/if}
+</div>

--- a/frontend/src/lib/components/SessionExpiryBanner.svelte
+++ b/frontend/src/lib/components/SessionExpiryBanner.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { authState } from '$lib/auth-state.svelte';
+  import { nextExpiryState } from '$lib/session-expiry';
+  import { Clock3, ExternalLink } from '@lucide/svelte';
+
+  let now = $state(Date.now());
+  const expiryState = $derived(nextExpiryState(authState.sessionExpiresAt, now));
+
+  $effect(() => {
+    const timer = window.setInterval(() => {
+      now = Date.now();
+    }, 1000);
+    return () => window.clearInterval(timer);
+  });
+
+  $effect(() => {
+    if (expiryState === 'expired') authState.markExpired();
+  });
+
+  $effect(() => {
+    async function refreshSession() {
+      if (document.visibilityState !== 'visible') return;
+      try {
+        await authState.refresh();
+        now = Date.now();
+      } catch {
+        // The existing state remains authoritative until the next request or refresh.
+      }
+    }
+
+    window.addEventListener('focus', refreshSession);
+    document.addEventListener('visibilitychange', refreshSession);
+    return () => {
+      window.removeEventListener('focus', refreshSession);
+      document.removeEventListener('visibilitychange', refreshSession);
+    };
+  });
+
+  function openReauthentication() {
+    window.open('/login?reauth=1', '_blank', 'noopener');
+  }
+</script>
+
+{#if expiryState === 'active'}
+  <div class="border-b border-amber-300 bg-amber-50 text-amber-950 dark:border-amber-800 dark:bg-amber-950/70 dark:text-amber-100" role="status">
+    <div class="mx-auto flex max-w-5xl flex-col gap-2 px-4 py-2.5 sm:flex-row sm:items-center sm:justify-between">
+      <p class="flex items-center gap-2 text-sm font-medium">
+        <Clock3 class="h-4 w-4 shrink-0" />
+        Your session expires in 5 minutes.
+      </p>
+      <button
+        type="button"
+        onclick={openReauthentication}
+        class="inline-flex w-fit items-center gap-1.5 rounded-md bg-amber-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-800 dark:bg-amber-200 dark:text-amber-950 dark:hover:bg-amber-100"
+      >
+        Sign in again <ExternalLink class="h-3.5 w-3.5" />
+      </button>
+    </div>
+  </div>
+{/if}

--- a/frontend/src/lib/components/SettingsNav.svelte
+++ b/frontend/src/lib/components/SettingsNav.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import { authState } from '$lib/auth-state.svelte';
+  import { settingsTabs } from '$lib/settings-nav';
+
+  const tabs = $derived(settingsTabs(authState.authMode));
+
+  function isActive(href: string): boolean {
+    return href === '/settings'
+      ? page.url.pathname === '/settings'
+      : page.url.pathname.startsWith(href);
+  }
+</script>
+
+<nav class="inline-flex rounded-lg border border-border bg-muted/40 p-1" aria-label="Settings sections">
+  {#each tabs as tab}
+    <a
+      href={tab.href}
+      class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors {isActive(tab.href) ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'}"
+      aria-current={isActive(tab.href) ? 'page' : undefined}
+    >
+      {tab.label}
+    </a>
+  {/each}
+</nav>

--- a/frontend/src/lib/integration-api.ts
+++ b/frontend/src/lib/integration-api.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from '$lib/api-client';
+import { parseApiError } from '$lib/api-error';
 import type {
   CreateProviderCredentialRequest,
   CredentialPolicyResponse,
@@ -14,7 +16,7 @@ async function requestJson<T>(
   path: string,
   options: RequestInit = {},
 ): Promise<T> {
-  const response = await fetch(`${BASE_URL}${path}`, {
+  const response = await apiFetch(`${BASE_URL}${path}`, {
     ...options,
     headers: {
       'Content-Type': 'application/json',
@@ -23,17 +25,8 @@ async function requestJson<T>(
   });
 
   if (!response.ok) {
-    let message = 'Credential request failed.';
-    try {
-      const payload = (await response.json()) as {
-        detail?: string;
-        error?: { message?: string };
-      };
-      message = payload.error?.message ?? payload.detail ?? message;
-    } catch {
-      // Keep the stable fallback instead of exposing an unreadable response body.
-    }
-    throw new Error(message);
+    const payload: unknown = await response.json().catch(() => undefined);
+    throw parseApiError(payload, 'Credential request failed.', response.status);
   }
 
   return response.json() as Promise<T>;

--- a/frontend/src/lib/login-flow.test.ts
+++ b/frontend/src/lib/login-flow.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+
+import { loginSuccessDestination } from './login-flow';
+
+
+describe('loginSuccessDestination', () => {
+    test('returns a sanitized destination for a normal login', () => {
+        expect(loginSuccessDestination(new URL('http://applykit.local/login?returnTo=%2Fhistory')))
+            .toEqual({ kind: 'navigate', path: '/history' });
+        expect(loginSuccessDestination(new URL('http://applykit.local/login?returnTo=https%3A%2F%2Fevil.example')))
+            .toEqual({ kind: 'navigate', path: '/' });
+    });
+
+    test('returns a reauthentication completion state', () => {
+        expect(loginSuccessDestination(new URL('http://applykit.local/login?reauth=1')))
+            .toEqual({ kind: 'reauth-complete' });
+    });
+});

--- a/frontend/src/lib/login-flow.ts
+++ b/frontend/src/lib/login-flow.ts
@@ -1,0 +1,15 @@
+import { sanitizeReturnTo } from './auth-utils';
+
+export type LoginSuccessDestination =
+    | { kind: 'navigate'; path: string }
+    | { kind: 'reauth-complete' };
+
+export function loginSuccessDestination(url: URL): LoginSuccessDestination {
+    if (url.searchParams.get('reauth') === '1') {
+        return { kind: 'reauth-complete' };
+    }
+    return {
+        kind: 'navigate',
+        path: sanitizeReturnTo(url.searchParams.get('returnTo')),
+    };
+}

--- a/frontend/src/lib/security-form.test.ts
+++ b/frontend/src/lib/security-form.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+
+import { changePasswordEligible, otherSessionsLabel } from './security-form';
+
+
+describe('changePasswordEligible', () => {
+    test('requires current password plus a valid matching new password', () => {
+        expect(changePasswordEligible('current', 'a'.repeat(12), 'a'.repeat(12))).toBeTrue();
+        expect(changePasswordEligible('', 'a'.repeat(12), 'a'.repeat(12))).toBeFalse();
+        expect(changePasswordEligible('current', 'a'.repeat(11), 'a'.repeat(11))).toBeFalse();
+        expect(changePasswordEligible('current', 'a'.repeat(12), 'b'.repeat(12))).toBeFalse();
+    });
+});
+
+
+describe('otherSessionsLabel', () => {
+    test('formats zero, singular, and plural counts without device metadata', () => {
+        expect(otherSessionsLabel(0)).toBe('No other active sessions');
+        expect(otherSessionsLabel(1)).toBe('1 other active session');
+        expect(otherSessionsLabel(2)).toBe('2 other active sessions');
+    });
+});

--- a/frontend/src/lib/security-form.ts
+++ b/frontend/src/lib/security-form.ts
@@ -1,0 +1,16 @@
+import { passwordFormEligible } from './auth-utils';
+
+export function changePasswordEligible(
+    currentPassword: string,
+    newPassword: string,
+    confirmation: string,
+): boolean {
+    return currentPassword.trim().length > 0
+        && passwordFormEligible(newPassword, confirmation);
+}
+
+export function otherSessionsLabel(count: number): string {
+    if (count <= 0) return 'No other active sessions';
+    if (count === 1) return '1 other active session';
+    return `${count} other active sessions`;
+}

--- a/frontend/src/lib/session-expiry.test.ts
+++ b/frontend/src/lib/session-expiry.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+
+import { nextExpiryState } from './session-expiry';
+
+
+describe('nextExpiryState', () => {
+    const now = Date.parse('2026-08-02T10:00:00Z');
+
+    test('is inactive without an expiry or before the warning window', () => {
+        expect(nextExpiryState(null, now)).toBe('inactive');
+        expect(nextExpiryState('2026-08-02T10:05:00.001Z', now)).toBe('inactive');
+    });
+
+    test('is active during the final positive five minutes', () => {
+        expect(nextExpiryState('2026-08-02T10:05:00Z', now)).toBe('active');
+        expect(nextExpiryState('2026-08-02T10:00:00.001Z', now)).toBe('active');
+    });
+
+    test('is expired at or after the absolute expiry', () => {
+        expect(nextExpiryState('2026-08-02T10:00:00Z', now)).toBe('expired');
+        expect(nextExpiryState('2026-08-02T09:59:59Z', now)).toBe('expired');
+    });
+});

--- a/frontend/src/lib/session-expiry.ts
+++ b/frontend/src/lib/session-expiry.ts
@@ -1,0 +1,14 @@
+import { sessionRemainingMs } from './auth-utils';
+
+export type SessionExpiryState = 'inactive' | 'active' | 'expired';
+
+export function nextExpiryState(
+    expiresAt: string | null,
+    nowMs: number = Date.now(),
+): SessionExpiryState {
+    const remaining = sessionRemainingMs(expiresAt, nowMs);
+    if (remaining === null) return 'inactive';
+    if (remaining <= 0) return 'expired';
+    if (remaining <= 5 * 60 * 1000) return 'active';
+    return 'inactive';
+}

--- a/frontend/src/lib/settings-nav.test.ts
+++ b/frontend/src/lib/settings-nav.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+
+import { settingsTabs } from './settings-nav';
+
+
+describe('settingsTabs', () => {
+    test('shows only AI integrations in disabled mode', () => {
+        expect(settingsTabs('disabled')).toEqual([
+            { href: '/settings', label: 'AI Integrations' },
+        ]);
+    });
+
+    test('shows Security only in password mode', () => {
+        expect(settingsTabs('password')).toEqual([
+            { href: '/settings', label: 'AI Integrations' },
+            { href: '/settings/security', label: 'Security' },
+        ]);
+    });
+});

--- a/frontend/src/lib/settings-nav.ts
+++ b/frontend/src/lib/settings-nav.ts
@@ -1,0 +1,16 @@
+import type { AuthMode } from './auth-types';
+
+export interface SettingsTab {
+    href: string;
+    label: string;
+}
+
+export function settingsTabs(authMode: AuthMode): SettingsTab[] {
+    const tabs: SettingsTab[] = [
+        { href: '/settings', label: 'AI Integrations' },
+    ];
+    if (authMode === 'password') {
+        tabs.push({ href: '/settings/security', label: 'Security' });
+    }
+    return tabs;
+}

--- a/frontend/src/lib/setup-form.test.ts
+++ b/frontend/src/lib/setup-form.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+
+import { setupFormEligible } from './setup-form';
+
+
+describe('setupFormEligible', () => {
+    test('requires a token, a valid-length password, and matching confirmation', () => {
+        expect(setupFormEligible('token', 'a'.repeat(12), 'a'.repeat(12))).toBeTrue();
+        expect(setupFormEligible('', 'a'.repeat(12), 'a'.repeat(12))).toBeFalse();
+        expect(setupFormEligible('token', 'a'.repeat(11), 'a'.repeat(11))).toBeFalse();
+        expect(setupFormEligible('token', 'a'.repeat(12), 'b'.repeat(12))).toBeFalse();
+    });
+});

--- a/frontend/src/lib/setup-form.ts
+++ b/frontend/src/lib/setup-form.ts
@@ -1,0 +1,9 @@
+import { passwordFormEligible } from './auth-utils';
+
+export function setupFormEligible(
+    setupToken: string,
+    password: string,
+    confirmation: string,
+): boolean {
+    return passwordFormEligible(password, confirmation, setupToken);
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -131,6 +131,18 @@
                 <Menu class="w-4.5 h-4.5" />
               {/if}
             </button>
+          {:else}
+            <ThemeToggle />
+            {#if authState.authMode === 'password'}
+              <button
+                type="button"
+                onclick={signOut}
+                disabled={signingOut}
+                class="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+              >
+                <LogOut class="h-4 w-4" />Sign out
+              </button>
+            {/if}
           {/if}
         </div>
       </div>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,16 +1,25 @@
 <script lang="ts">
+  import { goto } from '$app/navigation';
   import { page } from '$app/state';
+  import { logoutOwner } from '$lib/auth-api';
+  import { authState } from '$lib/auth-state.svelte';
   import ProfileSwitcher from '$lib/components/ProfileSwitcher.svelte';
+  import SessionExpiryBanner from '$lib/components/SessionExpiryBanner.svelte';
   import SettingsButton from '$lib/components/SettingsButton.svelte';
+  import SettingsNav from '$lib/components/SettingsNav.svelte';
   import ThemeToggle from '$lib/components/ThemeToggle.svelte';
   import Toaster from '$lib/components/Toaster.svelte';
   import { themeState } from '$lib/theme.svelte';
-  import { Menu, X, Zap } from '@lucide/svelte';
+  import { toastState } from '$lib/toast.svelte';
+  import { LogOut, Menu, X, Zap } from '@lucide/svelte';
   import '../app.css';
 
   let { data, children } = $props();
   const isOnboarded = $derived(data.isOnboarded);
+  const isAuthRoute = $derived(data.isAuthRoute);
+  const onSettings = $derived(page.url.pathname.startsWith('/settings'));
   let mobileMenuOpen = $state(false);
+  let signingOut = $state(false);
 
   function navClass(href: string) {
     return `px-3 py-1.5 rounded-md text-sm transition-colors ${
@@ -28,91 +37,142 @@
     }`;
   }
 
-  // Close mobile menu on route change
+  async function signOut() {
+    if (signingOut) return;
+    signingOut = true;
+    try {
+      await logoutOwner();
+      authState.clearSession();
+      await goto('/login');
+    } catch (error) {
+      toastState.error(error instanceof Error ? error.message : 'Could not sign out.');
+    } finally {
+      signingOut = false;
+    }
+  }
+
   $effect(() => {
     page.url.pathname;
     mobileMenuOpen = false;
   });
 
-  // Dark mode effect
   $effect(() => {
     const isDark = themeState.current === 'dark';
     document.documentElement.classList.toggle('dark', isDark);
     localStorage.setItem('theme', themeState.current);
   });
+
+  $effect(() => {
+    if (
+      !isAuthRoute
+      && authState.authMode === 'password'
+      && !authState.authenticated
+      && !authState.checking
+    ) {
+      const returnTo = encodeURIComponent(`${page.url.pathname}${page.url.search}`);
+      void goto(`/login?returnTo=${returnTo}`);
+    }
+  });
 </script>
 
-<div class="min-h-screen flex flex-col bg-muted/40">
-  <header class="sticky top-0 z-60 border-b bg-card">
-    <div class="mx-auto max-w-5xl px-4 py-3 flex items-center justify-between gap-3">
-      <!-- Left: logo + desktop nav -->
-      <div class="flex items-center gap-4 min-w-0">
-        <a
-          href={isOnboarded ? '/' : '/onboarding'}
-          class="font-bold text-lg tracking-tight hover:text-primary transition-colors shrink-0"
-        >ApplyKit</a>
+{#if isAuthRoute}
+  {@render children()}
+  <Toaster />
+{:else}
+  <div class="min-h-screen flex flex-col bg-muted/40">
+    <header class="sticky top-0 z-60 border-b bg-card">
+      <div class="mx-auto max-w-5xl px-4 py-3 flex items-center justify-between gap-3">
+        <div class="flex items-center gap-4 min-w-0">
+          <a
+            href={isOnboarded ? '/' : '/onboarding'}
+            class="font-bold text-lg tracking-tight hover:text-primary transition-colors shrink-0"
+          >ApplyKit</a>
 
-        {#if isOnboarded}
-          <!-- Desktop nav — hidden on mobile -->
-          <nav class="hidden md:flex items-center gap-1 animate-in fade-in slide-in-from-left-2 duration-500">
-            <a href="/" class={navClass('/')}>Dashboard</a>
-            <span class="w-px h-4 bg-border mx-2 shrink-0"></span>
-            <a href="/cover-letter" class={navClass('/cover-letter')}>Cover Letter</a>
-            <a href="/generate" class={navClass('/generate')}>Generate CV</a>
-            <a href="/smart-apply" class="{navClass('/smart-apply')} flex items-center gap-1.5">
-              <Zap class="w-3.5 h-3.5" />
+          {#if isOnboarded}
+            <nav class="hidden md:flex items-center gap-1 animate-in fade-in slide-in-from-left-2 duration-500">
+              <a href="/" class={navClass('/')}>Dashboard</a>
+              <span class="w-px h-4 bg-border mx-2 shrink-0"></span>
+              <a href="/cover-letter" class={navClass('/cover-letter')}>Cover Letter</a>
+              <a href="/generate" class={navClass('/generate')}>Generate CV</a>
+              <a href="/smart-apply" class="{navClass('/smart-apply')} flex items-center gap-1.5">
+                <Zap class="w-3.5 h-3.5" />
+                Smart Apply
+              </a>
+              <span class="w-px h-4 bg-border mx-2 shrink-0"></span>
+              <a href="/history" class={navClass('/history')}>History</a>
+              <a href="/tracker" class={navClass('/tracker')}>Tracker</a>
+            </nav>
+          {/if}
+        </div>
+
+        <div class="flex items-center gap-2 shrink-0">
+          {#if isOnboarded}
+            <ProfileSwitcher />
+            <ThemeToggle />
+            <SettingsButton />
+            {#if authState.authMode === 'password'}
+              <button
+                type="button"
+                onclick={signOut}
+                disabled={signingOut}
+                class="hidden md:inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+              >
+                <LogOut class="h-4 w-4" />Sign out
+              </button>
+            {/if}
+            <button
+              onclick={() => mobileMenuOpen = !mobileMenuOpen}
+              class="md:hidden flex items-center justify-center w-8 h-8 rounded-md hover:bg-accent transition-colors"
+              aria-label="Toggle menu"
+            >
+              {#if mobileMenuOpen}
+                <X class="w-4.5 h-4.5" />
+              {:else}
+                <Menu class="w-4.5 h-4.5" />
+              {/if}
+            </button>
+          {/if}
+        </div>
+      </div>
+
+      {#if isOnboarded && mobileMenuOpen}
+        <div class="md:hidden border-t border-border bg-card animate-in slide-in-from-top-2 duration-200">
+          <nav class="mx-auto max-w-5xl">
+            <a href="/" class={mobileNavClass('/')}>Dashboard</a>
+            <a href="/cover-letter" class={mobileNavClass('/cover-letter')}>Cover Letter</a>
+            <a href="/generate" class={mobileNavClass('/generate')}>Generate CV</a>
+            <a href="/smart-apply" class="{mobileNavClass('/smart-apply')} gap-2">
+              <Zap class="w-3.5 h-3.5 text-primary" />
               Smart Apply
             </a>
-            <span class="w-px h-4 bg-border mx-2 shrink-0"></span>
-            <a href="/history" class={navClass('/history')}>History</a>
-            <a href="/tracker" class={navClass('/tracker')}>Tracker</a>
-          </nav>
-        {/if}
-      </div>
-
-      <!-- Right: controls + mobile hamburger -->
-      <div class="flex items-center gap-2 shrink-0">
-        {#if isOnboarded}
-          <ProfileSwitcher />
-          <ThemeToggle />
-          <SettingsButton />
-          <!-- Hamburger — visible on mobile only -->
-          <button
-            onclick={() => mobileMenuOpen = !mobileMenuOpen}
-            class="md:hidden flex items-center justify-center w-8 h-8 rounded-md hover:bg-accent transition-colors"
-            aria-label="Toggle menu"
-          >
-            {#if mobileMenuOpen}
-              <X class="w-4.5 h-4.5" />
-            {:else}
-              <Menu class="w-4.5 h-4.5" />
+            <a href="/history" class={mobileNavClass('/history')}>History</a>
+            <a href="/tracker" class={mobileNavClass('/tracker')}>Tracker</a>
+            {#if authState.authMode === 'password'}
+              <button
+                type="button"
+                onclick={signOut}
+                disabled={signingOut}
+                class="flex w-full items-center gap-2 px-4 py-3 text-left text-sm text-foreground transition-colors hover:bg-accent/50 disabled:opacity-50"
+              >
+                <LogOut class="h-4 w-4" />Sign out
+              </button>
             {/if}
-          </button>
-        {/if}
-      </div>
-    </div>
+          </nav>
+        </div>
+      {/if}
+    </header>
 
-    <!-- Mobile menu dropdown -->
-    {#if isOnboarded && mobileMenuOpen}
-      <div class="md:hidden border-t border-border bg-card animate-in slide-in-from-top-2 duration-200">
-        <nav class="mx-auto max-w-5xl">
-          <a href="/" class={mobileNavClass('/')}>Dashboard</a>
-          <a href="/cover-letter" class={mobileNavClass('/cover-letter')}>Cover Letter</a>
-          <a href="/generate" class={mobileNavClass('/generate')}>Generate CV</a>
-          <a href="/smart-apply" class="{mobileNavClass('/smart-apply')} gap-2">
-            <Zap class="w-3.5 h-3.5 text-primary" />
-            Smart Apply
-          </a>
-          <a href="/history" class={mobileNavClass('/history')}>History</a>
-          <a href="/tracker" class={mobileNavClass('/tracker')}>Tracker</a>
-        </nav>
-      </div>
+    {#if authState.authMode === 'password' && authState.authenticated}
+      <SessionExpiryBanner />
     {/if}
-  </header>
 
-  <main class="flex-1 mx-auto w-full max-w-5xl px-4 py-8">
-    {@render children()}
-  </main>
+    <main class="flex-1 mx-auto w-full max-w-5xl px-4 py-8">
+      {#if onSettings}
+        <div class="mb-6"><SettingsNav /></div>
+      {/if}
+      {@render children()}
+    </main>
 
-  <Toaster />
-</div>
+    <Toaster />
+  </div>
+{/if}

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,11 +1,12 @@
-import { redirect, isRedirect } from '@sveltejs/kit';
 import { browser } from '$app/environment';
+import { redirect, isRedirect } from '@sveltejs/kit';
 import { getOnboardingStatus, getStatus, listProfiles, createProfile } from '$lib/api';
+import { getAuthStatus } from '$lib/auth-api';
+import { resolveAuthDestination } from '$lib/auth-routing';
+import { authState } from '$lib/auth-state.svelte';
 import { profiles } from '$lib/profiles.svelte';
 import { activeProfile } from '$lib/activeProfile.svelte';
 
-// Module-level cache — survives across navigations within the same browser session.
-// Re-fetched only when the user visits /settings or /onboarding (where values can change).
 let cachedOnboarded: boolean | null = null;
 let cachedApiKeyConfigured: boolean | null = null;
 let profilesLoaded = false;
@@ -14,11 +15,25 @@ export const ssr = false;
 
 export const load = async ({ url, fetch }) => {
   const pathname = url.pathname;
+  const isAuthRoute = pathname === '/login' || pathname === '/setup';
   const onSettings = pathname.startsWith('/settings');
   const onOnboarding = pathname.startsWith('/onboarding');
   const onProfile = pathname === '/profile' || pathname.startsWith('/profile/');
 
-  // Bust cache when visiting pages where these values can change
+  const authStatus = await getAuthStatus(fetch);
+  authState.applyStatus(authStatus);
+  const authDestination = resolveAuthDestination(authStatus, pathname, url.search);
+  if (authDestination) throw redirect(307, authDestination);
+
+  if (isAuthRoute) {
+    return {
+      authStatus,
+      isAuthRoute: true,
+      isOnboarded: cachedOnboarded ?? true,
+      isApiKeyConfigured: cachedApiKeyConfigured ?? true,
+    };
+  }
+
   if (onSettings || onOnboarding) {
     cachedOnboarded = null;
     cachedApiKeyConfigured = null;
@@ -29,7 +44,6 @@ export const load = async ({ url, fetch }) => {
   let isApiKeyConfigured = cachedApiKeyConfigured ?? true;
 
   try {
-    // Only hit the API if we don't have cached values yet
     if (cachedOnboarded === null || cachedApiKeyConfigured === null) {
       const [onboarding, llmStatus] = await Promise.all([
         getOnboardingStatus(fetch),
@@ -41,7 +55,6 @@ export const load = async ({ url, fetch }) => {
       cachedApiKeyConfigured = isApiKeyConfigured;
     }
 
-    // Only fetch profiles once per session
     if (!profilesLoaded) {
       try {
         let res = await listProfiles(fetch);
@@ -62,15 +75,21 @@ export const load = async ({ url, fetch }) => {
           } catch { /* corrupted localStorage — ignore */ }
         }
         const activeItem =
-          (storedId != null ? res.items.find((p) => p.id === storedId) : null) ??
+          (storedId != null ? res.items.find((profile) => profile.id === storedId) : null) ??
           res.items[0] ??
           null;
         const validated = activeItem
-          ? { id: activeItem.id, label: activeItem.label, color: activeItem.color, icon: activeItem.icon, name: activeItem.name }
+          ? {
+              id: activeItem.id,
+              label: activeItem.label,
+              color: activeItem.color,
+              icon: activeItem.icon,
+              name: activeItem.name,
+            }
           : null;
         activeProfile.initFromStorage(validated);
-      } catch (e) {
-        console.warn('Could not load profiles. Using defaults.', e);
+      } catch (error) {
+        console.warn('Could not load profiles. Using defaults.', error);
       }
     }
 
@@ -81,10 +100,10 @@ export const load = async ({ url, fetch }) => {
     if (!isOnboarded && !onSettings && !onOnboarding && !onProfile) {
       throw redirect(307, '/onboarding');
     }
-  } catch (err: unknown) {
-    if (isRedirect(err)) throw err;
-    console.warn('Could not check onboarding status. Allowing navigation.', err);
+  } catch (error: unknown) {
+    if (isRedirect(error)) throw error;
+    console.warn('Could not check onboarding status. Allowing navigation.', error);
   }
 
-  return { isOnboarded, isApiKeyConfigured };
+  return { authStatus, isAuthRoute: false, isOnboarded, isApiKeyConfigured };
 };

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/state';
+  import { loginOwner } from '$lib/auth-api';
+  import { authState } from '$lib/auth-state.svelte';
+  import AuthShell from '$lib/components/AuthShell.svelte';
+  import { loginSuccessDestination } from '$lib/login-flow';
+  import { Check, Clipboard, Eye, EyeOff, Loader2, Terminal } from '@lucide/svelte';
+
+  const dockerCommand = 'docker compose exec backend uv run python -m app.cli auth reset-password';
+  const manualCommand = 'cd backend\nuv run python -m app.cli auth reset-password';
+
+  let password = $state('');
+  let rememberDevice = $state(false);
+  let showPassword = $state(false);
+  let showRecovery = $state(false);
+  let submitting = $state(false);
+  let errorMessage = $state('');
+  let copied = $state<'docker' | 'manual' | null>(null);
+  let reauthComplete = $state(false);
+
+  async function submit(event: SubmitEvent) {
+    event.preventDefault();
+    if (!password || submitting) return;
+
+    submitting = true;
+    errorMessage = '';
+    try {
+      const session = await loginOwner({
+        password,
+        remember_device: rememberDevice,
+      });
+      authState.applySession(session);
+      password = '';
+
+      const destination = loginSuccessDestination(page.url);
+      if (destination.kind === 'reauth-complete') {
+        reauthComplete = true;
+        setTimeout(() => window.close(), 250);
+      } else {
+        await goto(destination.path);
+      }
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : 'Sign in failed. Please try again.';
+    } finally {
+      submitting = false;
+    }
+  }
+
+  async function copyCommand(kind: 'docker' | 'manual', command: string) {
+    try {
+      await navigator.clipboard.writeText(command);
+      copied = kind;
+      setTimeout(() => {
+        if (copied === kind) copied = null;
+      }, 1800);
+    } catch {
+      copied = null;
+    }
+  }
+</script>
+
+{#if reauthComplete}
+  <AuthShell
+    title="You're signed in"
+    description="Your ApplyKit session has been renewed. You can return to the original tab."
+  >
+    <div class="space-y-5 text-center">
+      <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100 text-green-700 dark:bg-green-950/60 dark:text-green-300">
+        <Check class="h-6 w-6" />
+      </div>
+      <p class="text-sm text-muted-foreground">This tab may close automatically when your browser allows it.</p>
+      <button
+        type="button"
+        onclick={() => window.close()}
+        class="inline-flex w-full items-center justify-center rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90"
+      >
+        Close this tab
+      </button>
+    </div>
+  </AuthShell>
+{:else}
+  <AuthShell title="Sign in to ApplyKit" description="Enter the owner password for this installation.">
+    <form class="space-y-5" onsubmit={submit}>
+      {#if errorMessage}
+        <div class="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive" role="alert">
+          {errorMessage}
+        </div>
+      {/if}
+
+      <div class="space-y-2">
+        <label for="password" class="text-sm font-medium">Password</label>
+        <div class="relative">
+          <input
+            id="password"
+            name="password"
+            type={showPassword ? 'text' : 'password'}
+            autocomplete="current-password"
+            bind:value={password}
+            maxlength="128"
+            class="w-full rounded-lg border border-input bg-background px-3 py-2.5 pr-10 text-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+            required
+            autofocus
+          />
+          <button
+            type="button"
+            onclick={() => showPassword = !showPassword}
+            class="absolute inset-y-0 right-0 flex w-10 items-center justify-center text-muted-foreground hover:text-foreground"
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
+          >
+            {#if showPassword}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
+          </button>
+        </div>
+      </div>
+
+      <label class="flex cursor-pointer items-start gap-3 rounded-lg border border-border bg-muted/30 px-3 py-3">
+        <input type="checkbox" bind:checked={rememberDevice} class="mt-0.5 h-4 w-4 rounded border-input" />
+        <span>
+          <span class="block text-sm font-medium">Remember this device</span>
+          <span class="mt-0.5 block text-xs leading-5 text-muted-foreground">
+            Keep this browser signed in for 30 days instead of 7 days.
+          </span>
+        </span>
+      </label>
+
+      <button
+        type="submit"
+        disabled={!password || submitting}
+        class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {#if submitting}<Loader2 class="h-4 w-4 animate-spin" />Signing in…{:else}Sign in{/if}
+      </button>
+
+      <div class="border-t border-border pt-4">
+        <button
+          type="button"
+          onclick={() => showRecovery = !showRecovery}
+          class="text-sm font-medium text-primary hover:underline"
+          aria-expanded={showRecovery}
+        >
+          Forgot password?
+        </button>
+
+        {#if showRecovery}
+          <div class="mt-4 space-y-4 rounded-xl border border-border bg-muted/30 p-4">
+            <div class="flex items-start gap-2">
+              <Terminal class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+              <p class="text-xs leading-5 text-muted-foreground">
+                ApplyKit has no email recovery. Run one of these commands on the machine hosting ApplyKit.
+              </p>
+            </div>
+
+            <div class="space-y-2">
+              <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Docker</p>
+              <div class="flex items-start gap-2 rounded-lg border border-border bg-background p-3">
+                <code class="min-w-0 flex-1 break-all text-xs">{dockerCommand}</code>
+                <button type="button" onclick={() => copyCommand('docker', dockerCommand)} class="shrink-0 text-muted-foreground hover:text-foreground" aria-label="Copy Docker reset command">
+                  {#if copied === 'docker'}<Check class="h-4 w-4" />{:else}<Clipboard class="h-4 w-4" />{/if}
+                </button>
+              </div>
+            </div>
+
+            <div class="space-y-2">
+              <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Manual setup</p>
+              <div class="flex items-start gap-2 rounded-lg border border-border bg-background p-3">
+                <code class="min-w-0 flex-1 whitespace-pre-wrap text-xs">{manualCommand}</code>
+                <button type="button" onclick={() => copyCommand('manual', manualCommand)} class="shrink-0 text-muted-foreground hover:text-foreground" aria-label="Copy manual reset command">
+                  {#if copied === 'manual'}<Check class="h-4 w-4" />{:else}<Clipboard class="h-4 w-4" />{/if}
+                </button>
+              </div>
+            </div>
+          </div>
+        {/if}
+      </div>
+    </form>
+  </AuthShell>
+{/if}

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -100,7 +100,6 @@
             maxlength="128"
             class="w-full rounded-lg border border-input bg-background px-3 py-2.5 pr-10 text-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
             required
-            autofocus
           />
           <button
             type="button"

--- a/frontend/src/routes/settings/security/+page.svelte
+++ b/frontend/src/routes/settings/security/+page.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+  import {
+    changeOwnerPassword,
+    getSecuritySummary,
+    revokeOtherSessions,
+  } from '$lib/auth-api';
+  import { authState } from '$lib/auth-state.svelte';
+  import PasswordStrength from '$lib/components/PasswordStrength.svelte';
+  import { changePasswordEligible, otherSessionsLabel } from '$lib/security-form';
+  import { toastState } from '$lib/toast.svelte';
+  import { KeyRound, Loader2, LogOut, ShieldCheck } from '@lucide/svelte';
+
+  let currentPassword = $state('');
+  let newPassword = $state('');
+  let confirmation = $state('');
+  let changing = $state(false);
+  let loadingSessions = $state(true);
+  let otherSessions = $state(0);
+  let confirmingRevoke = $state(false);
+  let revoking = $state(false);
+  let errorMessage = $state('');
+
+  const eligible = $derived(
+    changePasswordEligible(currentPassword, newPassword, confirmation),
+  );
+  const confirmationError = $derived(
+    confirmation.length > 0 && confirmation !== newPassword
+      ? 'Passwords do not match.'
+      : '',
+  );
+
+  $effect(() => {
+    loadSessions();
+  });
+
+  async function loadSessions() {
+    loadingSessions = true;
+    try {
+      const summary = await getSecuritySummary();
+      otherSessions = summary.other_sessions;
+    } catch (error) {
+      toastState.error(error instanceof Error ? error.message : 'Failed to load active sessions.');
+    } finally {
+      loadingSessions = false;
+    }
+  }
+
+  async function submitPassword(event: SubmitEvent) {
+    event.preventDefault();
+    if (!eligible || changing) return;
+
+    changing = true;
+    errorMessage = '';
+    try {
+      const session = await changeOwnerPassword({
+        current_password: currentPassword,
+        new_password: newPassword,
+      });
+      authState.applySession(session);
+      currentPassword = '';
+      newPassword = '';
+      confirmation = '';
+      otherSessions = 0;
+      toastState.success('Password changed. Other sessions were signed out.');
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : 'Password could not be changed.';
+    } finally {
+      changing = false;
+    }
+  }
+
+  async function signOutOthers() {
+    if (revoking) return;
+    revoking = true;
+    try {
+      await revokeOtherSessions();
+      otherSessions = 0;
+      confirmingRevoke = false;
+      toastState.success('Other devices have been signed out.');
+    } catch (error) {
+      toastState.error(error instanceof Error ? error.message : 'Could not sign out other devices.');
+    } finally {
+      revoking = false;
+    }
+  }
+</script>
+
+<div class="mx-auto max-w-3xl space-y-6">
+  <header>
+    <h1 class="flex items-center gap-2 text-2xl font-bold tracking-tight">
+      <ShieldCheck class="h-6 w-6 text-primary" />Security
+    </h1>
+    <p class="mt-1 text-sm text-muted-foreground">
+      Change the installation owner password and control other active sessions.
+    </p>
+  </header>
+
+  <section class="rounded-2xl border border-border bg-card p-5 shadow-sm sm:p-6">
+    <div class="mb-5 flex items-start gap-3">
+      <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+        <KeyRound class="h-5 w-5" />
+      </div>
+      <div>
+        <h2 class="font-semibold">Change password</h2>
+        <p class="mt-1 text-sm text-muted-foreground">
+          Changing it keeps this browser signed in and revokes every other session.
+        </p>
+      </div>
+    </div>
+
+    <form class="space-y-4" onsubmit={submitPassword}>
+      {#if errorMessage}
+        <div class="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive" role="alert">
+          {errorMessage}
+        </div>
+      {/if}
+
+      <div class="space-y-2">
+        <label for="current-password" class="text-sm font-medium">Current password</label>
+        <input
+          id="current-password"
+          type="password"
+          autocomplete="current-password"
+          bind:value={currentPassword}
+          class="w-full rounded-lg border border-input bg-background px-3 py-2.5 text-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+          required
+        />
+      </div>
+
+      <div class="space-y-2">
+        <label for="new-password" class="text-sm font-medium">New password</label>
+        <input
+          id="new-password"
+          type="password"
+          autocomplete="new-password"
+          bind:value={newPassword}
+          minlength="12"
+          maxlength="128"
+          class="w-full rounded-lg border border-input bg-background px-3 py-2.5 text-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+          required
+        />
+        <PasswordStrength password={newPassword} />
+      </div>
+
+      <div class="space-y-2">
+        <label for="confirm-new-password" class="text-sm font-medium">Confirm new password</label>
+        <input
+          id="confirm-new-password"
+          type="password"
+          autocomplete="new-password"
+          bind:value={confirmation}
+          maxlength="128"
+          class="w-full rounded-lg border border-input bg-background px-3 py-2.5 text-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+          aria-invalid={confirmationError ? 'true' : 'false'}
+          required
+        />
+        {#if confirmationError}<p class="text-xs text-destructive">{confirmationError}</p>{/if}
+      </div>
+
+      <button
+        type="submit"
+        disabled={!eligible || changing}
+        class="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {#if changing}<Loader2 class="h-4 w-4 animate-spin" />Changing password…{:else}Change password{/if}
+      </button>
+    </form>
+  </section>
+
+  <section class="rounded-2xl border border-border bg-card p-5 shadow-sm sm:p-6">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex items-start gap-3">
+        <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+          <LogOut class="h-5 w-5" />
+        </div>
+        <div>
+          <h2 class="font-semibold">Active sessions</h2>
+          <p class="mt-1 text-sm text-muted-foreground">
+            {#if loadingSessions}Checking sessions…{:else}{otherSessionsLabel(otherSessions)}{/if}
+          </p>
+        </div>
+      </div>
+
+      {#if !confirmingRevoke}
+        <button
+          type="button"
+          onclick={() => confirmingRevoke = true}
+          disabled={loadingSessions || otherSessions === 0}
+          class="rounded-lg border border-border px-3 py-2 text-sm font-medium hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Sign out other devices
+        </button>
+      {/if}
+    </div>
+
+    {#if confirmingRevoke}
+      <div class="mt-5 rounded-xl border border-border bg-muted/30 p-4">
+        <p class="text-sm font-medium">Sign out {otherSessionsLabel(otherSessions).toLowerCase()}?</p>
+        <p class="mt-1 text-xs leading-5 text-muted-foreground">This browser will remain signed in.</p>
+        <div class="mt-3 flex gap-2">
+          <button type="button" onclick={signOutOthers} disabled={revoking} class="inline-flex items-center gap-2 rounded-lg bg-destructive px-3 py-2 text-sm font-semibold text-destructive-foreground disabled:opacity-50">
+            {#if revoking}<Loader2 class="h-4 w-4 animate-spin" />Signing out…{:else}Confirm{/if}
+          </button>
+          <button type="button" onclick={() => confirmingRevoke = false} disabled={revoking} class="rounded-lg border border-border px-3 py-2 text-sm font-medium hover:bg-accent">Cancel</button>
+        </div>
+      </div>
+    {/if}
+  </section>
+</div>

--- a/frontend/src/routes/setup/+page.svelte
+++ b/frontend/src/routes/setup/+page.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/state';
+  import { setupOwner } from '$lib/auth-api';
+  import { authState } from '$lib/auth-state.svelte';
+  import { sanitizeReturnTo } from '$lib/auth-utils';
+  import AuthShell from '$lib/components/AuthShell.svelte';
+  import PasswordStrength from '$lib/components/PasswordStrength.svelte';
+  import { setupFormEligible } from '$lib/setup-form';
+  import { Eye, EyeOff, Loader2 } from '@lucide/svelte';
+
+  let setupToken = $state('');
+  let password = $state('');
+  let confirmation = $state('');
+  let showPassword = $state(false);
+  let submitting = $state(false);
+  let errorMessage = $state('');
+
+  const eligible = $derived(setupFormEligible(setupToken, password, confirmation));
+  const confirmationError = $derived(
+    confirmation.length > 0 && password !== confirmation
+      ? 'Passwords do not match.'
+      : '',
+  );
+
+  async function submit(event: SubmitEvent) {
+    event.preventDefault();
+    if (!eligible || submitting) return;
+
+    submitting = true;
+    errorMessage = '';
+    try {
+      const session = await setupOwner({
+        setup_token: setupToken,
+        password,
+      });
+      authState.applySession(session);
+      setupToken = '';
+      password = '';
+      confirmation = '';
+      await goto(sanitizeReturnTo(page.url.searchParams.get('returnTo')));
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : 'Owner setup could not be completed.';
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<AuthShell
+  title="Protect your ApplyKit installation"
+  description="Create one owner password for this installation. Every career profile will use the same sign-in."
+>
+  <form class="space-y-5" onsubmit={submit}>
+    {#if errorMessage}
+      <div class="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive" role="alert">
+        {errorMessage}
+      </div>
+    {/if}
+
+    <div class="space-y-2">
+      <label for="setup-token" class="text-sm font-medium">One-time setup token</label>
+      <input
+        id="setup-token"
+        name="setup-token"
+        type="text"
+        autocomplete="off"
+        bind:value={setupToken}
+        class="w-full rounded-lg border border-input bg-background px-3 py-2.5 text-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+        placeholder="Paste the token from backend logs"
+        required
+      />
+      <p class="text-xs leading-5 text-muted-foreground">
+        The token appears in the latest backend or container logs and expires after 30 minutes.
+      </p>
+    </div>
+
+    <div class="space-y-2">
+      <label for="password" class="text-sm font-medium">Password</label>
+      <div class="relative">
+        <input
+          id="password"
+          name="password"
+          type={showPassword ? 'text' : 'password'}
+          autocomplete="new-password"
+          bind:value={password}
+          minlength="12"
+          maxlength="128"
+          class="w-full rounded-lg border border-input bg-background px-3 py-2.5 pr-10 text-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+          required
+        />
+        <button
+          type="button"
+          onclick={() => showPassword = !showPassword}
+          class="absolute inset-y-0 right-0 flex w-10 items-center justify-center text-muted-foreground hover:text-foreground"
+          aria-label={showPassword ? 'Hide password' : 'Show password'}
+        >
+          {#if showPassword}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
+        </button>
+      </div>
+      <PasswordStrength {password} />
+      <p class="text-xs text-muted-foreground">Use 12–128 characters. Long passphrases are welcome.</p>
+    </div>
+
+    <div class="space-y-2">
+      <label for="confirm-password" class="text-sm font-medium">Confirm password</label>
+      <input
+        id="confirm-password"
+        name="confirm-password"
+        type="password"
+        autocomplete="new-password"
+        bind:value={confirmation}
+        maxlength="128"
+        class="w-full rounded-lg border border-input bg-background px-3 py-2.5 text-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+        aria-invalid={confirmationError ? 'true' : 'false'}
+        required
+      />
+      {#if confirmationError}
+        <p class="text-xs text-destructive">{confirmationError}</p>
+      {/if}
+    </div>
+
+    <button
+      type="submit"
+      disabled={!eligible || submitting}
+      class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {#if submitting}<Loader2 class="h-4 w-4 animate-spin" />Creating owner password…{:else}Create owner password{/if}
+    </button>
+  </form>
+</AuthShell>


### PR DESCRIPTION
## Summary
- add dedicated `/setup` and `/login` routes for optional single-owner Community authentication
- run the auth status guard before onboarding, provider status, or profile requests
- preserve the existing login-free localhost flow when `AUTH_MODE=disabled`
- use one shared frontend transport with `credentials: include`, CSRF headers for unsafe methods, and no automatic request replay after `401`
- sanitize `returnTo` destinations to prevent external redirects and auth-route loops
- add setup-token, password confirmation, and advisory zxcvbn password-strength UX without imposing extra password composition rules
- add **Remember this device**, inline CLI-only forgotten-password guidance, lockout retry timing, and new-tab reauthentication
- add desktop/mobile sign out controls, including during onboarding
- add **AI Integrations | Security** settings navigation and `/settings/security`
- support password changes, other-session counts, and confirmed sign-out-other-devices actions
- warn during the final five minutes of absolute session expiry and refresh auth state after returning from the reauthentication tab
- route all existing JSON, upload, PDF, streaming, and credential-management requests through the authenticated transport
- document the browser protected-mode flow and same-host HTTPS/CSRF deployment requirement

## Verification
- Bun unit tests: **73 passed, 0 failed** across 20 files
- Assertions: **178 passed**
- Svelte type-check: **0 errors**
- Production build: **success** with the Node adapter
- Frontend CI: **success** on head `5373418acc4e1cd29bd663527f3ac3dd262d31c2`

The three remaining Svelte accessibility warnings are in the pre-existing `SettingsModal.svelte`, which this PR does not modify. Vite also reports its non-blocking large-chunk advisory during the successful build.

## Follow-up
- Session-expiry draft recovery for large forms remains a separate focused PR. Failed mutations are intentionally not replayed automatically.

The approved design and implementation plan are intentionally not committed. No tag or release is included.