### PR TITLE
fix Docker image builds and frontend runtime

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -41,3 +41,12 @@ jobs:
 
       - name: Run tests
         run: uv run --frozen pytest
+
+  container-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build backend container
+        run: docker build --tag applykit-backend:ci ./backend

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -37,3 +37,37 @@ jobs:
 
       - name: Build
         run: bun run build
+
+  container-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build frontend container
+        run: docker build --tag applykit-frontend:ci ./frontend
+
+      - name: Start frontend container
+        run: docker run --detach --name applykit-frontend-ci --publish 3000:3000 applykit-frontend:ci
+
+      - name: Wait for frontend
+        run: |
+          for attempt in {1..30}; do
+            if ! docker ps --filter name=applykit-frontend-ci --filter status=running --quiet | grep --quiet .; then
+              docker logs applykit-frontend-ci
+              exit 1
+            fi
+
+            if curl --fail --silent --show-error http://localhost:3000 > /dev/null; then
+              exit 0
+            fi
+
+            sleep 1
+          done
+
+          docker logs applykit-frontend-ci
+          exit 1
+
+      - name: Stop frontend container
+        if: always()
+        run: docker rm --force applykit-frontend-ci || true

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpango-1.0-0 \
     libpangocairo-1.0-0 \
     libpangoft2-1.0-0 \
-    libgdk-pixbuf2.0-0 \
+    libgdk-pixbuf-2.0-0 \
     libffi-dev \
     shared-mime-info \
     libjpeg-dev \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,12 @@
-# Stage 1: Build
+# Stage 1: Production dependencies
+FROM oven/bun:1 AS production-dependencies
+
+WORKDIR /app
+
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production --ignore-scripts
+
+# Stage 2: Build
 FROM oven/bun:1 AS build
 
 WORKDIR /app
@@ -14,13 +22,14 @@ ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 
 RUN bun run build
 
-# Stage 2: Runtime
+# Stage 3: Runtime
 FROM node:20-slim AS runtime
 
 WORKDIR /app
 
 COPY --from=build /app/build ./build
 COPY --from=build /app/package.json ./
+COPY --from=production-dependencies /app/node_modules ./node_modules
 
 ENV PORT=3000
 ENV HOST=0.0.0.0


### PR DESCRIPTION
## Summary

Adds container-level regression coverage for both Docker failures reported by @inducingchaos and fixes the underlying backend and frontend image issues.

This replacement PR supersedes #1 and #2 while preserving credit for identifying both problems.

## Root causes

- The backend image used the obsolete Debian package name `libgdk-pixbuf2.0-0`, which is unavailable in the current Debian Trixie-based `python:3.12-slim` image.
- The SvelteKit adapter-node build retained runtime imports such as `clsx`, but the runtime image copied only `build/` and `package.json`.

## Changes

- Replace the backend package with `libgdk-pixbuf-2.0-0`.
- Install frontend production dependencies in a dedicated Bun stage with scripts disabled.
- Copy only production `node_modules` into the Node.js runtime image.
- Build the backend image in Backend CI.
- Build, start, and HTTP-smoke-test the frontend image in Frontend CI.

## Validation

Regression-first CI confirmed both checks fail on the previous Dockerfiles:

- Backend container build: `libgdk-pixbuf2.0-0` had no installation candidate.
- Frontend container startup: `ERR_MODULE_NOT_FOUND` for `clsx`.

The final head passes:

- Backend CI: Python 3.12 tests, Python 3.13 tests, lint, and container build.
- Frontend CI: 73 unit tests, type check, production build, container build, startup, and HTTP smoke test.
- Local production-only runtime simulation returned HTTP successfully.

Supersedes #1 and #2.
