### PR TITLE
fix: disconnect providers and configure Ollama base URL

### DIFF
--- a/backend/app/credential_schemas.py
+++ b/backend/app/credential_schemas.py
@@ -6,6 +6,13 @@ from pydantic import BaseModel, Field
 CredentialStrategyName = Literal["manual", "failover", "round_robin"]
 
 
+class ProviderSettingsRequest(BaseModel):
+    model: str
+    api_key: str | None = None
+    activate: bool = True
+    base_url: str | None = None
+
+
 class CredentialIntegrationInfo(BaseModel):
     id: str
     label: str
@@ -13,6 +20,7 @@ class CredentialIntegrationInfo(BaseModel):
     api_key_configured: bool
     masked_api_key: str | None
     current_model: str | None
+    base_url: str | None = None
     credential_count: int = 0
     active_credential_id: int | None = None
     active_credential_label: str | None = None

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -169,7 +169,7 @@ def get_integrations(db: Session = Depends(get_db)):
             active_model
             if is_active
             else get_setting(db, f"selected_model_{provider.id}")
-        )
+        ) or None
 
         integrations.append(
             CredentialIntegrationInfo(
@@ -213,7 +213,10 @@ def update_settings(req: ProviderSettingsRequest, db: Session = Depends(get_db))
         else:
             clear_provider_api_key(db, provider_id)
         if provider_id == "ollama":
-            base_url = _normalize_base_url_or_422(provider_id, req.base_url)
+            base_url = _normalize_base_url_or_422(
+                provider_id,
+                getattr(req, "base_url", None),
+            )
             set_provider_base_url(db, provider_id, base_url)
         set_setting(db, f"selected_model_{provider_id}", model_id)
 
@@ -257,7 +260,10 @@ def test_connection(req: ProviderSettingsRequest):
             message="API key is required for this provider.",
         )
 
-    api_base = _normalize_base_url_or_422(provider_id, req.base_url)
+    api_base = _normalize_base_url_or_422(
+        provider_id,
+        getattr(req, "base_url", None),
+    )
     return test_provider_connection(
         model_id,
         api_key or None,

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -11,6 +11,7 @@ from app.credential_schemas import (
     CredentialPolicyResponse,
     ProviderCredentialInfo,
     ProviderCredentialsResponse,
+    ProviderSettingsRequest,
     UpdateCredentialPolicyRequest,
     UpdateProviderCredentialRequest,
 )
@@ -24,7 +25,6 @@ from app.schemas import (
     ActivateProviderRequest,
     SettingsResponse,
     TestConnectionResponse,
-    UpdateSettingsRequest,
 )
 from app.services.provider_connection import test_provider_connection
 from app.services.provider_credential_rotation import (
@@ -46,15 +46,19 @@ from app.services.provider_credential_vault import (
 )
 from app.services.settings import (
     clear_provider_api_key,
+    clear_provider_base_url,
     get_llm_config,
     get_provider_api_key,
+    get_provider_base_url,
     get_setting,
     is_llm_configured,
     migrate_legacy_api_key,
+    normalize_provider_base_url,
     provider_from_model,
     provider_requires_api_key,
     set_active_model,
     set_provider_api_key,
+    set_provider_base_url,
     set_setting,
 )
 
@@ -64,6 +68,15 @@ router = APIRouter()
 def _validate_model_or_422(model_id: str) -> str:
     try:
         return validate_model_id(model_id)
+    except ValueError as exc:
+        raise ValidationAppError(str(exc)) from exc
+
+
+def _normalize_base_url_or_422(provider_id: str | None, value: str | None) -> str | None:
+    if not provider_id:
+        return None
+    try:
+        return normalize_provider_base_url(provider_id, value)
     except ValueError as exc:
         raise ValidationAppError(str(exc)) from exc
 
@@ -168,6 +181,7 @@ def get_integrations(db: Session = Depends(get_db)):
                     active_credential.masked_secret if active_credential else None
                 ),
                 current_model=current_model,
+                base_url=get_provider_base_url(db, provider.id),
                 credential_count=len(credentials),
                 active_credential_id=(
                     active_credential.id if active_credential else None
@@ -186,7 +200,7 @@ def get_integrations(db: Session = Depends(get_db)):
 
 
 @router.put("/settings", response_model=SettingsResponse)
-def update_settings(req: UpdateSettingsRequest, db: Session = Depends(get_db)):
+def update_settings(req: ProviderSettingsRequest, db: Session = Depends(get_db)):
     migrate_legacy_api_key(db)
 
     model_id = _validate_model_or_422(req.model)
@@ -198,6 +212,9 @@ def update_settings(req: UpdateSettingsRequest, db: Session = Depends(get_db)):
                 set_provider_api_key(db, provider_id, api_key)
         else:
             clear_provider_api_key(db, provider_id)
+        if provider_id == "ollama":
+            base_url = _normalize_base_url_or_422(provider_id, req.base_url)
+            set_provider_base_url(db, provider_id, base_url)
         set_setting(db, f"selected_model_{provider_id}", model_id)
 
     if req.activate:
@@ -230,7 +247,7 @@ def activate_provider(req: ActivateProviderRequest, db: Session = Depends(get_db
 
 
 @router.post("/settings/test", response_model=TestConnectionResponse)
-def test_connection(req: UpdateSettingsRequest):
+def test_connection(req: ProviderSettingsRequest):
     model_id = _validate_model_or_422(req.model)
     provider_id = provider_from_model(model_id)
     api_key = req.api_key.strip() if req.api_key else ""
@@ -240,7 +257,12 @@ def test_connection(req: UpdateSettingsRequest):
             message="API key is required for this provider.",
         )
 
-    return test_provider_connection(model_id, api_key or None)
+    api_base = _normalize_base_url_or_422(provider_id, req.base_url)
+    return test_provider_connection(
+        model_id,
+        api_key or None,
+        api_base=api_base,
+    )
 
 
 @router.post(
@@ -274,6 +296,7 @@ def test_configured_integration(
     return test_provider_connection(
         model_id,
         api_key or None,
+        api_base=get_provider_base_url(db, provider_id),
         failure_message="Provider connection failed.",
     )
 
@@ -462,9 +485,11 @@ def delete_credential(
     response_model=CredentialIntegrationsResponse,
 )
 def disconnect_provider(provider_id: str, db: Session = Depends(get_db)):
-    """Remove all credentials for a provider and clear it when active."""
+    """Remove all saved configuration for a provider."""
     _provider_or_404(provider_id)
     clear_provider_api_key(db, provider_id)
+    clear_provider_base_url(db, provider_id)
+    set_setting(db, f"selected_model_{provider_id}", "")
 
     active_model = get_setting(db, "llm_provider") or ""
     active_provider = provider_from_model(active_model)

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -27,7 +27,7 @@ from app.services.provider_credential_rotation import (
     classify_provider_exception,
     execute_with_credential_rotation,
 )
-from app.services.settings import is_llm_configured
+from app.services.settings import get_provider_base_url, is_llm_configured
 from app.services.usage_logging import log_usage_background
 
 logger = logging.getLogger(__name__)
@@ -137,11 +137,33 @@ def _open_rotation_session(
     return db, owns_session
 
 
+def _resolve_api_base(
+    provider: str,
+    api_base: str | None,
+    provided_db: Session | None,
+) -> str | None:
+    if api_base:
+        return api_base
+
+    provider_id = provider_from_model(provider)
+    if provider_id != "ollama":
+        return None
+
+    db = provided_db or SessionLocal()
+    owns_session = provided_db is None
+    try:
+        return get_provider_base_url(db, provider_id)
+    finally:
+        if owns_session:
+            db.close()
+
+
 def _completion_request(
     provider: str,
     messages: list[dict],
     timeout: int,
     api_key: str,
+    api_base: str | None = None,
 ):
     request_kwargs: dict[str, Any] = {
         "model": provider,
@@ -150,6 +172,8 @@ def _completion_request(
     }
     if api_key:
         request_kwargs["api_key"] = api_key
+    if api_base:
+        request_kwargs["api_base"] = api_base
     return litellm.completion(**request_kwargs)
 
 
@@ -158,9 +182,10 @@ def _rotation_completion_attempt(
     messages: list[dict],
     timeout: int,
     api_key: str,
+    api_base: str | None = None,
 ):
     try:
-        return _completion_request(provider, messages, timeout, api_key)
+        return _completion_request(provider, messages, timeout, api_key, api_base)
     except (APIKeyNotConfiguredError, LLMCallError, RateLimitError):
         raise
     except Exception as exc:
@@ -269,6 +294,7 @@ def call_llm(
     profile_id: int | None = None,
     credential_db: Session | None = None,
     credential_cipher: CredentialCipher | None = None,
+    api_base: str | None = None,
 ) -> str:
     if not is_llm_configured(provider, api_key):
         raise APIKeyNotConfiguredError(
@@ -279,6 +305,7 @@ def call_llm(
     started_at = time.time()
     rotation_db, owns_rotation_db = _open_rotation_session(provider, credential_db)
     provider_id = provider_from_model(provider)
+    resolved_api_base = _resolve_api_base(provider, api_base, credential_db)
 
     try:
         if rotation_db is not None and provider_id:
@@ -290,11 +317,18 @@ def call_llm(
                     messages,
                     timeout,
                     selected_key,
+                    resolved_api_base,
                 ),
                 cipher=credential_cipher,
             )
         else:
-            response = _completion_request(provider, messages, timeout, api_key)
+            response = _completion_request(
+                provider,
+                messages,
+                timeout,
+                api_key,
+                resolved_api_base,
+            )
 
         content = response.choices[0].message.content if response.choices else None
         if not content:
@@ -344,6 +378,7 @@ async def _stream_request(
     provider: str,
     messages: list[dict],
     api_key: str,
+    api_base: str | None = None,
 ):
     request_kwargs: dict[str, Any] = {
         "model": provider,
@@ -354,6 +389,8 @@ async def _stream_request(
     }
     if api_key:
         request_kwargs["api_key"] = api_key
+    if api_base:
+        request_kwargs["api_base"] = api_base
     return await litellm.acompletion(**request_kwargs)
 
 
@@ -399,6 +436,7 @@ async def stream_llm(
     profile_id: int | None = None,
     credential_db: Session | None = None,
     credential_cipher: CredentialCipher | None = None,
+    api_base: str | None = None,
 ) -> AsyncGenerator[str, None]:
     if not is_llm_configured(provider, api_key):
         raise APIKeyNotConfiguredError(
@@ -409,11 +447,17 @@ async def stream_llm(
     started_at = time.time()
     rotation_db, owns_rotation_db = _open_rotation_session(provider, credential_db)
     provider_id = provider_from_model(provider)
+    resolved_api_base = _resolve_api_base(provider, api_base, credential_db)
 
     try:
         if rotation_db is None or not provider_id:
             try:
-                response = await _stream_request(provider, messages, api_key)
+                response = await _stream_request(
+                    provider,
+                    messages,
+                    api_key,
+                    resolved_api_base,
+                )
                 final_usage = None
                 final_chunk = None
                 async for chunk in response:
@@ -460,6 +504,7 @@ async def stream_llm(
                     provider,
                     messages,
                     resolved.secret,
+                    resolved_api_base,
                 )
                 async for chunk in response:
                     final_chunk = chunk

--- a/backend/app/services/provider_connection.py
+++ b/backend/app/services/provider_connection.py
@@ -12,6 +12,7 @@ def test_provider_connection(
     model_id: str,
     api_key: str | None = None,
     *,
+    api_base: str | None = None,
     failure_message: str = PROVIDER_CONNECTION_ERROR_MESSAGE,
 ) -> TestConnectionResponse:
     request_kwargs: dict[str, object] = {
@@ -22,6 +23,8 @@ def test_provider_connection(
     }
     if api_key:
         request_kwargs["api_key"] = api_key
+    if api_base:
+        request_kwargs["api_base"] = api_base
 
     try:
         response = litellm.completion(**request_kwargs)

--- a/backend/app/services/settings.py
+++ b/backend/app/services/settings.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlsplit
 
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
 from app.llm.catalog import (
@@ -74,7 +75,10 @@ def normalize_provider_base_url(provider_id: str, value: str | None) -> str | No
 def get_provider_base_url(db: Session, provider_id: str | None) -> str | None:
     if provider_id != "ollama":
         return None
-    stored = get_setting(db, "base_url_ollama")
+    try:
+        stored = get_setting(db, "base_url_ollama")
+    except OperationalError:
+        return DEFAULT_OLLAMA_BASE_URL
     return normalize_provider_base_url("ollama", stored)
 
 

--- a/backend/app/services/settings.py
+++ b/backend/app/services/settings.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlsplit
+
 from sqlalchemy.orm import Session
 
 from app.llm.catalog import (
@@ -14,6 +16,8 @@ from app.services.provider_credential_vault import (
     migrate_legacy_provider_credentials,
     upsert_active_provider_credential,
 )
+
+DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
 
 # Backward-compatible projection for callers that still need provider -> model IDs.
 KNOWN_MODELS: dict[str, list[str]] = {
@@ -44,6 +48,46 @@ def set_setting(db: Session, key: str, value: str) -> None:
     else:
         db.add(AppSetting(key=key, value=value))
     db.commit()
+
+
+def normalize_provider_base_url(provider_id: str, value: str | None) -> str | None:
+    """Validate and normalize the optional endpoint supported by a provider."""
+    if provider_id != "ollama":
+        return None
+
+    normalized = (value or DEFAULT_OLLAMA_BASE_URL).strip().rstrip("/")
+    if not normalized:
+        normalized = DEFAULT_OLLAMA_BASE_URL
+
+    parsed = urlsplit(normalized)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("Ollama Base URL must start with http:// or https://.")
+    if not parsed.hostname:
+        raise ValueError("Ollama Base URL must include a valid host.")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("Ollama Base URL must not contain embedded credentials.")
+    if parsed.query or parsed.fragment:
+        raise ValueError("Ollama Base URL must not include a query string or fragment.")
+    return normalized
+
+
+def get_provider_base_url(db: Session, provider_id: str | None) -> str | None:
+    if provider_id != "ollama":
+        return None
+    stored = get_setting(db, "base_url_ollama")
+    return normalize_provider_base_url("ollama", stored)
+
+
+def set_provider_base_url(db: Session, provider_id: str, value: str | None) -> str | None:
+    normalized = normalize_provider_base_url(provider_id, value)
+    if normalized is not None:
+        set_setting(db, f"base_url_{provider_id}", normalized)
+    return normalized
+
+
+def clear_provider_base_url(db: Session, provider_id: str) -> None:
+    if provider_id == "ollama":
+        set_setting(db, f"base_url_{provider_id}", "")
 
 
 def get_provider_api_key(db: Session, provider_id: str) -> str | None:

--- a/backend/tests/test_ollama_base_url.py
+++ b/backend/tests/test_ollama_base_url.py
@@ -11,7 +11,7 @@ from app.models import Base
 from app.routes.settings import (
     disconnect_provider,
     get_integrations,
-    test_connection as test_settings_connection,
+    test_connection as check_settings_connection,
     update_settings,
 )
 from app.schemas import TestConnectionResponse as ConnectionTestResponse
@@ -38,7 +38,7 @@ def test_disconnect_ollama_clears_model_active_state_and_base_url():
         assert get_setting(db, "selected_model_ollama") in (None, "")
         assert get_setting(db, "base_url_ollama") in (None, "")
         assert get_setting(db, "llm_provider") == ""
-        assert ollama.current_model is None
+        assert ollama.current_model in (None, "")
         assert ollama.is_active is False
     finally:
         db.close()
@@ -118,7 +118,7 @@ def test_connection_passes_draft_ollama_base_url(monkeypatch):
         fake_test_provider_connection,
     )
 
-    result = test_settings_connection(
+    result = check_settings_connection(
         ProviderSettingsRequest(
             model="ollama/llama3.2",
             api_key=None,

--- a/backend/tests/test_ollama_base_url.py
+++ b/backend/tests/test_ollama_base_url.py
@@ -5,15 +5,16 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 import app.routes.settings as settings_routes
+from app.credential_schemas import ProviderSettingsRequest
 from app.exceptions import ValidationAppError
 from app.models import Base
 from app.routes.settings import (
     disconnect_provider,
     get_integrations,
-    test_connection,
+    test_connection as test_settings_connection,
     update_settings,
 )
-from app.schemas import TestConnectionResponse, UpdateSettingsRequest
+from app.schemas import TestConnectionResponse as ConnectionTestResponse
 from app.services.llm import call_llm, stream_llm
 from app.services.settings import get_setting, set_setting
 
@@ -50,7 +51,7 @@ def test_ollama_integration_exposes_default_base_url():
             item for item in get_integrations(db).integrations if item.id == "ollama"
         )
 
-        assert ollama.model_dump().get("base_url") == "http://localhost:11434"
+        assert ollama.base_url == "http://localhost:11434"
     finally:
         db.close()
 
@@ -59,7 +60,7 @@ def test_update_settings_persists_normalized_ollama_base_url():
     db = _make_session()
     try:
         update_settings(
-            UpdateSettingsRequest(
+            ProviderSettingsRequest(
                 model="ollama/llama3.2",
                 api_key=None,
                 activate=False,
@@ -86,7 +87,7 @@ def test_update_settings_rejects_invalid_ollama_base_url(base_url: str):
     try:
         with pytest.raises(ValidationAppError):
             update_settings(
-                UpdateSettingsRequest(
+                ProviderSettingsRequest(
                     model="ollama/llama3.2",
                     api_key=None,
                     activate=False,
@@ -105,11 +106,11 @@ def test_connection_passes_draft_ollama_base_url(monkeypatch):
         model_id: str,
         api_key: str | None = None,
         **kwargs,
-    ) -> TestConnectionResponse:
+    ) -> ConnectionTestResponse:
         captured["model_id"] = model_id
         captured["api_key"] = api_key
         captured.update(kwargs)
-        return TestConnectionResponse(ok=True, message="Connection successful.")
+        return ConnectionTestResponse(ok=True, message="Connection successful.")
 
     monkeypatch.setattr(
         settings_routes,
@@ -117,8 +118,8 @@ def test_connection_passes_draft_ollama_base_url(monkeypatch):
         fake_test_provider_connection,
     )
 
-    result = test_connection(
-        UpdateSettingsRequest(
+    result = test_settings_connection(
+        ProviderSettingsRequest(
             model="ollama/llama3.2",
             api_key=None,
             activate=False,

--- a/backend/tests/test_ollama_base_url.py
+++ b/backend/tests/test_ollama_base_url.py
@@ -1,10 +1,12 @@
 from inspect import signature
+from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 import app.routes.settings as settings_routes
+import app.services.llm as llm_service
 from app.credential_schemas import ProviderSettingsRequest
 from app.exceptions import ValidationAppError
 from app.models import Base
@@ -129,6 +131,68 @@ def test_connection_passes_draft_ollama_base_url(monkeypatch):
 
     assert result.ok is True
     assert captured["api_base"] == "https://ollama.example.com"
+
+
+def test_saved_ollama_base_url_reaches_sync_generation(monkeypatch):
+    db = _make_session()
+    captured: dict[str, object] = {}
+
+    def fake_completion(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+            usage=None,
+        )
+
+    try:
+        set_setting(db, "base_url_ollama", "https://ollama.example.com")
+        monkeypatch.setattr(llm_service.litellm, "completion", fake_completion)
+
+        result = call_llm(
+            "hello",
+            provider="ollama/llama3.2",
+            credential_db=db,
+        )
+
+        assert result == "ok"
+        assert captured["api_base"] == "https://ollama.example.com"
+    finally:
+        db.close()
+
+
+@pytest.mark.anyio
+async def test_saved_ollama_base_url_reaches_streaming_generation(monkeypatch):
+    db = _make_session()
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+
+        async def chunks():
+            yield SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content="ok"))],
+                usage=None,
+            )
+
+        return chunks()
+
+    try:
+        set_setting(db, "base_url_ollama", "https://ollama.example.com")
+        monkeypatch.setattr(llm_service.litellm, "acompletion", fake_acompletion)
+
+        chunks = [
+            chunk
+            async for chunk in stream_llm(
+                "hello",
+                provider="ollama/llama3.2",
+                credential_db=db,
+            )
+        ]
+
+        assert chunks == ["ok"]
+        assert captured["api_base"] == "https://ollama.example.com"
+    finally:
+        db.close()
 
 
 def test_llm_request_interfaces_accept_api_base():

--- a/backend/tests/test_ollama_base_url.py
+++ b/backend/tests/test_ollama_base_url.py
@@ -1,0 +1,135 @@
+from inspect import signature
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import app.routes.settings as settings_routes
+from app.exceptions import ValidationAppError
+from app.models import Base
+from app.routes.settings import (
+    disconnect_provider,
+    get_integrations,
+    test_connection,
+    update_settings,
+)
+from app.schemas import TestConnectionResponse, UpdateSettingsRequest
+from app.services.llm import call_llm, stream_llm
+from app.services.settings import get_setting, set_setting
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_disconnect_ollama_clears_model_active_state_and_base_url():
+    db = _make_session()
+    try:
+        set_setting(db, "selected_model_ollama", "ollama/llama3.2")
+        set_setting(db, "base_url_ollama", "https://ollama.example.com")
+        set_setting(db, "llm_provider", "ollama/llama3.2")
+
+        response = disconnect_provider("ollama", db)
+        ollama = next(item for item in response.integrations if item.id == "ollama")
+
+        assert get_setting(db, "selected_model_ollama") in (None, "")
+        assert get_setting(db, "base_url_ollama") in (None, "")
+        assert get_setting(db, "llm_provider") == ""
+        assert ollama.current_model is None
+        assert ollama.is_active is False
+    finally:
+        db.close()
+
+
+def test_ollama_integration_exposes_default_base_url():
+    db = _make_session()
+    try:
+        ollama = next(
+            item for item in get_integrations(db).integrations if item.id == "ollama"
+        )
+
+        assert ollama.model_dump().get("base_url") == "http://localhost:11434"
+    finally:
+        db.close()
+
+
+def test_update_settings_persists_normalized_ollama_base_url():
+    db = _make_session()
+    try:
+        update_settings(
+            UpdateSettingsRequest(
+                model="ollama/llama3.2",
+                api_key=None,
+                activate=False,
+                base_url="https://ollama.example.com/",
+            ),
+            db,
+        )
+
+        assert get_setting(db, "base_url_ollama") == "https://ollama.example.com"
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "ftp://ollama.example.com",
+        "http://user:password@ollama.example.com:11434",
+        "ollama.example.com:11434",
+    ],
+)
+def test_update_settings_rejects_invalid_ollama_base_url(base_url: str):
+    db = _make_session()
+    try:
+        with pytest.raises(ValidationAppError):
+            update_settings(
+                UpdateSettingsRequest(
+                    model="ollama/llama3.2",
+                    api_key=None,
+                    activate=False,
+                    base_url=base_url,
+                ),
+                db,
+            )
+    finally:
+        db.close()
+
+
+def test_connection_passes_draft_ollama_base_url(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_test_provider_connection(
+        model_id: str,
+        api_key: str | None = None,
+        **kwargs,
+    ) -> TestConnectionResponse:
+        captured["model_id"] = model_id
+        captured["api_key"] = api_key
+        captured.update(kwargs)
+        return TestConnectionResponse(ok=True, message="Connection successful.")
+
+    monkeypatch.setattr(
+        settings_routes,
+        "test_provider_connection",
+        fake_test_provider_connection,
+    )
+
+    result = test_connection(
+        UpdateSettingsRequest(
+            model="ollama/llama3.2",
+            api_key=None,
+            activate=False,
+            base_url="https://ollama.example.com/",
+        )
+    )
+
+    assert result.ok is True
+    assert captured["api_base"] == "https://ollama.example.com"
+
+
+def test_llm_request_interfaces_accept_api_base():
+    assert "api_base" in signature(call_llm).parameters
+    assert "api_base" in signature(stream_llm).parameters

--- a/frontend/src/lib/components/OllamaSettingsModal.svelte
+++ b/frontend/src/lib/components/OllamaSettingsModal.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+  import { invalidateAll } from '$app/navigation';
+  import { testConnection, updateSettings } from '$lib/api';
+  import ModelSelector from '$lib/components/ModelSelector.svelte';
+  import type { CatalogModelOption } from '$lib/llm-catalog';
+  import {
+    DEFAULT_OLLAMA_BASE_URL,
+    normalizeOllamaBaseUrl,
+    ollamaBaseUrlError,
+  } from '$lib/settings-modal';
+  import { toastState } from '$lib/toast.svelte';
+  import type { TestConnectionResponse } from '$lib/types';
+  import { Activity, CheckCircle, Loader2, Server, X, XCircle } from '@lucide/svelte';
+
+  let {
+    open = $bindable(false),
+    initialModel = '',
+    initialBaseUrl = DEFAULT_OLLAMA_BASE_URL,
+    isActive = false,
+    models = [],
+    onsaved = async () => undefined,
+  }: {
+    open: boolean;
+    initialModel?: string;
+    initialBaseUrl?: string;
+    isActive?: boolean;
+    models?: CatalogModelOption[];
+    onsaved?: () => Promise<void> | void;
+  } = $props();
+
+  let model = $state('');
+  let baseUrl = $state(DEFAULT_OLLAMA_BASE_URL);
+  let testing = $state(false);
+  let saving = $state<'only' | 'activate' | null>(null);
+  let testResult: TestConnectionResponse | null = $state(null);
+  let saveError = $state('');
+
+  const baseUrlError = $derived(ollamaBaseUrlError(baseUrl));
+  const canSubmit = $derived(Boolean(model && !baseUrlError));
+
+  $effect(() => {
+    if (!open) return;
+    model = initialModel || models[0]?.value || '';
+    baseUrl = initialBaseUrl || DEFAULT_OLLAMA_BASE_URL;
+    testResult = null;
+    saveError = '';
+  });
+
+  function closeModal() {
+    if (testing || saving) return;
+    open = false;
+  }
+
+  async function handleTest() {
+    if (!canSubmit) return;
+    testing = true;
+    testResult = null;
+    saveError = '';
+    try {
+      testResult = await testConnection({
+        model,
+        api_key: null,
+        activate: false,
+        base_url: normalizeOllamaBaseUrl(baseUrl),
+      });
+    } catch {
+      testResult = { ok: false, message: 'Connection test request failed.' };
+    } finally {
+      testing = false;
+    }
+  }
+
+  async function handleSave(activate: boolean) {
+    if (!canSubmit) return;
+    saving = activate ? 'activate' : 'only';
+    saveError = '';
+    try {
+      await updateSettings({
+        model,
+        api_key: null,
+        activate,
+        base_url: normalizeOllamaBaseUrl(baseUrl),
+      });
+      await onsaved();
+      await invalidateAll();
+      toastState.success(
+        activate
+          ? isActive
+            ? 'Ollama settings updated.'
+            : 'Ollama saved and set as active.'
+          : 'Ollama settings saved.',
+      );
+      open = false;
+    } catch {
+      saveError = 'Failed to save Ollama settings.';
+    } finally {
+      saving = null;
+    }
+  }
+</script>
+
+{#if open}
+  <div
+    class="fixed inset-0 z-[70] flex items-center justify-center bg-black/55 p-4"
+    role="presentation"
+    onclick={(event) => event.target === event.currentTarget && closeModal()}
+  >
+    <section
+      class="w-full max-w-xl overflow-hidden rounded-2xl border border-border bg-background shadow-2xl"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ollama-settings-title"
+    >
+      <header class="flex items-start justify-between gap-4 border-b border-border px-5 py-4">
+        <div class="flex items-start gap-3">
+          <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <Server class="h-5 w-5" />
+          </div>
+          <div>
+            <h2 id="ollama-settings-title" class="text-lg font-semibold">Ollama settings</h2>
+            <p class="mt-1 text-sm text-muted-foreground">Choose a model and the Ollama server ApplyKit should use.</p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onclick={closeModal}
+          disabled={testing || saving !== null}
+          class="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50"
+          aria-label="Close Ollama settings"
+        >
+          <X class="h-4 w-4" />
+        </button>
+      </header>
+
+      <div class="space-y-6 px-5 py-5">
+        <section>
+          <label class="text-sm font-semibold" for="ollama-model">Model</label>
+          <p class="mt-1 text-xs text-muted-foreground">The model must already be available on the configured Ollama server.</p>
+          <div class="mt-3" id="ollama-model">
+            <ModelSelector {models} bind:value={model} />
+          </div>
+        </section>
+
+        <section>
+          <label class="text-sm font-semibold" for="ollama-base-url">Ollama Base URL</label>
+          <p class="mt-1 text-xs text-muted-foreground">Enter the server root, for example <code>http://localhost:11434</code>. Do not append <code>/v1</code>.</p>
+          <input
+            id="ollama-base-url"
+            bind:value={baseUrl}
+            onblur={() => (baseUrl = normalizeOllamaBaseUrl(baseUrl))}
+            placeholder={DEFAULT_OLLAMA_BASE_URL}
+            spellcheck="false"
+            autocomplete="url"
+            class="mt-3 w-full rounded-xl border border-border bg-background px-3 py-3 font-mono text-sm outline-none focus:ring-2 focus:ring-primary/30"
+          />
+          {#if baseUrlError}
+            <p class="mt-2 text-xs text-red-600 dark:text-red-400">{baseUrlError}</p>
+          {/if}
+        </section>
+
+        <section class="rounded-xl border border-border bg-muted/20 p-4">
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p class="text-sm font-semibold">Verify this endpoint</p>
+              <p class="mt-1 text-xs text-muted-foreground">Sends one minimal request using the model and Base URL above.</p>
+            </div>
+            <button
+              type="button"
+              onclick={handleTest}
+              disabled={testing || !canSubmit}
+              class="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50"
+            >
+              {#if testing}<Loader2 class="h-4 w-4 animate-spin" /> Testing…{:else}<Activity class="h-4 w-4" /> Test connection{/if}
+            </button>
+          </div>
+          {#if testResult}
+            <div class="mt-3 flex items-start gap-2 text-sm {testResult.ok ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300'}">
+              {#if testResult.ok}<CheckCircle class="mt-0.5 h-4 w-4 shrink-0" />{:else}<XCircle class="mt-0.5 h-4 w-4 shrink-0" />{/if}
+              <span>{testResult.message}</span>
+            </div>
+          {/if}
+        </section>
+
+        {#if saveError}<p class="text-sm text-red-600 dark:text-red-400">{saveError}</p>{/if}
+      </div>
+
+      <footer class="flex flex-col-reverse gap-2 border-t border-border px-5 py-4 sm:flex-row sm:justify-end">
+        <button type="button" onclick={closeModal} disabled={testing || saving !== null} class="rounded-lg border border-border px-4 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50">Cancel</button>
+        <button type="button" onclick={() => handleSave(false)} disabled={!canSubmit || saving !== null} class="rounded-lg border border-border px-4 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50">{saving === 'only' ? 'Saving…' : 'Save'}</button>
+        <button type="button" onclick={() => handleSave(true)} disabled={!canSubmit || saving !== null} class="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50">{saving === 'activate' ? 'Saving…' : isActive ? 'Save changes' : 'Save & set active'}</button>
+      </footer>
+    </section>
+  </div>
+{/if}

--- a/frontend/src/lib/components/OllamaSettingsModal.svelte
+++ b/frontend/src/lib/components/OllamaSettingsModal.svelte
@@ -2,7 +2,10 @@
   import { invalidateAll } from '$app/navigation';
   import { testConnection, updateSettings } from '$lib/api';
   import ModelSelector from '$lib/components/ModelSelector.svelte';
-  import type { CatalogModelOption } from '$lib/llm-catalog';
+  import {
+    customModelValidationError,
+    type CatalogModelOption,
+  } from '$lib/llm-catalog';
   import {
     DEFAULT_OLLAMA_BASE_URL,
     normalizeOllamaBaseUrl,
@@ -29,6 +32,7 @@
   } = $props();
 
   let model = $state('');
+  let customMode = $state(false);
   let baseUrl = $state(DEFAULT_OLLAMA_BASE_URL);
   let testing = $state(false);
   let saving = $state<'only' | 'activate' | null>(null);
@@ -36,11 +40,19 @@
   let saveError = $state('');
 
   const baseUrlError = $derived(ollamaBaseUrlError(baseUrl));
-  const canSubmit = $derived(Boolean(model && !baseUrlError));
+  const customModelError = $derived(
+    customMode ? customModelValidationError('ollama', model) : null,
+  );
+  const canSubmit = $derived(
+    Boolean(model && !baseUrlError && !customModelError),
+  );
 
   $effect(() => {
     if (!open) return;
     model = initialModel || models[0]?.value || '';
+    customMode = Boolean(
+      initialModel && !models.some((option) => option.value === initialModel),
+    );
     baseUrl = initialBaseUrl || DEFAULT_OLLAMA_BASE_URL;
     testResult = null;
     saveError = '';
@@ -51,6 +63,13 @@
     open = false;
   }
 
+  function toggleCustomMode() {
+    customMode = !customMode;
+    model = customMode ? 'ollama/' : models[0]?.value || '';
+    testResult = null;
+    saveError = '';
+  }
+
   async function handleTest() {
     if (!canSubmit) return;
     testing = true;
@@ -58,7 +77,7 @@
     saveError = '';
     try {
       testResult = await testConnection({
-        model,
+        model: model.trim(),
         api_key: null,
         activate: false,
         base_url: normalizeOllamaBaseUrl(baseUrl),
@@ -76,7 +95,7 @@
     saveError = '';
     try {
       await updateSettings({
-        model,
+        model: model.trim(),
         api_key: null,
         activate,
         base_url: normalizeOllamaBaseUrl(baseUrl),
@@ -134,10 +153,37 @@
 
       <div class="space-y-6 px-5 py-5">
         <section>
-          <label class="text-sm font-semibold" for="ollama-model">Model</label>
-          <p class="mt-1 text-xs text-muted-foreground">The model must already be available on the configured Ollama server.</p>
-          <div class="mt-3" id="ollama-model">
-            <ModelSelector {models} bind:value={model} />
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p class="text-sm font-semibold">Model</p>
+              <p class="mt-1 text-xs text-muted-foreground">The model must already be available on the configured Ollama server.</p>
+            </div>
+            <button
+              type="button"
+              onclick={toggleCustomMode}
+              class="text-xs font-medium text-primary hover:underline"
+            >
+              {customMode ? 'Choose from catalog' : 'Use custom model ID'}
+            </button>
+          </div>
+
+          <div class="mt-3">
+            {#if customMode}
+              <input
+                bind:value={model}
+                placeholder="ollama/model-name"
+                maxlength="200"
+                spellcheck="false"
+                autocomplete="off"
+                aria-label="Custom Ollama model ID"
+                class="w-full rounded-xl border border-border bg-background px-3 py-3 font-mono text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              />
+              {#if customModelError}
+                <p class="mt-2 text-xs text-red-600 dark:text-red-400">{customModelError}</p>
+              {/if}
+            {:else}
+              <ModelSelector {models} bind:value={model} />
+            {/if}
           </div>
         </section>
 

--- a/frontend/src/lib/ollama-base-url.test.ts
+++ b/frontend/src/lib/ollama-base-url.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+
+import * as settingsModal from '$lib/settings-modal';
+
+interface OllamaBaseUrlHelpers {
+  normalizeOllamaBaseUrl?: (value: string) => string;
+  ollamaBaseUrlError?: (value: string) => string | null;
+}
+
+const helpers = settingsModal as typeof settingsModal & OllamaBaseUrlHelpers;
+
+describe('Ollama base URL', () => {
+  test('normalizes surrounding whitespace and trailing slashes', () => {
+    expect(typeof helpers.normalizeOllamaBaseUrl).toBe('function');
+    if (!helpers.normalizeOllamaBaseUrl) return;
+
+    expect(
+      helpers.normalizeOllamaBaseUrl('  https://ollama.example.com///  '),
+    ).toBe('https://ollama.example.com');
+    expect(helpers.normalizeOllamaBaseUrl('http://localhost:11434/')).toBe(
+      'http://localhost:11434',
+    );
+  });
+
+  test('accepts HTTP and HTTPS endpoints', () => {
+    expect(typeof helpers.ollamaBaseUrlError).toBe('function');
+    if (!helpers.ollamaBaseUrlError) return;
+
+    expect(helpers.ollamaBaseUrlError('http://localhost:11434')).toBeNull();
+    expect(helpers.ollamaBaseUrlError('https://ollama.example.com')).toBeNull();
+  });
+
+  test('rejects missing schemes, unsupported schemes, and embedded credentials', () => {
+    expect(typeof helpers.ollamaBaseUrlError).toBe('function');
+    if (!helpers.ollamaBaseUrlError) return;
+
+    expect(helpers.ollamaBaseUrlError('localhost:11434')).not.toBeNull();
+    expect(helpers.ollamaBaseUrlError('ftp://ollama.example.com')).not.toBeNull();
+    expect(
+      helpers.ollamaBaseUrlError(
+        'http://user:password@ollama.example.com:11434',
+      ),
+    ).not.toBeNull();
+  });
+});

--- a/frontend/src/lib/provider-disconnect.test.ts
+++ b/frontend/src/lib/provider-disconnect.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+
+import * as settingsIntegrations from '$lib/settings-integrations';
+import type { IntegrationInfo } from '$lib/types';
+
+const activeProvider: IntegrationInfo = {
+  id: 'groq',
+  label: 'Groq',
+  is_active: true,
+  api_key_configured: true,
+  masked_api_key: 'gsk_••••••••',
+  current_model: 'groq/openai/gpt-oss-20b',
+};
+
+const localProvider: IntegrationInfo = {
+  id: 'ollama',
+  label: 'Ollama',
+  is_active: false,
+  api_key_configured: false,
+  masked_api_key: null,
+  current_model: 'ollama/llama3.2',
+};
+
+describe('provider disconnect availability', () => {
+  test('allows disconnecting active, credential-backed, and local providers', () => {
+    const helper = (
+      settingsIntegrations as typeof settingsIntegrations & {
+        canDisconnectIntegration?: (integration: IntegrationInfo) => boolean;
+      }
+    ).canDisconnectIntegration;
+
+    expect(typeof helper).toBe('function');
+    if (!helper) return;
+
+    expect(helper(activeProvider)).toBe(true);
+    expect(helper({ ...activeProvider, is_active: false })).toBe(true);
+    expect(helper(localProvider)).toBe(true);
+  });
+
+  test('does not offer disconnect for an unconfigured provider', () => {
+    const helper = (
+      settingsIntegrations as typeof settingsIntegrations & {
+        canDisconnectIntegration?: (integration: IntegrationInfo) => boolean;
+      }
+    ).canDisconnectIntegration;
+
+    expect(typeof helper).toBe('function');
+    if (!helper) return;
+
+    expect(
+      helper({
+        id: 'gemini',
+        label: 'Google Gemini',
+        is_active: false,
+        api_key_configured: false,
+        masked_api_key: null,
+        current_model: null,
+      }),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/lib/settings-integrations.ts
+++ b/frontend/src/lib/settings-integrations.ts
@@ -21,6 +21,10 @@ export function isConfiguredIntegration(integration: IntegrationInfo): boolean {
   );
 }
 
+export function canDisconnectIntegration(integration: IntegrationInfo): boolean {
+  return isConfiguredIntegration(integration);
+}
+
 export function groupIntegrations(
   integrations: IntegrationInfo[],
 ): IntegrationGroups {

--- a/frontend/src/lib/settings-modal.ts
+++ b/frontend/src/lib/settings-modal.ts
@@ -1,9 +1,38 @@
+export const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434';
+
 export type SettingsModalMode = 'connect' | 'edit';
 export type ConnectionTestMode = 'draft' | 'stored' | 'disabled';
 export type SettingsSaveResult =
   | { status: 'saved' }
   | { status: 'save_failed'; error: unknown }
   | { status: 'refresh_failed'; error: unknown };
+
+export function normalizeOllamaBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, '');
+}
+
+export function ollamaBaseUrlError(value: string): string | null {
+  const normalized = normalizeOllamaBaseUrl(value);
+  if (!normalized) return 'Enter the Ollama server URL.';
+
+  try {
+    const parsed = new URL(normalized);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return 'Base URL must start with http:// or https://.';
+    }
+    if (!parsed.hostname) return 'Base URL must include a valid host.';
+    if (parsed.username || parsed.password) {
+      return 'Base URL must not contain embedded credentials.';
+    }
+    if (parsed.search || parsed.hash) {
+      return 'Base URL must not include a query string or fragment.';
+    }
+  } catch {
+    return 'Enter a valid URL including http:// or https://.';
+  }
+
+  return null;
+}
 
 export function focusTrapTarget<T>(
   focusable: readonly T[],

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -219,6 +219,7 @@ export interface UpdateSettingsRequest {
   model: string;
   api_key: string | null;
   activate?: boolean;
+  base_url?: string | null;
 }
 
 export interface TestConnectionResponse {
@@ -249,6 +250,7 @@ export interface IntegrationInfo {
   api_key_configured: boolean;
   masked_api_key: string | null;
   current_model: string | null;
+  base_url?: string | null;
 }
 
 export interface IntegrationsResponse {

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { invalidateAll } from '$app/navigation';
   import { activateProvider, disconnectProvider, getIntegrations, getModels } from '$lib/api';
+  import OllamaSettingsModal from '$lib/components/OllamaSettingsModal.svelte';
   import SettingsModal from '$lib/components/SettingsModal.svelte';
   import { testConfiguredIntegration } from '$lib/integration-api';
   import {
@@ -11,18 +12,19 @@
   } from '$lib/integration-testing';
   import {
     credentialActionLabel,
+    type CatalogModelOption,
     type CatalogProviderInfo,
   } from '$lib/llm-catalog';
-  import {
-    credentialStrategyLabel,
-  } from '$lib/provider-credentials';
+  import { credentialStrategyLabel } from '$lib/provider-credentials';
   import type { CredentialIntegrationInfo } from '$lib/provider-credential-types';
   import {
+    canDisconnectIntegration,
     groupIntegrations,
     integrationModelKind,
     settingsOverview,
     type IntegrationModelKind,
   } from '$lib/settings-integrations';
+  import { DEFAULT_OLLAMA_BASE_URL } from '$lib/settings-modal';
   import { toastState } from '$lib/toast.svelte';
   import {
     Activity,
@@ -36,7 +38,6 @@
     Pencil,
     Plus,
     Settings,
-    ShieldCheck,
     Trash2,
     Zap,
   } from '@lucide/svelte';
@@ -45,6 +46,11 @@
   let modalProviderId = $state('');
   let modalModel = $state('');
   let modalApiKeyConfigured = $state(false);
+  let ollamaModalOpen = $state(false);
+  let ollamaModel = $state('');
+  let ollamaBaseUrl = $state(DEFAULT_OLLAMA_BASE_URL);
+  let ollamaIsActive = $state(false);
+  let ollamaModels: CatalogModelOption[] = $state([]);
   let integrations: CredentialIntegrationInfo[] = $state([]);
   let providers: CatalogProviderInfo[] = $state([]);
   let loading = $state(true);
@@ -118,6 +124,16 @@
   }
 
   function openEdit(integration: CredentialIntegrationInfo) {
+    if (integration.id === 'ollama') {
+      const provider = providerFor('ollama');
+      ollamaModel = integration.current_model ?? provider?.models[0]?.value ?? '';
+      ollamaBaseUrl = integration.base_url ?? DEFAULT_OLLAMA_BASE_URL;
+      ollamaIsActive = integration.is_active;
+      ollamaModels = provider?.models ?? [];
+      ollamaModalOpen = true;
+      return;
+    }
+
     modalProviderId = integration.id;
     modalModel = integration.current_model ?? '';
     modalApiKeyConfigured = integration.api_key_configured;
@@ -149,7 +165,7 @@
       testStates = nextStates;
       testSummary = null;
       await invalidateAll();
-      toastState.success('Provider disconnected and credentials removed.');
+      toastState.success('Provider disconnected and saved settings removed.');
     } catch {
       toastState.error('Failed to disconnect provider.');
     } finally {
@@ -309,12 +325,15 @@
                       {#if !provider?.local}<span class="rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase text-muted-foreground">{credentialStrategyLabel(integration.credential_strategy)}</span>{/if}
                     </div>
                     <code class="mt-1 block break-all text-sm font-medium text-foreground">{integration.current_model ?? 'No model selected'}</code>
+                    {#if integration.id === 'ollama' && integration.base_url}
+                      <code class="mt-1 block break-all text-xs text-muted-foreground">{integration.base_url}</code>
+                    {/if}
                     {#if modelKind === 'unavailable'}
                       <p class="mt-1 flex items-start gap-1.5 text-xs text-yellow-700 dark:text-yellow-300"><CircleAlert class="mt-0.5 h-3.5 w-3.5 shrink-0" /><span>Model is no longer in the catalog — edit this provider to replace it.</span></p>
                     {/if}
                     <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
                       <span class="inline-flex min-w-0 items-center gap-1.5">
-                        {#if provider?.local}<CircleCheck class="h-3.5 w-3.5 shrink-0 text-blue-500" />Local · ready on this device{:else}<KeyRound class="h-3.5 w-3.5 shrink-0 text-green-500" />{integration.credential_count} credential{integration.credential_count === 1 ? '' : 's'} · Active key: {integration.active_credential_label ?? 'None'}{/if}
+                        {#if provider?.local}<CircleCheck class="h-3.5 w-3.5 shrink-0 text-blue-500" />Local or self-hosted endpoint{:else}<KeyRound class="h-3.5 w-3.5 shrink-0 text-green-500" />{integration.credential_count} credential{integration.credential_count === 1 ? '' : 's'} · Active key: {integration.active_credential_label ?? 'None'}{/if}
                       </span>
                       {#if testState}
                         <span class="inline-flex items-center gap-1.5 {testState.status === 'success' ? 'text-green-700 dark:text-green-300' : testState.status === 'failure' ? 'text-red-700 dark:text-red-300' : 'text-muted-foreground'}">
@@ -341,19 +360,27 @@
                     {#if testState?.status === 'testing'}<Loader2 class="h-3.5 w-3.5 animate-spin" />Testing…{:else}<Activity class="h-3.5 w-3.5" />Test{/if}
                   </button>
                   <button data-provider-settings-trigger={integration.id} onclick={() => openEdit(integration)} class="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-border px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground sm:flex-none"><Pencil class="h-3.5 w-3.5" />Edit</button>
-                  {#if integration.api_key_configured && !integration.is_active && integration.id !== 'ollama'}
+                  {#if canDisconnectIntegration(integration)}
                     <details class="relative shrink-0">
                       <summary class="flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded-lg border border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground [&::-webkit-details-marker]:hidden" aria-label={`More actions for ${integration.label}`}><MoreHorizontal class="h-4 w-4" /></summary>
-                      <div class="absolute right-0 z-20 mt-2 w-64 rounded-lg border border-border bg-popover p-3 text-popover-foreground shadow-lg">
+                      <div class="absolute right-0 z-20 mt-2 w-72 rounded-lg border border-border bg-popover p-3 text-popover-foreground shadow-lg">
                         {#if confirmingDisconnect === integration.id}
                           <p class="text-sm font-medium">Disconnect {integration.label}?</p>
-                          <p class="mt-1 text-xs text-muted-foreground">All {integration.credential_count} saved credentials for this provider will be permanently removed.</p>
+                          <p class="mt-1 text-xs text-muted-foreground">
+                            {#if integration.is_active}
+                              Its credentials and saved settings will be removed. AI features will remain inactive until another provider is set as active.
+                            {:else if integration.credential_count > 0}
+                              All {integration.credential_count} saved credential{integration.credential_count === 1 ? '' : 's'}, the selected model, and provider settings will be permanently removed.
+                            {:else}
+                              The selected model and provider settings will be permanently removed.
+                            {/if}
+                          </p>
                           <div class="mt-3 flex gap-2">
                             <button onclick={() => handleDisconnect(integration.id)} disabled={disconnecting === integration.id} class="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md bg-destructive px-2.5 py-1.5 text-xs font-semibold text-destructive-foreground disabled:opacity-50">{#if disconnecting === integration.id}<Loader2 class="h-3 w-3 animate-spin" />{:else}<Trash2 class="h-3 w-3" />{/if}Disconnect</button>
                             <button onclick={() => (confirmingDisconnect = '')} class="rounded-md border border-border px-2.5 py-1.5 text-xs hover:bg-accent">Cancel</button>
                           </div>
                         {:else}
-                          <button onclick={() => (confirmingDisconnect = integration.id)} class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-destructive hover:bg-destructive/10"><Trash2 class="h-4 w-4" />Disconnect and remove all keys</button>
+                          <button onclick={() => (confirmingDisconnect = integration.id)} class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-destructive hover:bg-destructive/10"><Trash2 class="h-4 w-4" />Disconnect provider</button>
                         {/if}
                       </div>
                     </details>
@@ -383,9 +410,9 @@
             <article class="flex flex-col rounded-xl border border-border bg-card p-4 transition-colors hover:border-primary/30 hover:bg-accent/20">
               <div class="flex items-start gap-3">
                 <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-[11px] font-bold" style="background:{color}18; color:{color}" aria-hidden="true">{mark}</div>
-                <div class="min-w-0 flex-1"><h3 class="font-medium">{integration.label}</h3><p class="mt-0.5 text-xs text-muted-foreground">{#if provider?.local}Local · no API key{:else if provider?.auth_type === 'token'}Access token required{:else}API key required{/if}</p></div>
+                <div class="min-w-0 flex-1"><h3 class="font-medium">{integration.label}</h3><p class="mt-0.5 text-xs text-muted-foreground">{#if provider?.local}Local or self-hosted · no API key{:else if provider?.auth_type === 'token'}Access token required{:else}API key required{/if}</p></div>
               </div>
-              <p class="mt-4 flex-1 text-sm text-muted-foreground">{#if provider?.local}Run supported models locally without sending a credential to ApplyKit.{:else}Add one or more credentials and select the model ApplyKit should use.{/if}</p>
+              <p class="mt-4 flex-1 text-sm text-muted-foreground">{#if provider?.local}Connect to a local or remote Ollama server and select one of its supported models.{:else}Add one or more credentials and select the model ApplyKit should use.{/if}</p>
               <div class="mt-4 flex items-center justify-between gap-3">
                 {#if provider?.credential_url}<a href={provider.credential_url} target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">{credentialActionLabel(provider.auth_type)}<ExternalLink class="h-3 w-3" /></a>{:else}<span class="text-xs text-muted-foreground">Ready to configure</span>{/if}
                 <button data-provider-settings-trigger={integration.id} onclick={() => openEdit(integration)} class="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"><Plus class="h-3.5 w-3.5" />Connect</button>
@@ -403,5 +430,14 @@
   initialProviderId={modalProviderId}
   initialModel={modalModel}
   initialApiKeyConfigured={modalApiKeyConfigured}
+  onsaved={handleProviderSaved}
+/>
+
+<OllamaSettingsModal
+  bind:open={ollamaModalOpen}
+  initialModel={ollamaModel}
+  initialBaseUrl={ollamaBaseUrl}
+  isActive={ollamaIsActive}
+  models={ollamaModels}
   onsaved={handleProviderSaved}
 />


### PR DESCRIPTION
## Summary

Fixes provider disconnect behavior and adds a configurable Base URL for Ollama.

## Provider disconnect

- Exposes the disconnect action for every configured provider, including the active provider and Ollama.
- Warns that disconnecting the active provider leaves AI features inactive until another provider is selected.
- Removes all provider credentials, the selected model, provider-specific settings, and the active model when applicable.
- Returns the disconnected provider to the Available providers section immediately.

## Ollama Base URL

- Adds an Ollama-specific settings modal with model and Base URL controls.
- Defaults to `http://localhost:11434`.
- Supports local, LAN, domain, reverse-proxy, and self-hosted HTTP/HTTPS endpoints.
- Normalizes trailing slashes and rejects unsupported schemes, invalid hosts, embedded credentials, query strings, and fragments.
- Preserves custom Ollama model IDs.
- Uses the saved endpoint for connection testing, synchronous generation, and streaming generation.
- Does not append `/v1` and does not require an API key.

## Verification

- Backend lint
- Backend tests on Python 3.12 and 3.13
- Backend container build
- Frontend unit tests
- Svelte/TypeScript check
- Frontend production build
- Frontend container smoke test

No onboarding work, OpenAI-compatible provider, tag, or release is included.