### PR TITLE
fix: refresh providers and improve settings editor

### DIFF
--- a/frontend/src/lib/components/ModelSelector.svelte
+++ b/frontend/src/lib/components/ModelSelector.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import { tick } from 'svelte';
-  import { Check, ChevronDown, Search, X } from '@lucide/svelte';
+  import { Check, Search, X } from '@lucide/svelte';
 
   import {
     filterCatalogModels,
@@ -8,6 +7,7 @@
     type CatalogModelOption,
     type ModelStatus,
   } from '$lib/llm-catalog';
+  import { nextModelIndex, selectedModelForKey } from '$lib/model-selector';
 
   let {
     models,
@@ -19,14 +19,12 @@
     unavailableValue?: string;
   } = $props();
 
-  let open = $state(false);
   let query = $state('');
   let statuses = $state<ModelStatus[]>([]);
   let freeTier = $state(false);
   let reasoning = $state(false);
   let structuredOutput = $state(false);
   let activeIndex = $state(0);
-  let searchInput: HTMLInputElement | undefined = $state();
 
   const filters = $derived<CatalogModelFilters>({
     statuses: new Set(statuses),
@@ -50,14 +48,6 @@
     activeIndex = 0;
   });
 
-  async function toggleOpen() {
-    open = !open;
-    if (open) {
-      await tick();
-      searchInput?.focus();
-    }
-  }
-
   function toggleStatus(status: ModelStatus) {
     statuses = statuses.includes(status)
       ? statuses.filter((item) => item !== status)
@@ -74,30 +64,25 @@
 
   function chooseModel(model: CatalogModelOption) {
     value = model.value;
-    open = false;
-    query = '';
   }
 
   function handleSearchKeydown(event: KeyboardEvent) {
-    if (event.key === 'ArrowDown') {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
       event.preventDefault();
-      if (filteredModels.length > 0) {
-        activeIndex = Math.min(activeIndex + 1, filteredModels.length - 1);
-      }
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault();
-      if (filteredModels.length > 0) {
-        activeIndex = Math.max(activeIndex - 1, 0);
-      }
-    } else if (event.key === 'Enter') {
-      event.preventDefault();
-      const model = filteredModels[activeIndex];
-      if (model) chooseModel(model);
-    } else if (event.key === 'Escape') {
-      event.preventDefault();
-      event.stopPropagation();
-      open = false;
+      activeIndex = nextModelIndex(activeIndex, filteredModels.length, event.key);
+      return;
     }
+
+    const selectedValue = selectedModelForKey(
+      event.key,
+      activeIndex,
+      filteredModels.map((model) => model.value),
+    );
+    if (!selectedValue) return;
+
+    event.preventDefault();
+    const model = filteredModels.find((item) => item.value === selectedValue);
+    if (model) chooseModel(model);
   }
 
   function statusBadgeClass(status: ModelStatus): string {
@@ -111,127 +96,126 @@
   }
 </script>
 
-<div class="relative">
-  <button
-    type="button"
-    class="flex w-full items-center justify-between gap-3 rounded-md border border-border bg-background px-3 py-2 text-left text-sm hover:bg-accent/40"
-    aria-haspopup="listbox"
-    aria-expanded={open}
-    onclick={toggleOpen}
-  >
-    <span class="min-w-0 flex-1">
-      <span class="block truncate font-medium">
-        {selectedModel?.label ?? (unavailableSelected ? unavailableValue : 'Select a model')}
+<div class="overflow-hidden rounded-xl border border-border bg-background">
+  <div class="border-b border-border bg-muted/35 p-3">
+    <div class="flex items-start justify-between gap-3 rounded-lg bg-background px-3 py-2.5 shadow-sm ring-1 ring-border/70">
+      <span class="min-w-0 flex-1">
+        <span class="block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Selected model</span>
+        <span class="mt-1 block truncate text-sm font-medium">
+          {selectedModel?.label ?? (unavailableSelected ? unavailableValue : 'Choose a model below')}
+        </span>
+        {#if selectedModel}
+          <span class="block truncate font-mono text-[11px] text-muted-foreground">{selectedModel.value}</span>
+        {:else if unavailableSelected}
+          <span class="block text-[11px] text-yellow-700 dark:text-yellow-300">Unavailable in this release</span>
+        {/if}
       </span>
       {#if selectedModel}
-        <span class="block truncate font-mono text-[11px] text-muted-foreground">{selectedModel.value}</span>
-      {:else if unavailableSelected}
-        <span class="block truncate text-[11px] text-yellow-700 dark:text-yellow-300">Unavailable in this release</span>
+        <span class="mt-1 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary" aria-hidden="true">
+          <Check class="h-4 w-4" />
+        </span>
       {/if}
-    </span>
-    <ChevronDown class="h-4 w-4 shrink-0 text-muted-foreground transition-transform {open ? 'rotate-180' : ''}" />
-  </button>
-
-  {#if open}
-    <div class="absolute z-50 mt-2 w-full overflow-hidden rounded-lg border border-border bg-popover shadow-xl">
-      <div class="space-y-3 border-b border-border p-3">
-        <div class="relative">
-          <Search class="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <input
-            bind:this={searchInput}
-            bind:value={query}
-            onkeydown={handleSearchKeydown}
-            placeholder="Search by name or model ID…"
-            aria-label="Search models"
-            class="w-full rounded-md border border-border bg-background py-2 pl-8 pr-3 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-          />
-        </div>
-
-        <div class="flex flex-wrap gap-1.5" aria-label="Model filters">
-          {#each ['stable', 'preview', 'experimental'] as status}
-            <button
-              type="button"
-              aria-pressed={statuses.includes(status as ModelStatus)}
-              onclick={() => toggleStatus(status as ModelStatus)}
-              class="rounded-full border px-2 py-1 text-[11px] font-medium capitalize transition-colors {statuses.includes(status as ModelStatus)
-                ? 'border-primary bg-primary text-primary-foreground'
-                : 'border-border hover:bg-accent'}"
-            >{status}</button>
-          {/each}
-          <button
-            type="button"
-            aria-pressed={freeTier}
-            onclick={() => (freeTier = !freeTier)}
-            class="rounded-full border px-2 py-1 text-[11px] font-medium transition-colors {freeTier ? 'border-primary bg-primary text-primary-foreground' : 'border-border hover:bg-accent'}"
-          >Free tier</button>
-          <button
-            type="button"
-            aria-pressed={reasoning}
-            onclick={() => (reasoning = !reasoning)}
-            class="rounded-full border px-2 py-1 text-[11px] font-medium transition-colors {reasoning ? 'border-primary bg-primary text-primary-foreground' : 'border-border hover:bg-accent'}"
-          >Reasoning</button>
-          <button
-            type="button"
-            aria-pressed={structuredOutput}
-            onclick={() => (structuredOutput = !structuredOutput)}
-            class="rounded-full border px-2 py-1 text-[11px] font-medium transition-colors {structuredOutput ? 'border-primary bg-primary text-primary-foreground' : 'border-border hover:bg-accent'}"
-          >Structured output</button>
-          {#if query || activeFilterCount > 0}
-            <button
-              type="button"
-              onclick={clearFilters}
-              class="inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground"
-            >
-              <X class="h-3 w-3" /> Clear
-            </button>
-          {/if}
-        </div>
-      </div>
-
-      <div class="max-h-72 overflow-y-auto p-1" role="listbox" aria-label="Available models">
-        {#if filteredModels.length === 0}
-          <div class="px-3 py-8 text-center text-sm text-muted-foreground">
-            No models match the current search and filters.
-          </div>
-        {:else}
-          {#each filteredModels as model, index}
-            <button
-              type="button"
-              role="option"
-              aria-selected={model.value === value}
-              onclick={() => chooseModel(model)}
-              onmouseenter={() => (activeIndex = index)}
-              class="flex w-full items-start gap-2 rounded-md px-3 py-2 text-left transition-colors {index === activeIndex ? 'bg-accent' : 'hover:bg-accent/70'}"
-            >
-              <span class="min-w-0 flex-1">
-                <span class="flex flex-wrap items-center gap-1.5">
-                  <span class="text-sm font-medium">{model.label}</span>
-                  {#if model.status !== 'stable'}
-                    <span class="rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase {statusBadgeClass(model.status)}">{model.status}</span>
-                  {/if}
-                  {#if model.free_tier}
-                    <span class="rounded bg-green-100 px-1.5 py-0.5 text-[9px] font-semibold uppercase text-green-800 dark:bg-green-950 dark:text-green-300">Free tier</span>
-                  {/if}
-                  {#if model.traits.includes('reasoning')}
-                    <span class="rounded bg-muted px-1.5 py-0.5 text-[9px] uppercase text-muted-foreground">Reasoning</span>
-                  {/if}
-                  {#if model.capabilities.includes('structured_output')}
-                    <span class="rounded bg-muted px-1.5 py-0.5 text-[9px] uppercase text-muted-foreground">Structured</span>
-                  {/if}
-                </span>
-                <span class="mt-0.5 block truncate font-mono text-[11px] text-muted-foreground">{model.value}</span>
-              </span>
-              {#if model.value === value}
-                <Check class="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-              {/if}
-            </button>
-          {/each}
-        {/if}
-      </div>
-
-      <div class="border-t border-border px-3 py-2 text-[11px] text-muted-foreground">
-        {filteredModels.length} of {models.length} models
-      </div>
     </div>
-  {/if}
+
+    <div class="relative mt-3">
+      <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      <input
+        bind:value={query}
+        onkeydown={handleSearchKeydown}
+        placeholder="Search by name or model ID..."
+        aria-label="Search models"
+        aria-controls="available-models"
+        class="min-h-11 w-full rounded-lg border border-border bg-background py-2 pl-9 pr-3 text-sm outline-none transition-shadow focus-visible:ring-2 focus-visible:ring-primary/40"
+      />
+    </div>
+
+    <div class="mt-3 flex flex-wrap gap-1.5" aria-label="Model filters">
+      {#each ['stable', 'preview', 'experimental'] as status}
+        <button
+          type="button"
+          aria-pressed={statuses.includes(status as ModelStatus)}
+          onclick={() => toggleStatus(status as ModelStatus)}
+          class="min-h-8 rounded-full border px-2.5 py-1 text-[11px] font-medium capitalize transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 {statuses.includes(status as ModelStatus)
+            ? 'border-primary bg-primary text-primary-foreground'
+            : 'border-border bg-background hover:bg-accent'}"
+        >{status}</button>
+      {/each}
+      <button
+        type="button"
+        aria-pressed={freeTier}
+        onclick={() => (freeTier = !freeTier)}
+        class="min-h-8 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 {freeTier ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-background hover:bg-accent'}"
+      >Free tier</button>
+      <button
+        type="button"
+        aria-pressed={reasoning}
+        onclick={() => (reasoning = !reasoning)}
+        class="min-h-8 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 {reasoning ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-background hover:bg-accent'}"
+      >Reasoning</button>
+      <button
+        type="button"
+        aria-pressed={structuredOutput}
+        onclick={() => (structuredOutput = !structuredOutput)}
+        class="min-h-8 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 {structuredOutput ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-background hover:bg-accent'}"
+      >Structured output</button>
+      {#if query || activeFilterCount > 0}
+        <button
+          type="button"
+          onclick={clearFilters}
+          class="inline-flex min-h-8 items-center gap-1 rounded-full px-2.5 py-1 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        >
+          <X class="h-3 w-3" /> Clear
+        </button>
+      {/if}
+    </div>
+  </div>
+
+  <div id="available-models" class="max-h-[min(42vh,26rem)] overflow-y-auto p-1.5" role="listbox" aria-label="Available models">
+    {#if filteredModels.length === 0}
+      <div class="px-3 py-10 text-center text-sm text-muted-foreground">
+        No models match the current search and filters.
+      </div>
+    {:else}
+      {#each filteredModels as model, index}
+        <button
+          type="button"
+          role="option"
+          aria-selected={model.value === value}
+          onclick={() => chooseModel(model)}
+          onmouseenter={() => (activeIndex = index)}
+          class="flex min-h-12 w-full items-start gap-2 rounded-lg px-3 py-2.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40 {model.value === value
+            ? 'bg-primary/10 ring-1 ring-inset ring-primary/25'
+            : index === activeIndex
+              ? 'bg-accent'
+              : 'hover:bg-accent/70'}"
+        >
+          <span class="min-w-0 flex-1">
+            <span class="flex flex-wrap items-center gap-1.5">
+              <span class="text-sm font-medium">{model.label}</span>
+              {#if model.status !== 'stable'}
+                <span class="rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase {statusBadgeClass(model.status)}">{model.status}</span>
+              {/if}
+              {#if model.free_tier}
+                <span class="rounded bg-green-100 px-1.5 py-0.5 text-[9px] font-semibold uppercase text-green-800 dark:bg-green-950 dark:text-green-300">Free tier</span>
+              {/if}
+              {#if model.traits.includes('reasoning')}
+                <span class="rounded bg-muted px-1.5 py-0.5 text-[9px] uppercase text-muted-foreground">Reasoning</span>
+              {/if}
+              {#if model.capabilities.includes('structured_output')}
+                <span class="rounded bg-muted px-1.5 py-0.5 text-[9px] uppercase text-muted-foreground">Structured</span>
+              {/if}
+            </span>
+            <span class="mt-0.5 block truncate font-mono text-[11px] text-muted-foreground">{model.value}</span>
+          </span>
+          {#if model.value === value}
+            <Check class="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+          {/if}
+        </button>
+      {/each}
+    {/if}
+  </div>
+
+  <div class="border-t border-border px-3 py-2 text-[11px] text-muted-foreground">
+    Showing {filteredModels.length} of {models.length} models
+  </div>
 </div>

--- a/frontend/src/lib/components/SettingsModal.svelte
+++ b/frontend/src/lib/components/SettingsModal.svelte
@@ -35,6 +35,7 @@
     modalMode,
     modalTitle,
     primaryActionLabel,
+    saveSettingsWithRefresh,
   } from '$lib/settings-modal';
   import { toastState } from '$lib/toast.svelte';
   import type { TestConnectionResponse } from '$lib/types';
@@ -61,11 +62,13 @@
     initialProviderId = '',
     initialModel = '',
     initialApiKeyConfigured = false,
+    onsaved = async () => undefined,
   }: {
     open: boolean;
     initialProviderId?: string;
     initialModel?: string;
     initialApiKeyConfigured?: boolean;
+    onsaved?: () => Promise<void> | void;
   } = $props();
 
   let providers: CatalogProviderInfo[] = $state([]);
@@ -331,11 +334,27 @@
     saving = activate ? 'activate' : 'only';
     saveError = '';
     try {
-      await updateSettings({
-        model: selectedModel.trim(),
-        api_key: keyToSave,
-        activate,
-      });
+      const result = await saveSettingsWithRefresh(
+        () =>
+          updateSettings({
+            model: selectedModel.trim(),
+            api_key: keyToSave,
+            activate,
+          }),
+        async () => {
+          await onsaved();
+        },
+      );
+
+      if (result.status === 'save_failed') {
+        saveError = errorMessage(result.error, 'Failed to save settings.');
+        return;
+      }
+      if (result.status === 'refresh_failed') {
+        saveError = 'Provider saved, but the settings list could not refresh. Try refreshing again.';
+        return;
+      }
+
       toastState.success(
         activate
           ? isActive
@@ -354,6 +373,15 @@
       apiKey = '';
       showApiKey = false;
       saving = null;
+    }
+  }
+
+  async function handleCredentialChanged() {
+    try {
+      await refreshCredentialState(selectedProviderId);
+      await onsaved();
+    } catch {
+      saveError = 'Credential saved, but the settings list could not refresh.';
     }
   }
 
@@ -739,7 +767,7 @@
               providerLabel={selectedProvider.label}
               credentialUrl={selectedProvider.credential_url}
               authType={selectedProvider.auth_type}
-              onChanged={() => refreshCredentialState(selectedProvider.id)}
+              onChanged={handleCredentialChanged}
             />
           {:else if activeTab === 'routing'}
             <div class="mx-auto max-w-2xl space-y-5">

--- a/frontend/src/lib/components/SettingsModal.svelte
+++ b/frontend/src/lib/components/SettingsModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { tick } from 'svelte';
   import { goto, invalidateAll } from '$app/navigation';
   import { page } from '$app/state';
   import { getModels, getSettings, testConnection, updateSettings } from '$lib/api';
@@ -92,6 +93,17 @@
   let savedRoutingStrategy: CredentialStrategy = $state('manual');
   let savedRoutingMaxAttempts = $state(2);
   let savingRouting = $state(false);
+  let parentRefreshFailed = $state(false);
+  let refreshingParent = $state(false);
+  let panelElement: HTMLElement | undefined = $state();
+  let previouslyFocused: HTMLElement | null = null;
+  let previousBodyOverflow = '';
+  let previousBodyPosition = '';
+  let previousBodyTop = '';
+  let previousBodyLeft = '';
+  let previousBodyWidth = '';
+  let lockedScrollX = 0;
+  let lockedScrollY = 0;
 
   const selectedProvider = $derived(
     providers.find((provider) => provider.id === selectedProviderId),
@@ -162,6 +174,37 @@
     loadData();
   });
 
+  $effect(() => {
+    if (!open || typeof document === 'undefined') return;
+
+    previouslyFocused = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    lockedScrollX = window.scrollX;
+    lockedScrollY = window.scrollY;
+    previousBodyOverflow = document.body.style.overflow;
+    previousBodyPosition = document.body.style.position;
+    previousBodyTop = document.body.style.top;
+    previousBodyLeft = document.body.style.left;
+    previousBodyWidth = document.body.style.width;
+    document.body.style.overflow = 'hidden';
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${lockedScrollY}px`;
+    document.body.style.left = `-${lockedScrollX}px`;
+    document.body.style.width = '100%';
+    void tick().then(() => panelElement?.focus());
+
+    return () => {
+      document.body.style.overflow = previousBodyOverflow;
+      document.body.style.position = previousBodyPosition;
+      document.body.style.top = previousBodyTop;
+      document.body.style.left = previousBodyLeft;
+      document.body.style.width = previousBodyWidth;
+      previouslyFocused?.focus({ preventScroll: true });
+      window.scrollTo(lockedScrollX, lockedScrollY);
+    };
+  });
+
   function selectExistingModel(modelId: string): boolean {
     for (const provider of providers) {
       if (provider.models.some((model) => model.value === modelId)) {
@@ -224,6 +267,7 @@
     showApiKey = false;
     customMode = false;
     hasStoredCredential = initialApiKeyConfigured;
+    parentRefreshFailed = false;
 
     try {
       const [modelsResponse, settingsResponse] = await Promise.all([
@@ -273,6 +317,7 @@
     activeTab = 'model';
     testResult = null;
     saveError = '';
+    parentRefreshFailed = false;
   }
 
   function toggleCustomMode() {
@@ -289,6 +334,24 @@
     activeTab = tab;
     saveError = '';
     testResult = null;
+  }
+
+  async function handleTabKeydown(event: KeyboardEvent, currentTab: ProviderSettingsTab) {
+    const tabs: ProviderSettingsTab[] = ['model', 'credentials', 'routing'];
+    const currentIndex = tabs.indexOf(currentTab);
+    let nextIndex = currentIndex;
+
+    if (event.key === 'ArrowRight') nextIndex = (currentIndex + 1) % tabs.length;
+    else if (event.key === 'ArrowLeft') nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+    else if (event.key === 'Home') nextIndex = 0;
+    else if (event.key === 'End') nextIndex = tabs.length - 1;
+    else return;
+
+    event.preventDefault();
+    const nextTab = tabs[nextIndex];
+    selectTab(nextTab);
+    await tick();
+    document.getElementById(`provider-tab-${nextTab}`)?.focus();
   }
 
   async function handleTest() {
@@ -352,8 +415,11 @@
       }
       if (result.status === 'refresh_failed') {
         saveError = 'Provider saved, but the settings list could not refresh. Try refreshing again.';
+        parentRefreshFailed = true;
         return;
       }
+
+      parentRefreshFailed = false;
 
       toastState.success(
         activate
@@ -380,8 +446,24 @@
     try {
       await refreshCredentialState(selectedProviderId);
       await onsaved();
+      parentRefreshFailed = false;
     } catch {
       saveError = 'Credential saved, but the settings list could not refresh.';
+      parentRefreshFailed = true;
+    }
+  }
+
+  async function retryParentRefresh() {
+    refreshingParent = true;
+    try {
+      await onsaved();
+      parentRefreshFailed = false;
+      saveError = '';
+      toastState.success('Settings list refreshed.');
+    } catch {
+      saveError = 'The settings list still could not refresh. Try again.';
+    } finally {
+      refreshingParent = false;
     }
   }
 
@@ -420,8 +502,33 @@
     open = false;
   }
 
+  function handleBackdropClick(event: MouseEvent) {
+    if (event.target === event.currentTarget) closeModal();
+  }
+
   function handleKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape') closeModal();
+    if (event.key === 'Escape') {
+      closeModal();
+      return;
+    }
+    if (event.key !== 'Tab' || !panelElement) return;
+
+    const focusable = Array.from(
+      panelElement.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter((element) => !element.hasAttribute('hidden'));
+    if (focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
   }
 </script>
 
@@ -429,20 +536,19 @@
 
 {#if open}
   <div
-    class="fixed inset-0 z-50 flex items-end justify-center bg-black/55 sm:items-center sm:p-4"
-    onclick={closeModal}
-    onkeydown={(event) => event.key === 'Escape' && closeModal()}
-    role="dialog"
-    tabindex="-1"
-    aria-modal="true"
-    aria-labelledby="provider-settings-title"
+    class="panel-overlay fixed inset-0 z-[70] bg-black/55"
+    onclick={handleBackdropClick}
+    role="presentation"
   >
     <div
-      class="flex max-h-[96vh] w-full max-w-4xl flex-col overflow-hidden rounded-t-2xl border border-border bg-background shadow-2xl sm:max-h-[calc(100vh-2rem)] sm:rounded-2xl"
-      onclick={(event) => event.stopPropagation()}
-      role="presentation"
+      bind:this={panelElement}
+      class="provider-panel ml-auto flex h-full w-full max-w-[46rem] flex-col overflow-hidden border-l border-border bg-background shadow-2xl"
+      role="dialog"
+      tabindex="-1"
+      aria-modal="true"
+      aria-labelledby="provider-settings-title"
     >
-      <header class="flex items-start justify-between gap-4 border-b border-border px-5 py-4 sm:px-6">
+      <header class="flex shrink-0 items-start justify-between gap-4 border-b border-border px-5 py-4 sm:px-6">
         <div class="flex min-w-0 items-start gap-3">
           <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
             <Sparkles class="h-5 w-5" />
@@ -471,7 +577,7 @@
             </div>
             {#if managesCredentialVault}
               <p class="mt-1 text-sm text-muted-foreground">
-                {credentialSummary.length} credential{credentialSummary.length === 1 ? '' : 's'} ·
+                {credentialSummary.length} credential{credentialSummary.length === 1 ? '' : 's'} &middot;
                 {credentialStrategyLabel(savedRoutingStrategy)} strategy
               </p>
             {:else}
@@ -484,7 +590,7 @@
         <button
           onclick={closeModal}
           disabled={saving !== null || testing || savingRouting}
-          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+          class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
           aria-label="Close provider settings"
         >
           <X class="h-4 w-4" />
@@ -492,20 +598,30 @@
       </header>
 
       {#if managesCredentialVault}
-        <nav class="sticky top-0 z-10 flex border-b border-border bg-background px-5 sm:px-6" aria-label="Provider settings sections">
+        <div class="flex shrink-0 overflow-x-auto border-b border-border bg-background px-5 sm:px-6" role="tablist" aria-label="Provider settings sections">
           <button
+            id="provider-tab-model"
             type="button"
+            role="tab"
             onclick={() => selectTab('model')}
+            onkeydown={(event) => handleTabKeydown(event, 'model')}
             aria-selected={activeTab === 'model'}
-            class="inline-flex items-center gap-2 border-b-2 px-3 py-3 text-sm font-medium transition-colors {activeTab === 'model' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
+            aria-controls="provider-settings-content"
+            tabindex={activeTab === 'model' ? 0 : -1}
+            class="inline-flex min-h-12 shrink-0 items-center gap-2 border-b-2 px-3 py-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40 {activeTab === 'model' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
           >
             <Sparkles class="h-4 w-4" /> Model
           </button>
           <button
+            id="provider-tab-credentials"
             type="button"
+            role="tab"
             onclick={() => selectTab('credentials')}
+            onkeydown={(event) => handleTabKeydown(event, 'credentials')}
             aria-selected={activeTab === 'credentials'}
-            class="inline-flex items-center gap-2 border-b-2 px-3 py-3 text-sm font-medium transition-colors {activeTab === 'credentials' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
+            aria-controls="provider-settings-content"
+            tabindex={activeTab === 'credentials' ? 0 : -1}
+            class="inline-flex min-h-12 shrink-0 items-center gap-2 border-b-2 px-3 py-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40 {activeTab === 'credentials' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
           >
             <KeyRound class="h-4 w-4" /> Credentials
             <span class="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
@@ -513,23 +629,33 @@
             </span>
           </button>
           <button
+            id="provider-tab-routing"
             type="button"
+            role="tab"
             onclick={() => selectTab('routing')}
+            onkeydown={(event) => handleTabKeydown(event, 'routing')}
             aria-selected={activeTab === 'routing'}
-            class="inline-flex items-center gap-2 border-b-2 px-3 py-3 text-sm font-medium transition-colors {activeTab === 'routing' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
+            aria-controls="provider-settings-content"
+            tabindex={activeTab === 'routing' ? 0 : -1}
+            class="inline-flex min-h-12 shrink-0 items-center gap-2 border-b-2 px-3 py-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40 {activeTab === 'routing' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
           >
             <Route class="h-4 w-4" /> Routing
           </button>
-        </nav>
+        </div>
       {/if}
 
       {#if loading}
         <div class="flex min-h-80 flex-1 items-center justify-center gap-2 text-muted-foreground">
           <Loader2 class="h-5 w-5 animate-spin" />
-          Loading provider settings…
+          Loading provider settings...
         </div>
       {:else}
-        <div class="flex-1 overflow-y-auto px-5 py-5 sm:px-6">
+        <div
+          id={managesCredentialVault ? 'provider-settings-content' : undefined}
+          role={managesCredentialVault ? 'tabpanel' : undefined}
+          aria-labelledby={managesCredentialVault ? `provider-tab-${activeTab}` : undefined}
+          class="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 py-5 sm:px-6"
+        >
           {#if source === 'env' && activeTab === 'model'}
             <div class="mb-5 flex items-start gap-3 rounded-xl border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800 dark:border-blue-900 dark:bg-blue-950/30 dark:text-blue-300">
               <CircleAlert class="mt-0.5 h-4 w-4 shrink-0" />
@@ -845,14 +971,29 @@
           {/if}
 
           {#if saveError}
-            <div class="mx-auto mt-5 flex max-w-2xl items-start gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+            <div role="alert" class="mx-auto mt-5 flex max-w-2xl items-start gap-3 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
               <XCircle class="mt-0.5 h-4 w-4 shrink-0" />
-              <span>{saveError}</span>
+              <div class="min-w-0 flex-1">
+                <p>{saveError}</p>
+                {#if parentRefreshFailed}
+                  <button
+                    type="button"
+                    onclick={retryParentRefresh}
+                    disabled={refreshingParent}
+                    class="mt-2 inline-flex min-h-9 items-center justify-center gap-2 rounded-lg border border-red-300 bg-background px-3 py-1.5 text-xs font-semibold text-red-700 transition-colors hover:bg-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/40 disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950"
+                  >
+                    {#if refreshingParent}
+                      <Loader2 class="h-3.5 w-3.5 animate-spin" />
+                    {/if}
+                    Retry refresh
+                  </button>
+                {/if}
+              </div>
             </div>
           {/if}
         </div>
 
-        <footer class="border-t border-border bg-background/95 px-5 py-4 backdrop-blur sm:px-6">
+        <footer class="shrink-0 border-t border-border bg-background/95 px-5 py-4 backdrop-blur sm:px-6">
           {#if activeTab === 'credentials'}
             <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <p class="text-xs text-muted-foreground">
@@ -860,7 +1001,7 @@
               </p>
               <button
                 onclick={closeModal}
-                class="inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90"
+                class="inline-flex min-h-11 items-center justify-center rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
               >
                 {footerActionForTab('credentials')}
               </button>
@@ -870,14 +1011,14 @@
               <button
                 onclick={closeModal}
                 disabled={savingRouting}
-                class="inline-flex items-center justify-center rounded-lg border border-border px-4 py-2.5 text-sm font-medium hover:bg-accent disabled:opacity-50"
+                class="inline-flex min-h-11 items-center justify-center rounded-lg border border-border px-4 py-2.5 text-sm font-medium hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
               >
                 Cancel
               </button>
               <button
                 onclick={handleSaveRouting}
                 disabled={savingRouting || !routingDirty || (routingStrategy !== 'manual' && !automaticRoutingAvailable)}
-                class="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                class="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {#if savingRouting}
                   <Loader2 class="h-4 w-4 animate-spin" />
@@ -890,7 +1031,7 @@
               <button
                 onclick={closeModal}
                 disabled={saving !== null || testing}
-                class="inline-flex items-center justify-center rounded-lg border border-border px-4 py-2.5 text-sm font-medium transition-colors hover:bg-accent disabled:opacity-50"
+                class="inline-flex min-h-11 items-center justify-center rounded-lg border border-border px-4 py-2.5 text-sm font-medium transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
               >
                 Cancel
               </button>
@@ -899,7 +1040,7 @@
                   <button
                     onclick={() => handleSave(false)}
                     disabled={saving !== null || testing || !canSave}
-                    class="inline-flex items-center justify-center gap-2 rounded-lg border border-border px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                    class="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-border px-4 py-2.5 text-sm font-semibold transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {#if saving === 'only'}
                       <Loader2 class="h-4 w-4 animate-spin" />
@@ -910,7 +1051,7 @@
                 <button
                   onclick={() => handleSave(true)}
                   disabled={saving !== null || testing || !canSave}
-                  class="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                  class="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {#if saving === 'activate'}
                     <Loader2 class="h-4 w-4 animate-spin" />
@@ -925,3 +1066,28 @@
     </div>
   </div>
 {/if}
+
+<style>
+  .panel-overlay {
+    animation: overlay-in 180ms ease-out;
+  }
+
+  .provider-panel {
+    animation: panel-in 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  @keyframes overlay-in {
+    from { background-color: rgb(0 0 0 / 0%); }
+  }
+
+  @keyframes panel-in {
+    from { transform: translateX(100%); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .panel-overlay,
+    .provider-panel {
+      animation: none;
+    }
+  }
+</style>

--- a/frontend/src/lib/model-selector.test.ts
+++ b/frontend/src/lib/model-selector.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { nextModelIndex, selectedModelForKey } from '$lib/model-selector';
+
+describe('inline model browser keyboard navigation', () => {
+	test('moves within result boundaries', () => {
+		expect(nextModelIndex(0, 3, 'ArrowDown')).toBe(1);
+		expect(nextModelIndex(2, 3, 'ArrowDown')).toBe(2);
+		expect(nextModelIndex(2, 3, 'ArrowUp')).toBe(1);
+		expect(nextModelIndex(0, 3, 'ArrowUp')).toBe(0);
+		expect(nextModelIndex(0, 0, 'ArrowDown')).toBe(0);
+	});
+
+	test('selects only on Enter with a valid active result', () => {
+		const models = ['gemini/a', 'gemini/b'];
+
+		expect(selectedModelForKey('Enter', 1, models)).toBe('gemini/b');
+		expect(selectedModelForKey('Escape', 1, models)).toBeNull();
+		expect(selectedModelForKey('Enter', 4, models)).toBeNull();
+	});
+});

--- a/frontend/src/lib/model-selector.ts
+++ b/frontend/src/lib/model-selector.ts
@@ -1,0 +1,17 @@
+export function nextModelIndex(currentIndex: number, itemCount: number, key: string): number {
+	if (itemCount <= 0) return 0;
+	if (key === 'ArrowDown') return Math.min(currentIndex + 1, itemCount - 1);
+	if (key === 'ArrowUp') return Math.max(currentIndex - 1, 0);
+
+	return Math.min(Math.max(currentIndex, 0), itemCount - 1);
+}
+
+export function selectedModelForKey(
+	key: string,
+	activeIndex: number,
+	modelValues: string[],
+): string | null {
+	if (key !== 'Enter') return null;
+
+	return modelValues[activeIndex] ?? null;
+}

--- a/frontend/src/lib/settings-modal.test.ts
+++ b/frontend/src/lib/settings-modal.test.ts
@@ -5,6 +5,8 @@ import {
   modalMode,
   modalTitle,
   primaryActionLabel,
+  saveSettingsWithRefresh,
+  type SettingsSaveResult,
 } from '$lib/settings-modal';
 
 describe('settings modal presentation', () => {
@@ -68,5 +70,53 @@ describe('connection testing mode', () => {
         providerId: 'openai',
       }),
     ).toBe('disabled');
+  });
+});
+
+describe('settings save refresh flow', () => {
+  test('refreshes the parent after persistence succeeds', async () => {
+    const calls: string[] = [];
+
+    const result = await saveSettingsWithRefresh(
+      async () => {
+        calls.push('persist');
+      },
+      async () => {
+        calls.push('refresh');
+      },
+    );
+
+    expect(result).toEqual({ status: 'saved' } satisfies SettingsSaveResult);
+    expect(calls).toEqual(['persist', 'refresh']);
+  });
+
+  test('does not refresh when persistence fails', async () => {
+    const error = new Error('save failed');
+    let refreshCalls = 0;
+
+    const result = await saveSettingsWithRefresh(
+      async () => {
+        throw error;
+      },
+      async () => {
+        refreshCalls += 1;
+      },
+    );
+
+    expect(result).toEqual({ status: 'save_failed', error });
+    expect(refreshCalls).toBe(0);
+  });
+
+  test('reports a refresh failure after persistence succeeds', async () => {
+    const error = new Error('refresh failed');
+
+    const result = await saveSettingsWithRefresh(
+      async () => undefined,
+      async () => {
+        throw error;
+      },
+    );
+
+    expect(result).toEqual({ status: 'refresh_failed', error });
   });
 });

--- a/frontend/src/lib/settings-modal.ts
+++ b/frontend/src/lib/settings-modal.ts
@@ -1,5 +1,28 @@
 export type SettingsModalMode = 'connect' | 'edit';
 export type ConnectionTestMode = 'draft' | 'stored' | 'disabled';
+export type SettingsSaveResult =
+  | { status: 'saved' }
+  | { status: 'save_failed'; error: unknown }
+  | { status: 'refresh_failed'; error: unknown };
+
+export async function saveSettingsWithRefresh(
+  persist: () => Promise<unknown>,
+  refresh: () => Promise<void>,
+): Promise<SettingsSaveResult> {
+  try {
+    await persist();
+  } catch (error) {
+    return { status: 'save_failed', error };
+  }
+
+  try {
+    await refresh();
+  } catch (error) {
+    return { status: 'refresh_failed', error };
+  }
+
+  return { status: 'saved' };
+}
 
 export function modalMode(
   initialProviderId: string,

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -102,6 +102,17 @@
     }
   }
 
+  async function handleProviderSaved() {
+    const [integrationsResponse, modelsResponse] = await Promise.all([
+      getIntegrations(),
+      getModels(),
+    ]);
+    integrations = integrationsResponse.integrations as CredentialIntegrationInfo[];
+    providers = modelsResponse.providers as CatalogProviderInfo[];
+    testStates = {};
+    testSummary = null;
+  }
+
   function providerFor(providerId: string): CatalogProviderInfo | undefined {
     return providers.find((provider) => provider.id === providerId);
   }
@@ -387,4 +398,10 @@
   {/if}
 </div>
 
-<SettingsModal bind:open={modalOpen} initialProviderId={modalProviderId} initialModel={modalModel} initialApiKeyConfigured={modalApiKeyConfigured} />
+<SettingsModal
+  bind:open={modalOpen}
+  initialProviderId={modalProviderId}
+  initialModel={modalModel}
+  initialApiKeyConfigured={modalApiKeyConfigured}
+  onsaved={handleProviderSaved}
+/>


### PR DESCRIPTION
## Summary

- refresh the Connected provider list immediately after provider or credential saves
- replace the nested model dropdown with an inline searchable and filterable model browser
- move provider configuration into an accessible, responsive right-side panel with focus management and refresh retry handling
- keep keyboard focus inside the panel when using Shift+Tab from its initial focus position
- restore focus to the provider's replacement trigger after save, with the AI Settings heading as a stable fallback

## Root cause

The settings page stored integrations and catalog providers in local component state. Saving from the provider editor updated the backend and invalidated SvelteKit data, but it did not re-fetch that local state, so newly configured providers appeared only after a manual page refresh.

The panel initially focused its dialog container, while its focus trap only wrapped backward navigation from the first interactive control. Its cleanup also focused the original trigger unconditionally, even when a successful save moved that provider from Available to Connected and removed the trigger from the DOM.

## User impact

New providers now appear in Connected as soon as saving succeeds. Provider editing is easier to scan, model selection no longer opens a nested floating dropdown, and the panel works at desktop and mobile sizes. Keyboard focus no longer escapes on the initial Shift+Tab, and it returns to a live, relevant page target when the panel closes.

## Validation

- `bun test` - 80 passed
- `bun run check` - 0 errors, 0 warnings
- `bun run build` - production build succeeded
- production-only Node runtime started and returned HTTP 200
- regression tests cover initial backward focus wrapping and disconnected-trigger restoration
- Frontend CI #150 - check and container-smoke jobs succeeded
- browser-verified desktop and 390x844 layouts
- browser-verified Ollama `Save only` changed Connected from 2 to 3 without reloading and kept Groq active

## Scope

Implementation-only frontend changes. No `docs/` paths are included.