### PR TITLE
security: harden provider credential storage

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - 'backend/**'
+      - 'docker-compose.yml'
       - '.github/workflows/ci-backend.yml'
   pull_request:
     paths:
       - 'backend/**'
+      - 'docker-compose.yml'
       - '.github/workflows/ci-backend.yml'
 
 jobs:
@@ -50,3 +52,62 @@ jobs:
 
       - name: Build backend container
         run: docker build --tag applykit-backend:ci ./backend
+
+      - name: Create split storage volumes
+        run: |
+          docker volume create applykit-ci-data
+          docker volume create applykit-ci-secrets
+
+      - name: Seed legacy credential key
+        run: |
+          docker run --rm \
+            --entrypoint /bin/sh \
+            --volume applykit-ci-data:/data \
+            applykit-backend:ci \
+            -c "uv run python -c \"from cryptography.fernet import Fernet; open('/data/credential.key','wb').write(Fernet.generate_key()+b'\\n')\""
+
+      - name: Start backend container with split storage
+        run: |
+          docker run --detach \
+            --name applykit-backend-ci \
+            --publish 127.0.0.1:8000:8000 \
+            --volume applykit-ci-data:/data \
+            --volume applykit-ci-secrets:/run/applykit-secrets \
+            --env DEPLOYMENT_MODE=local \
+            --env DATABASE_URL=sqlite:////data/applykit.db \
+            --env CREDENTIAL_KEY_FILE=/run/applykit-secrets/credential.key \
+            --env CREDENTIAL_LEGACY_KEY_FILE=/data/credential.key \
+            --env 'CORS_ORIGINS=["http://localhost:3000"]' \
+            applykit-backend:ci
+
+      - name: Wait for backend
+        run: |
+          for attempt in {1..30}; do
+            if ! docker ps --filter name=applykit-backend-ci --filter status=running --quiet | grep --quiet .; then
+              docker logs applykit-backend-ci
+              exit 1
+            fi
+
+            if curl --fail --silent --show-error http://localhost:8000/health > /dev/null; then
+              exit 0
+            fi
+
+            sleep 1
+          done
+
+          docker logs applykit-backend-ci
+          exit 1
+
+      - name: Verify key moved outside data volume
+        run: |
+          docker exec applykit-backend-ci test -f /run/applykit-secrets/credential.key
+          if docker exec applykit-backend-ci test -e /data/credential.key; then
+            echo "Legacy key still exists in data volume"
+            exit 1
+          fi
+
+      - name: Stop backend container
+        if: always()
+        run: |
+          docker rm --force applykit-backend-ci || true
+          docker volume rm applykit-ci-data applykit-ci-secrets || true

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ApplyKit stores profiles, generated documents, application history, and provider credentials on infrastructure you control. No subscription is required.
 
-> ApplyKit defaults to local mode without login. Keep that mode on localhost. Remote deployments should enable protected mode and use HTTPS, or be placed behind an authentication proxy.
+> ApplyKit defaults to `DEPLOYMENT_MODE=local`, binds the manual backend to loopback, and rejects non-loopback browser origins. Remote deployments fail startup unless the required authentication, HTTPS, cookie, CORS, and credential-key protections are configured.
 
 ## Highlights
 
@@ -36,7 +36,12 @@ cd applykit
 docker compose up --build
 ```
 
-Open `http://localhost:3000`. The backend is available at `http://localhost:8000`, and persistent data is stored in the Docker volume `applykit_applykit-data`.
+Open `http://localhost:3000`. The backend is available at `http://localhost:8000`.
+
+Docker uses two persistent volumes:
+
+- `applykit_applykit-data` for SQLite and application data;
+- `applykit_applykit-secrets` for the local credential encryption key.
 
 ### Manual development setup
 
@@ -57,18 +62,37 @@ make backend     # http://localhost:8000
 make frontend    # http://localhost:5173
 ```
 
-## Optional Protected Mode
+The manual backend binds to `127.0.0.1` in local mode.
 
-ApplyKit supports two startup modes:
+## Deployment Modes
+
+ApplyKit has an explicit deployment boundary:
 
 ```env
-AUTH_MODE=disabled  # default; localhost only
+DEPLOYMENT_MODE=local   # default; loopback-only browser origins
+DEPLOYMENT_MODE=remote  # protected HTTPS deployment
+```
+
+Local mode allows:
+
+```env
+AUTH_MODE=disabled
+COOKIE_SECURE=false
+CORS_ORIGINS=["http://localhost:5173"]
+```
+
+Local mode rejects LAN addresses, public domains, wildcard origins, credential-bearing URLs, and origins containing paths, queries, or fragments. Switch deliberately to remote mode before exposing ApplyKit beyond loopback.
+
+### Optional protected mode
+
+```env
+AUTH_MODE=disabled  # local mode only
 AUTH_MODE=password  # single-owner protected mode
 ```
 
 Protected mode secures the whole installation and every career profile with one owner password. It does not create separate accounts for individual profiles.
 
-When password mode is enabled, the browser redirects an unclaimed installation to `/setup` and an existing protected installation to `/login`. The normal local flow remains unchanged when authentication is disabled.
+When password mode is enabled, the browser redirects an unclaimed installation to `/setup` and an existing protected installation to `/login`.
 
 ### First owner setup
 
@@ -111,27 +135,36 @@ Password changes and signing out other devices are available under **Settings �
 
 ### Remote HTTPS deployment
 
-For localhost over HTTP:
+Remote mode is fail-closed. The backend will not start unless all required protections are present:
 
 ```env
-COOKIE_SECURE=false
-```
-
-For remote protected mode, serve the frontend and API from the same hostname. A reverse proxy can expose the frontend at `/` and forward `/api` to the backend. This is required so the browser can read the CSRF cookie and send it with mutation requests.
-
-```env
+DEPLOYMENT_MODE=remote
 AUTH_MODE=password
 COOKIE_SECURE=true
+DEBUG=false
 CORS_ORIGINS=["https://applykit.example.com"]
+CREDENTIAL_ENCRYPTION_KEY_FILE=/run/secrets/applykit_credential_key
 ```
 
-Build the frontend with the same-origin API path:
+You may provide `CREDENTIAL_ENCRYPTION_KEY` directly instead of a mounted key file, but configure exactly one source. Prefer a platform-managed secret file where available.
+
+Serve the frontend and API from the same hostname. A reverse proxy can expose the frontend at `/` and forward `/api` to the backend. Build the frontend with the browser-reachable same-origin API path:
 
 ```bash
 VITE_API_BASE_URL=https://applykit.example.com/api docker compose up --build
 ```
 
-Do not place the browser UI at `app.example.com` while using a host-only API cookie from `api.example.com`. Do not expose protected mode through public plain HTTP. ApplyKit logs a warning when password mode starts with `COOKIE_SECURE=false`.
+Remote startup is rejected when:
+
+- authentication is disabled;
+- secure cookies are disabled;
+- debug mode is enabled;
+- a CORS origin uses HTTP or a wildcard;
+- an origin contains credentials, paths, queries, or fragments;
+- no external credential encryption key is configured;
+- two encryption-key sources are configured at the same time.
+
+Do not place the browser UI at `app.example.com` while using a host-only API cookie from `api.example.com`. Do not expose ApplyKit through public plain HTTP.
 
 ### Forgotten password
 
@@ -154,11 +187,11 @@ The reset command asks for the new password twice, clears login lockout, and sig
 DEBUG=false
 → /docs, /redoc, and /openapi.json are disabled
 
-DEBUG=true + AUTH_MODE=disabled
-→ API documentation is public
+DEBUG=true + DEPLOYMENT_MODE=local + AUTH_MODE=disabled
+→ API documentation is public on loopback
 
-DEBUG=true + AUTH_MODE=password
-→ API documentation requires a valid session
+DEPLOYMENT_MODE=remote
+→ DEBUG=true is rejected at startup
 ```
 
 ## AI Providers and Credentials
@@ -175,41 +208,92 @@ Manual routing is the default. Automatic modes require at least two enabled cred
 
 Ollama does not require an API key. Some non-AI features remain usable without configuring a provider.
 
-## Credential Security and Backups
+### Provider-key precautions
 
-Provider secrets are encrypted before being stored. The API and frontend receive masked values only.
+Use a dedicated API key for ApplyKit rather than reusing an administrator key. Where the provider supports them, apply:
 
-Local installations create:
+- the minimum required permissions;
+- spending and rate limits;
+- separate keys for personal and work environments;
+- periodic rotation;
+- immediate revocation after suspected exposure.
+
+## Credential Security
+
+Provider secrets are encrypted with Fernet before database persistence. The database stores encrypted ciphertext, a masked display value, a keyed duplicate-detection fingerprint, and operational metadata. API responses and the frontend receive masked values only.
+
+Credential input remains in component-local browser state and is not written to `localStorage` or `sessionStorage`. Provider failures return fixed public messages, and credential-bearing exception text is excluded from application logs and usage records.
+
+Local installations create a persistent fallback key at:
 
 ```text
 backend/.applykit/credential.key
 ```
 
-Back up this file together with `backend/applykit.db`. Encrypted credentials cannot be recovered without the same key.
+Docker stores the active key separately at:
 
-Docker stores both the SQLite database and encryption key in `/data`. Back up the complete volume:
+```text
+/run/applykit-secrets/credential.key
+```
+
+During an upgrade, ApplyKit can migrate the old Docker key from `/data/credential.key`. It copies the key atomically, verifies every encrypted credential, and removes the old key only after successful validation. If validation fails, startup stops and the old key is preserved.
+
+ApplyKit will not create a replacement key when encrypted credentials already exist. A missing, wrong, or corrupted key causes startup to fail rather than silently making stored credentials unreadable.
+
+Generate a Fernet key with:
+
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+Never commit an encryption key, bake it into a container image, or print it in CI logs.
+
+## Backup and Restore
+
+Treat the database and encryption key as separate sensitive assets. Both are needed to restore encrypted provider credentials, but they should not be kept in the same unrestricted backup location.
+
+Back up Docker application data:
+
+```bash
+mkdir -p backups/data backups/secrets
+
+docker run --rm \
+  -v applykit_applykit-data:/source:ro \
+  -v "$(pwd)/backups/data":/backup \
+  alpine tar czf /backup/applykit-data.tar.gz -C /source .
+```
+
+Back up the local Docker encryption key separately:
 
 ```bash
 docker run --rm \
-  -v applykit_applykit-data:/data \
-  -v "$(pwd)":/backup \
-  alpine tar czf /backup/applykit-backup.tar.gz /data
+  -v applykit_applykit-secrets:/source:ro \
+  -v "$(pwd)/backups/secrets":/backup \
+  alpine tar czf /backup/applykit-secrets.tar.gz -C /source .
 ```
 
-For managed deployments, set a persistent Fernet key:
+Store and access-control these archives separately. A database backup alone cannot decrypt provider credentials. A key alone does not contain the credentials. Anyone who obtains both may be able to decrypt them.
 
-```env
-CREDENTIAL_ENCRYPTION_KEY=<persistent-fernet-key>
-MAX_PROVIDER_CREDENTIALS=20
-```
+Losing the encryption key makes existing encrypted credentials unrecoverable. Revoke and replace the affected keys at each provider.
 
-Never rotate or delete the encryption key without first migrating stored credentials.
+Do not change or delete the encryption key without a supported credential-rotation procedure. ApplyKit does not yet provide encryption-key rotation or a rotation UI.
+
+## Security Boundaries
+
+Credential encryption materially reduces exposure from a database-only leak, but it cannot protect against every threat. ApplyKit does not claim protection from:
+
+- an administrator or attacker with access to both the database and encryption key;
+- malware or a malicious browser extension observing a key while it is entered;
+- memory inspection by a privileged attacker during a provider request;
+- a compromised AI provider account;
+- secrets already copied into historical backups or external logs before an upgrade.
 
 ## Configuration
 
-Common backend variables in `backend/.env`:
+Common local backend variables in `backend/.env`:
 
 ```env
+DEPLOYMENT_MODE=local
 DATABASE_URL=sqlite:///./applykit.db
 AUTH_MODE=disabled
 COOKIE_SECURE=false
@@ -219,7 +303,19 @@ CREDENTIAL_KEY_FILE=.applykit/credential.key
 MAX_PROVIDER_CREDENTIALS=20
 ```
 
-For a remote frontend build, use the browser-reachable same-host API URL described under protected mode.
+Managed remote deployments must configure either:
+
+```env
+CREDENTIAL_ENCRYPTION_KEY=<persistent-fernet-key>
+```
+
+or:
+
+```env
+CREDENTIAL_ENCRYPTION_KEY_FILE=/run/secrets/applykit_credential_key
+```
+
+For a remote frontend build, use the browser-reachable same-host API URL described under remote HTTPS deployment.
 
 ## Stack
 
@@ -227,6 +323,7 @@ For a remote frontend build, use the browser-reachable same-host API URL describ
 - **Backend:** FastAPI, Python 3.12, SQLAlchemy, Alembic
 - **Database:** SQLite by default
 - **Authentication:** optional Argon2id owner password and opaque database sessions
+- **Credential encryption:** Fernet authenticated encryption
 - **AI:** LiteLLM
 - **PDF:** WeasyPrint
 - **Scraping:** direct ATS APIs, Jina Reader, and Crawl4AI fallback

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,8 @@
+# Deployment boundary
+# local: loopback-only, no login required by default
+# remote: fail-closed HTTPS deployment with password protection
+DEPLOYMENT_MODE=local
+
 # Database path (SQLite default)
 DATABASE_URL=sqlite:///./applykit.db
 
@@ -9,10 +14,16 @@ AUTH_MODE=disabled
 COOKIE_SECURE=false
 
 # Provider credential vault
-# Managed deployments should set a persistent Fernet key. Generate one with:
+# Remote/managed deployments must supply exactly one external Fernet key source.
+# Generate a key with:
 # python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 # CREDENTIAL_ENCRYPTION_KEY=
+# CREDENTIAL_ENCRYPTION_KEY_FILE=/run/secrets/applykit_credential_key
+
+# Writable local fallback key. Local mode only.
 CREDENTIAL_KEY_FILE=.applykit/credential.key
+# Optional legacy key path used only during an upgrade migration.
+# CREDENTIAL_LEGACY_KEY_FILE=
 MAX_PROVIDER_CREDENTIALS=20
 
 # App and browser access

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,8 +26,9 @@ RUN uv sync --frozen --no-dev
 # Copy application code
 COPY . .
 
-# Directory for persistent SQLite database (mount a volume here)
-RUN mkdir -p /data
+# Persistent application data and the local credential key use separate mounts.
+RUN mkdir -p /data /run/applykit-secrets \
+    && chmod 700 /run/applykit-secrets
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/backend/app/auth/startup.py
+++ b/backend/app/auth/startup.py
@@ -20,10 +20,14 @@ logger = logging.getLogger(__name__)
 def initialize_auth(settings: Settings) -> None:
     """Record auth mode and issue a one-time setup token when required."""
     logger.info("ApplyKit authentication mode: %s", settings.auth_mode)
-    if settings.auth_mode == "password" and not settings.cookie_secure:
+    if (
+        settings.deployment_mode == "local"
+        and settings.auth_mode == "password"
+        and not settings.cookie_secure
+    ):
         logger.warning(
-            "Protected mode is using COOKIE_SECURE=false. "
-            "Use HTTPS and COOKIE_SECURE=true for remote deployments."
+            "Local protected mode is using COOKIE_SECURE=false. "
+            "This is acceptable only on loopback HTTP."
         )
 
     with SessionLocal() as db:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,14 +15,21 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
+    # Deployment boundary
+    # local: loopback-only access, no login required by default
+    # remote: fail-closed protected mode for HTTPS deployments
+    deployment_mode: Literal["local", "remote"] = "local"
+
     # Database
     database_url: str = "sqlite:///./applykit.db"
 
     # Credential vault
-    # Supply a Fernet key through CREDENTIAL_ENCRYPTION_KEY in managed
-    # deployments. Local installs automatically create the fallback key file.
+    # Managed deployments may provide a Fernet key directly or through an
+    # externally mounted file. Local installs use the writable fallback path.
     credential_encryption_key: str | None = None
+    credential_encryption_key_file: str | None = None
     credential_key_file: str = ".applykit/credential.key"
+    credential_legacy_key_file: str | None = None
     max_provider_credentials: int = 20
 
     # Community authentication

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -3,6 +3,7 @@
 from functools import lru_cache
 from typing import Literal
 
+from pydantic import SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -26,7 +27,7 @@ class Settings(BaseSettings):
     # Credential vault
     # Managed deployments may provide a Fernet key directly or through an
     # externally mounted file. Local installs use the writable fallback path.
-    credential_encryption_key: str | None = None
+    credential_encryption_key: SecretStr | None = None
     credential_encryption_key_file: str | None = None
     credential_key_file: str = ".applykit/credential.key"
     credential_legacy_key_file: str | None = None

--- a/backend/app/credential_schemas.py
+++ b/backend/app/credential_schemas.py
@@ -1,16 +1,38 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr, field_validator
 
 CredentialStrategyName = Literal["manual", "failover", "round_robin"]
 
 
+class CredentialSecret(SecretStr):
+    """Secret string compatible with existing narrow `.strip()` boundaries."""
+
+    def strip(self) -> str:
+        return self.get_secret_value().strip()
+
+
+def _validate_secret_length(
+    value: CredentialSecret | None,
+) -> CredentialSecret | None:
+    if value is None:
+        return None
+    length = len(value.get_secret_value())
+    if length < 1:
+        raise ValueError("Credential secret is required.")
+    if length > 4096:
+        raise ValueError("Credential secret must be 4096 characters or fewer.")
+    return value
+
+
 class ProviderSettingsRequest(BaseModel):
     model: str
-    api_key: str | None = None
+    api_key: CredentialSecret | None = None
     activate: bool = True
     base_url: str | None = None
+
+    _validate_api_key = field_validator("api_key")(_validate_secret_length)
 
 
 class CredentialIntegrationInfo(BaseModel):
@@ -57,13 +79,17 @@ class ProviderCredentialsResponse(BaseModel):
 
 class CreateProviderCredentialRequest(BaseModel):
     label: str = Field(min_length=1, max_length=80)
-    secret: str = Field(min_length=1, max_length=4096)
+    secret: CredentialSecret
     activate: bool = False
+
+    _validate_secret = field_validator("secret")(_validate_secret_length)
 
 
 class UpdateProviderCredentialRequest(BaseModel):
     label: str | None = Field(default=None, min_length=1, max_length=80)
-    secret: str | None = Field(default=None, min_length=1, max_length=4096)
+    secret: CredentialSecret | None = None
+
+    _validate_secret = field_validator("secret")(_validate_secret_length)
 
 
 class CredentialPolicyResponse(BaseModel):

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,15 +1,28 @@
 from collections.abc import Generator
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.config import get_settings
 
 _settings = get_settings()
 
+
+def configure_sqlite_security(dbapi_connection, _connection_record) -> None:
+    """Enable SQLite deletion hardening for every application connection."""
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute("PRAGMA secure_delete=ON")
+    finally:
+        cursor.close()
+
+
 engine = create_engine(
     _settings.database_url, connect_args={"check_same_thread": False}
 )
+if _settings.database_url.startswith("sqlite"):
+    event.listen(engine, "connect", configure_sqlite_security)
+
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 

--- a/backend/app/exceptions/handlers.py
+++ b/backend/app/exceptions/handlers.py
@@ -90,7 +90,7 @@ async def generic_exception_handler(
     method = getattr(request, "method", "UNKNOWN")
     path = getattr(getattr(request, "url", None), "path", "unknown")
     logger.error(
-        "Unhandled exception method=%s path=%s error_type=%s locations=%s",
+        "Unhandled exception for %s %s error_type=%s locations=%s",
         method,
         path,
         safe_exception_type(exc),

--- a/backend/app/exceptions/handlers.py
+++ b/backend/app/exceptions/handlers.py
@@ -10,6 +10,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from app.exceptions.base import AppError, ErrorBody, ErrorCode, ErrorEnvelope
 from app.exceptions.infrastructure import InternalApplicationError
 from app.exceptions.request import ValidationAppError
+from app.security.secrets import safe_exception_type, safe_traceback_locations
 
 logger = logging.getLogger(__name__)
 
@@ -89,10 +90,11 @@ async def generic_exception_handler(
     method = getattr(request, "method", "UNKNOWN")
     path = getattr(getattr(request, "url", None), "path", "unknown")
     logger.error(
-        "Unhandled exception for %s %s",
+        "Unhandled exception method=%s path=%s error_type=%s locations=%s",
         method,
         path,
-        exc_info=(type(exc), exc, exc.__traceback__),
+        safe_exception_type(exc),
+        safe_traceback_locations(exc),
     )
     return _response_for(InternalApplicationError())
 

--- a/backend/app/exceptions/stream.py
+++ b/backend/app/exceptions/stream.py
@@ -4,6 +4,7 @@ from fastapi.sse import ServerSentEvent
 
 from app.exceptions.base import AppError
 from app.exceptions.infrastructure import InternalApplicationError, RateLimitError
+from app.security.secrets import safe_exception_type, safe_traceback_locations
 
 logger = logging.getLogger(__name__)
 
@@ -18,8 +19,9 @@ def stream_error_event(exc: Exception) -> ServerSentEvent:
         event = "error"
     else:
         logger.error(
-            "Unhandled streaming exception",
-            exc_info=(type(exc), exc, exc.__traceback__),
+            "Unhandled streaming exception error_type=%s locations=%s",
+            safe_exception_type(exc),
+            safe_traceback_locations(exc),
         )
         public_error = InternalApplicationError()
         event = "error"

--- a/backend/app/security/__init__.py
+++ b/backend/app/security/__init__.py
@@ -1,0 +1,1 @@
+"""Security policy and secret-handling helpers."""

--- a/backend/app/security/deployment.py
+++ b/backend/app/security/deployment.py
@@ -6,6 +6,7 @@ from ipaddress import ip_address
 from urllib.parse import urlsplit
 
 from app.config import Settings
+from app.security.secrets import reveal_secret
 
 
 class DeploymentSecurityError(RuntimeError):
@@ -49,7 +50,7 @@ def validate_deployment_security(settings: Settings) -> None:
     """Reject unsafe local or remote deployment combinations."""
     violations: list[str] = []
 
-    has_direct_key = bool(settings.credential_encryption_key)
+    has_direct_key = bool(reveal_secret(settings.credential_encryption_key).strip())
     has_external_key_file = bool(settings.credential_encryption_key_file)
     if has_direct_key and has_external_key_file:
         violations.append(

--- a/backend/app/security/deployment.py
+++ b/backend/app/security/deployment.py
@@ -1,0 +1,100 @@
+"""Fail-closed deployment security validation."""
+
+from __future__ import annotations
+
+from ipaddress import ip_address
+from urllib.parse import urlsplit
+
+from app.config import Settings
+
+
+class DeploymentSecurityError(RuntimeError):
+    """Raised when deployment settings would expose ApplyKit unsafely."""
+
+
+def _is_exact_origin(origin: str, *, require_https: bool) -> bool:
+    if not origin or origin == "*":
+        return False
+
+    parsed = urlsplit(origin)
+    allowed_schemes = {"https"} if require_https else {"http", "https"}
+    if parsed.scheme not in allowed_schemes:
+        return False
+    if not parsed.hostname:
+        return False
+    if parsed.username is not None or parsed.password is not None:
+        return False
+    if parsed.path not in {"", "/"}:
+        return False
+    if parsed.query or parsed.fragment:
+        return False
+    return True
+
+
+def is_loopback_origin(origin: str) -> bool:
+    """Return whether *origin* is an exact HTTP(S) loopback origin."""
+    if not _is_exact_origin(origin, require_https=False):
+        return False
+
+    hostname = urlsplit(origin).hostname
+    if hostname == "localhost":
+        return True
+    try:
+        return ip_address(hostname or "").is_loopback
+    except ValueError:
+        return False
+
+
+def validate_deployment_security(settings: Settings) -> None:
+    """Reject unsafe local or remote deployment combinations."""
+    violations: list[str] = []
+
+    has_direct_key = bool(settings.credential_encryption_key)
+    has_external_key_file = bool(settings.credential_encryption_key_file)
+    if has_direct_key and has_external_key_file:
+        violations.append(
+            "Configure only one of CREDENTIAL_ENCRYPTION_KEY or "
+            "CREDENTIAL_ENCRYPTION_KEY_FILE."
+        )
+
+    if settings.deployment_mode == "local":
+        for origin in settings.cors_origins:
+            if not is_loopback_origin(origin):
+                violations.append(
+                    f'Local mode CORS origin "{origin}" is not loopback; '
+                    "use DEPLOYMENT_MODE=remote for network access."
+                )
+    else:
+        if settings.auth_mode != "password":
+            violations.append('AUTH_MODE must be "password".')
+        if not settings.cookie_secure:
+            violations.append("COOKIE_SECURE must be true.")
+        if settings.debug:
+            violations.append("DEBUG must be false.")
+        if "*" in settings.cors_origins:
+            violations.append("Remote mode must not use wildcard CORS.")
+
+        for origin in settings.cors_origins:
+            if origin == "*":
+                continue
+            if not _is_exact_origin(origin, require_https=True):
+                violations.append(
+                    f'Remote CORS origin "{origin}" must use HTTPS and be an '
+                    "exact origin without credentials, paths, queries, or fragments."
+                )
+
+        if not (has_direct_key or has_external_key_file):
+            violations.append(
+                "Remote mode requires an external credential encryption key."
+            )
+
+    if violations:
+        details = "\n".join(f"- {violation}" for violation in violations)
+        raise DeploymentSecurityError(
+            f"Unsafe {settings.deployment_mode} deployment configuration:\n{details}"
+        )
+
+
+def manual_bind_host(settings: Settings) -> str:
+    """Return the safe host used by the manual development runner."""
+    return "127.0.0.1" if settings.deployment_mode == "local" else "0.0.0.0"

--- a/backend/app/security/deployment.py
+++ b/backend/app/security/deployment.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from ipaddress import ip_address
+from pathlib import Path
 from urllib.parse import urlsplit
+
+from sqlalchemy.engine import make_url
 
 from app.config import Settings
 from app.security.secrets import reveal_secret
@@ -44,6 +47,18 @@ def is_loopback_origin(origin: str) -> bool:
         return ip_address(hostname or "").is_loopback
     except ValueError:
         return False
+
+
+def _sqlite_database_parent(database_url: str) -> Path | None:
+    try:
+        url = make_url(database_url)
+    except Exception:
+        return None
+    if not url.drivername.startswith("sqlite"):
+        return None
+    if not url.database or url.database == ":memory:":
+        return None
+    return Path(url.database).expanduser().resolve().parent
 
 
 def validate_deployment_security(settings: Settings) -> None:
@@ -88,6 +103,20 @@ def validate_deployment_security(settings: Settings) -> None:
             violations.append(
                 "Remote mode requires an external credential encryption key."
             )
+
+        if settings.credential_encryption_key_file:
+            database_parent = _sqlite_database_parent(settings.database_url)
+            key_parent = (
+                Path(settings.credential_encryption_key_file)
+                .expanduser()
+                .resolve()
+                .parent
+            )
+            if database_parent is not None and database_parent == key_parent:
+                violations.append(
+                    "Remote SQLite deployments must keep the credential key file "
+                    "in a separate storage location from the database."
+                )
 
     if violations:
         details = "\n".join(f"- {violation}" for violation in violations)

--- a/backend/app/security/secrets.py
+++ b/backend/app/security/secrets.py
@@ -1,0 +1,31 @@
+"""Helpers for handling secrets and reporting failures without secret text."""
+
+from __future__ import annotations
+
+from traceback import extract_tb
+
+from pydantic import SecretStr
+
+
+def reveal_secret(value: SecretStr | str | None) -> str:
+    """Return a secret only at the narrow boundary that requires plaintext."""
+    if value is None:
+        return ""
+    if isinstance(value, SecretStr):
+        return value.get_secret_value()
+    return value
+
+
+def safe_exception_type(exc: BaseException) -> str:
+    """Return only the exception class name, never its message or arguments."""
+    return type(exc).__name__
+
+
+def safe_traceback_locations(
+    exc: BaseException,
+    *,
+    limit: int = 8,
+) -> tuple[str, ...]:
+    """Return traceback source locations without exception text or locals."""
+    frames = extract_tb(exc.__traceback__, limit=limit)
+    return tuple(f"{frame.filename}:{frame.lineno}:{frame.name}" for frame in frames)

--- a/backend/app/services/credential_crypto.py
+++ b/backend/app/services/credential_crypto.py
@@ -1,21 +1,33 @@
 """Authenticated encryption for provider credentials.
 
-A deployment can supply ``APPLYKIT_CREDENTIAL_ENCRYPTION_KEY``. When it is
-absent, ApplyKit creates a persistent Fernet key in a local file so database
-backups do not contain the material needed to decrypt provider credentials.
+Managed deployments provide a Fernet key directly or through an externally
+mounted file. Local installations use a persistent fallback key file.
 """
 
 from __future__ import annotations
 
 import hmac
 import os
+from dataclasses import dataclass
 from functools import lru_cache
 from hashlib import sha256
 from pathlib import Path
+from typing import Literal
 
 from cryptography.fernet import Fernet, InvalidToken
 
-from app.config import get_settings
+from app.config import Settings, get_settings
+from app.security.secrets import reveal_secret
+
+CredentialKeySource = Literal["environment", "external_file", "local_file"]
+
+
+@dataclass(frozen=True)
+class CredentialKeyMaterial:
+    """Loaded Fernet key bytes plus their trusted source."""
+
+    key: bytes
+    source: CredentialKeySource
 
 
 class CredentialDecryptionError(ValueError):
@@ -62,6 +74,7 @@ def _read_key(path: Path) -> bytes:
     key = path.read_bytes().strip()
     if not key:
         raise ValueError(f"Credential key file is empty: {path}")
+    CredentialCipher(key)
     return key
 
 
@@ -75,6 +88,8 @@ def _create_key_file(path: Path) -> bytes:
 
     with os.fdopen(descriptor, "wb") as handle:
         handle.write(key + b"\n")
+        handle.flush()
+        os.fsync(handle.fileno())
     try:
         path.chmod(0o600)
     except OSError:
@@ -83,18 +98,56 @@ def _create_key_file(path: Path) -> bytes:
     return key
 
 
-def _load_production_key() -> bytes:
-    settings = get_settings()
-    if settings.credential_encryption_key:
-        return settings.credential_encryption_key.encode()
+def load_external_credential_key(
+    settings: Settings,
+) -> CredentialKeyMaterial | None:
+    """Load an explicitly supplied environment or external-file key."""
+    direct = reveal_secret(settings.credential_encryption_key).strip()
+    if direct:
+        key = direct.encode()
+        CredentialCipher(key)
+        return CredentialKeyMaterial(key=key, source="environment")
 
-    key_path = Path(settings.credential_key_file).expanduser()
-    if key_path.exists():
-        return _read_key(key_path)
-    return _create_key_file(key_path)
+    if settings.credential_encryption_key_file:
+        path = Path(settings.credential_encryption_key_file).expanduser()
+        return CredentialKeyMaterial(key=_read_key(path), source="external_file")
+
+    return None
+
+
+def load_local_credential_key(
+    path: Path,
+    *,
+    create: bool,
+) -> CredentialKeyMaterial:
+    """Load or explicitly create the local writable fallback key."""
+    expanded = path.expanduser()
+    if expanded.exists():
+        return CredentialKeyMaterial(key=_read_key(expanded), source="local_file")
+    if not create:
+        raise FileNotFoundError(expanded)
+    return CredentialKeyMaterial(
+        key=_create_key_file(expanded),
+        source="local_file",
+    )
+
+
+def _load_production_key() -> CredentialKeyMaterial:
+    settings = get_settings()
+    external = load_external_credential_key(settings)
+    if external is not None:
+        return external
+    if settings.deployment_mode == "remote":
+        raise ValueError(
+            "Remote mode requires an external credential encryption key."
+        )
+    return load_local_credential_key(
+        Path(settings.credential_key_file),
+        create=True,
+    )
 
 
 @lru_cache
 def get_credential_cipher() -> CredentialCipher:
     """Return the process-wide credential cipher."""
-    return CredentialCipher(_load_production_key())
+    return CredentialCipher(_load_production_key().key)

--- a/backend/app/services/credential_vault_startup.py
+++ b/backend/app/services/credential_vault_startup.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from sqlalchemy.orm import Session
 
 from app.config import Settings
+from app.database import SessionLocal
 from app.models import ProviderCredential
 from app.services.credential_crypto import (
     CredentialCipher,
@@ -126,7 +127,7 @@ def _select_local_key(
 def initialize_credential_vault(
     settings: Settings,
     *,
-    session_factory: SessionFactory,
+    session_factory: SessionFactory = SessionLocal,
 ) -> None:
     """Select, migrate, and validate the vault key before serving requests."""
     get_credential_cipher.cache_clear()

--- a/backend/app/services/credential_vault_startup.py
+++ b/backend/app/services/credential_vault_startup.py
@@ -1,0 +1,161 @@
+"""Failure-safe credential vault initialization and legacy key migration."""
+
+from __future__ import annotations
+
+import hmac
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from app.config import Settings
+from app.models import ProviderCredential
+from app.services.credential_crypto import (
+    CredentialCipher,
+    CredentialKeyMaterial,
+    get_credential_cipher,
+    load_external_credential_key,
+    load_local_credential_key,
+)
+
+SessionFactory = Callable[[], Session]
+
+
+class CredentialVaultStartupError(RuntimeError):
+    """Raised when the credential vault cannot be opened safely."""
+
+
+def _copy_key_atomically(source: Path, destination: Path) -> None:
+    key = source.read_bytes().strip()
+    CredentialCipher(key)
+    destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.tmp")
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        with os.fdopen(descriptor, "wb") as handle:
+            descriptor = None
+            handle.write(key + b"\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+        try:
+            destination.chmod(0o600)
+        except OSError:
+            pass
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _credential_count(session_factory: SessionFactory) -> int:
+    with session_factory() as db:
+        return db.query(ProviderCredential).count()
+
+
+def _validate_credentials(
+    session_factory: SessionFactory,
+    cipher: CredentialCipher,
+) -> None:
+    with session_factory() as db:
+        for credential in db.query(ProviderCredential).yield_per(100):
+            cipher.decrypt(credential.encrypted_secret)
+
+
+def _validation_failure() -> CredentialVaultStartupError:
+    return CredentialVaultStartupError(
+        "Credential vault validation failed.\n"
+        "The configured encryption key cannot decrypt existing provider "
+        "credentials.\n"
+        "Restore the original key or revoke and replace the affected "
+        "credentials."
+    )
+
+
+def _select_local_key(
+    settings: Settings,
+    session_factory: SessionFactory,
+) -> tuple[CredentialKeyMaterial, Path | None, bool]:
+    active_path = Path(settings.credential_key_file).expanduser()
+    legacy_path = (
+        Path(settings.credential_legacy_key_file).expanduser()
+        if settings.credential_legacy_key_file
+        else None
+    )
+    active_exists = active_path.exists()
+    legacy_exists = bool(legacy_path and legacy_path.exists())
+
+    if active_exists and legacy_exists and legacy_path is not None:
+        active = load_local_credential_key(active_path, create=False)
+        legacy = load_local_credential_key(legacy_path, create=False)
+        if not hmac.compare_digest(active.key, legacy.key):
+            raise CredentialVaultStartupError(
+                "Credential vault migration found different encryption keys in "
+                "the active and legacy locations. Restore the correct key and "
+                "retry startup."
+            )
+        return active, legacy_path, False
+
+    if active_exists:
+        return load_local_credential_key(active_path, create=False), None, False
+
+    if legacy_exists and legacy_path is not None:
+        _copy_key_atomically(legacy_path, active_path)
+        get_credential_cipher.cache_clear()
+        return load_local_credential_key(active_path, create=False), legacy_path, True
+
+    if _credential_count(session_factory) > 0:
+        raise CredentialVaultStartupError(
+            "Credential vault key is missing while encrypted provider "
+            "credentials already exist. Restore the original key or revoke and "
+            "replace the affected credentials."
+        )
+
+    material = load_local_credential_key(active_path, create=True)
+    get_credential_cipher.cache_clear()
+    return material, None, False
+
+
+def initialize_credential_vault(
+    settings: Settings,
+    *,
+    session_factory: SessionFactory,
+) -> None:
+    """Select, migrate, and validate the vault key before serving requests."""
+    get_credential_cipher.cache_clear()
+    external = load_external_credential_key(settings)
+    copied_active_path: Path | None = None
+    legacy_to_remove: Path | None = None
+
+    if external is not None:
+        material = external
+    else:
+        if settings.deployment_mode == "remote":
+            raise CredentialVaultStartupError(
+                "Remote mode requires an external credential encryption key."
+            )
+        material, legacy_to_remove, copied = _select_local_key(
+            settings,
+            session_factory,
+        )
+        if copied:
+            copied_active_path = Path(settings.credential_key_file).expanduser()
+
+    try:
+        _validate_credentials(session_factory, CredentialCipher(material.key))
+    except Exception:
+        if copied_active_path is not None and copied_active_path.exists():
+            copied_active_path.unlink()
+            get_credential_cipher.cache_clear()
+        raise _validation_failure() from None
+
+    if legacy_to_remove is not None and legacy_to_remove.exists():
+        legacy_to_remove.unlink()
+        get_credential_cipher.cache_clear()

--- a/backend/app/services/credential_vault_startup.py
+++ b/backend/app/services/credential_vault_startup.py
@@ -32,6 +32,8 @@ def _copy_key_atomically(source: Path, destination: Path) -> None:
     CredentialCipher(key)
     destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     temporary = destination.with_name(f".{destination.name}.tmp")
+    if temporary.exists():
+        temporary.unlink()
     descriptor: int | None = None
     try:
         descriptor = os.open(

--- a/backend/app/services/provider_connection.py
+++ b/backend/app/services/provider_connection.py
@@ -4,6 +4,7 @@ import litellm
 
 from app.public_errors import PROVIDER_CONNECTION_ERROR_MESSAGE
 from app.schemas import TestConnectionResponse
+from app.security.secrets import safe_exception_type
 
 logger = logging.getLogger(__name__)
 
@@ -34,9 +35,9 @@ def test_provider_connection(
         return TestConnectionResponse(ok=False, message="LLM returned empty response.")
     except Exception as exc:
         logger.warning(
-            "LLM connection test failed for model %s",
+            "LLM connection test failed model=%s error_type=%s",
             model_id,
-            exc_info=(type(exc), exc, exc.__traceback__),
+            safe_exception_type(exc),
         )
         return TestConnectionResponse(
             ok=False,

--- a/backend/app/services/provider_credential_vault.py
+++ b/backend/app/services/provider_credential_vault.py
@@ -103,7 +103,7 @@ def _deactivate_provider_credentials(db: Session, provider_id: str) -> None:
     ).update({"is_active": False}, synchronize_session=False)
 
 
-def create_provider_credential(
+def _create_provider_credential_pending(
     db: Session,
     *,
     provider_id: str,
@@ -113,6 +113,7 @@ def create_provider_credential(
     activate: bool | None = None,
     max_credentials: int = DEFAULT_MAX_PROVIDER_CREDENTIALS,
 ) -> ProviderCredential:
+    """Stage an encrypted credential without committing the transaction."""
     provider_id = provider_id.strip()
     label = label.strip()
     secret = secret.strip()
@@ -159,6 +160,28 @@ def create_provider_credential(
         health_status="unknown",
     )
     db.add(credential)
+    return credential
+
+
+def create_provider_credential(
+    db: Session,
+    *,
+    provider_id: str,
+    label: str,
+    secret: str,
+    cipher: CredentialCipher | None = None,
+    activate: bool | None = None,
+    max_credentials: int = DEFAULT_MAX_PROVIDER_CREDENTIALS,
+) -> ProviderCredential:
+    credential = _create_provider_credential_pending(
+        db,
+        provider_id=provider_id,
+        label=label,
+        secret=secret,
+        cipher=cipher,
+        activate=activate,
+        max_credentials=max_credentials,
+    )
     db.commit()
     db.refresh(credential)
     return credential
@@ -355,20 +378,28 @@ def migrate_legacy_provider_credentials(
             .filter_by(provider_id=provider.id)
             .first()
         )
-        if not existing:
-            create_provider_credential(
-                db,
-                provider_id=provider.id,
-                label="Default",
-                secret=plaintext,
-                cipher=selected_cipher,
-                activate=True,
-            )
-            migrated += 1
+        created = False
+        try:
+            if not existing:
+                _create_provider_credential_pending(
+                    db,
+                    provider_id=provider.id,
+                    label="Default",
+                    secret=plaintext,
+                    cipher=selected_cipher,
+                    activate=True,
+                )
+                created = True
 
-        _clear_plain_setting(db, provider_key_name)
-        if used_legacy_global:
-            _clear_plain_setting(db, "llm_api_key")
-        db.commit()
+            _clear_plain_setting(db, provider_key_name)
+            if used_legacy_global:
+                _clear_plain_setting(db, "llm_api_key")
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+
+        if created:
+            migrated += 1
 
     return migrated

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from app.routes import (
     usage,
 )
 from app.security.deployment import manual_bind_host, validate_deployment_security
+from app.services.credential_vault_startup import initialize_credential_vault
 from app.services.usage_logging import stop_usage_logger
 
 _settings = get_settings()
@@ -31,6 +32,7 @@ validate_deployment_security(_settings)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    initialize_credential_vault(_settings)
     initialize_auth(_settings)
     await start_http_client()
     try:

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,9 +22,11 @@ from app.routes import (
     settings,
     usage,
 )
+from app.security.deployment import manual_bind_host, validate_deployment_security
 from app.services.usage_logging import stop_usage_logger
 
 _settings = get_settings()
+validate_deployment_security(_settings)
 
 
 @asynccontextmanager
@@ -76,4 +78,9 @@ app.include_router(usage.router, prefix="/api")
 
 
 if __name__ == "__main__":
-    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run(
+        "main:app",
+        host=manual_bind_host(_settings),
+        port=8000,
+        reload=True,
+    )

--- a/backend/tests/test_credential_crypto_sources.py
+++ b/backend/tests/test_credential_crypto_sources.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+from pydantic import SecretStr
+
+from app.config import Settings
+from app.services.credential_crypto import (
+    CredentialCipher,
+    load_external_credential_key,
+    load_local_credential_key,
+)
+
+
+def test_environment_key_has_priority_and_is_not_represented_plainly() -> None:
+    key = Fernet.generate_key().decode()
+    settings = Settings(credential_encryption_key=key)
+    assert isinstance(settings.credential_encryption_key, SecretStr)
+    assert key not in repr(settings)
+
+    material = load_external_credential_key(settings)
+    assert material is not None
+    assert material.source == "environment"
+    assert CredentialCipher(material.key)
+
+
+def test_external_key_file_is_read_without_modification(tmp_path: Path) -> None:
+    key_path = tmp_path / "credential.key"
+    key = Fernet.generate_key()
+    key_path.write_bytes(key + b"\n")
+    settings = Settings(credential_encryption_key_file=str(key_path))
+
+    material = load_external_credential_key(settings)
+    assert material is not None
+    assert material.source == "external_file"
+    assert material.key == key
+    assert key_path.read_bytes() == key + b"\n"
+
+
+def test_local_key_is_not_created_when_create_is_false(tmp_path: Path) -> None:
+    key_path = tmp_path / "credential.key"
+    with pytest.raises(FileNotFoundError):
+        load_local_credential_key(key_path, create=False)
+    assert not key_path.exists()
+
+
+def test_local_key_creation_uses_restricted_permissions(tmp_path: Path) -> None:
+    key_path = tmp_path / "nested" / "credential.key"
+    material = load_local_credential_key(key_path, create=True)
+    assert material.source == "local_file"
+    assert key_path.exists()
+    assert key_path.stat().st_mode & 0o777 == 0o600

--- a/backend/tests/test_credential_secret_leakage.py
+++ b/backend/tests/test_credential_secret_leakage.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+from sqlalchemy import create_engine, event, text
+from sqlalchemy.orm import sessionmaker
+
+from app.database import configure_sqlite_security
+from app.models import Base
+from app.services.credential_crypto import CredentialCipher
+from app.services.provider_credential_vault import (
+    clear_provider_credentials,
+    create_provider_credential,
+    migrate_legacy_provider_credentials,
+    replace_provider_credential_secret,
+)
+from app.services.settings import set_setting
+
+
+def _database_bytes(database_path: Path) -> bytes:
+    payload = bytearray(database_path.read_bytes())
+    for suffix in ("-wal", "-journal"):
+        sidecar = Path(f"{database_path}{suffix}")
+        if sidecar.exists():
+            payload.extend(sidecar.read_bytes())
+    return bytes(payload)
+
+
+def _file_session(tmp_path: Path):
+    database_path = tmp_path / "applykit.db"
+    engine = create_engine(
+        f"sqlite:///{database_path}",
+        connect_args={"check_same_thread": False},
+    )
+    event.listen(engine, "connect", configure_sqlite_security)
+    Base.metadata.create_all(engine)
+    return database_path, engine, sessionmaker(bind=engine)
+
+
+def test_sqlite_connections_enable_secure_delete(tmp_path: Path) -> None:
+    _, engine, _ = _file_session(tmp_path)
+    try:
+        with engine.connect() as connection:
+            assert connection.execute(text("PRAGMA secure_delete")).scalar() == 1
+    finally:
+        engine.dispose()
+
+
+def test_save_replace_migrate_and_disconnect_leave_no_plaintext_canary(
+    tmp_path: Path,
+) -> None:
+    old_secret = "applykit-secret-canary-old-41d2"
+    new_secret = "applykit-secret-canary-new-8c63"
+    legacy_secret = "applykit-secret-canary-legacy-94aa"
+    database_path, engine, factory = _file_session(tmp_path)
+    cipher = CredentialCipher(Fernet.generate_key())
+
+    try:
+        with factory() as db:
+            credential = create_provider_credential(
+                db,
+                provider_id="openai",
+                label="Primary",
+                secret=old_secret,
+                cipher=cipher,
+            )
+            replace_provider_credential_secret(
+                db,
+                "openai",
+                credential.id,
+                new_secret,
+                cipher=cipher,
+            )
+            clear_provider_credentials(db, "openai")
+
+            set_setting(db, "api_key_gemini", legacy_secret)
+            assert migrate_legacy_provider_credentials(db, cipher=cipher) == 1
+            clear_provider_credentials(db, "gemini")
+    finally:
+        engine.dispose()
+
+    database_payload = _database_bytes(database_path)
+    assert old_secret.encode() not in database_payload
+    assert new_secret.encode() not in database_payload
+    assert legacy_secret.encode() not in database_payload

--- a/backend/tests/test_credential_secret_leakage.py
+++ b/backend/tests/test_credential_secret_leakage.py
@@ -72,6 +72,7 @@ def test_save_replace_migrate_and_disconnect_leave_no_plaintext_canary(
             )
             clear_provider_credentials(db, "openai")
 
+        with factory() as db:
             set_setting(db, "api_key_gemini", legacy_secret)
             assert migrate_legacy_provider_credentials(db, cipher=cipher) == 1
             clear_provider_credentials(db, "gemini")

--- a/backend/tests/test_credential_vault_startup.py
+++ b/backend/tests/test_credential_vault_startup.py
@@ -1,0 +1,186 @@
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.config import Settings
+from app.models import Base
+from app.services.credential_crypto import CredentialCipher
+from app.services.credential_vault_startup import (
+    CredentialVaultStartupError,
+    initialize_credential_vault,
+)
+from app.services.provider_credential_vault import create_provider_credential
+
+
+def _factory(tmp_path: Path):
+    database_path = tmp_path / "applykit.db"
+    engine = create_engine(
+        f"sqlite:///{database_path}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def _settings(tmp_path: Path, **overrides) -> Settings:
+    values = {
+        "deployment_mode": "local",
+        "credential_key_file": str(tmp_path / "active" / "credential.key"),
+        "credential_legacy_key_file": str(tmp_path / "legacy" / "credential.key"),
+    }
+    values.update(overrides)
+    return Settings(**values)
+
+
+def _add_credential(factory, key: bytes, secret: str = "stored-secret") -> str:
+    cipher = CredentialCipher(key)
+    with factory() as db:
+        credential = create_provider_credential(
+            db,
+            provider_id="openai",
+            label="Primary",
+            secret=secret,
+            cipher=cipher,
+        )
+        return credential.encrypted_secret
+
+
+def test_fresh_local_install_creates_active_key_only(tmp_path: Path) -> None:
+    factory = _factory(tmp_path)
+    settings = _settings(tmp_path)
+
+    initialize_credential_vault(settings, session_factory=factory)
+
+    active = Path(settings.credential_key_file)
+    legacy = Path(settings.credential_legacy_key_file or "")
+    assert active.exists()
+    assert active.stat().st_mode & 0o777 == 0o600
+    assert not legacy.exists()
+
+
+def test_existing_encrypted_rows_without_any_key_fail_without_creating_one(
+    tmp_path: Path,
+) -> None:
+    factory = _factory(tmp_path)
+    _add_credential(factory, Fernet.generate_key())
+    settings = _settings(tmp_path)
+
+    with pytest.raises(CredentialVaultStartupError):
+        initialize_credential_vault(settings, session_factory=factory)
+
+    assert not Path(settings.credential_key_file).exists()
+
+
+def test_legacy_key_moves_atomically_and_credentials_remain_decryptable(
+    tmp_path: Path,
+) -> None:
+    factory = _factory(tmp_path)
+    key = Fernet.generate_key()
+    ciphertext = _add_credential(factory, key)
+    settings = _settings(tmp_path)
+    legacy = Path(settings.credential_legacy_key_file or "")
+    legacy.parent.mkdir(parents=True)
+    legacy.write_bytes(key + b"\n")
+
+    initialize_credential_vault(settings, session_factory=factory)
+
+    active = Path(settings.credential_key_file)
+    assert active.read_bytes().strip() == key
+    assert not legacy.exists()
+    assert CredentialCipher(active.read_bytes().strip()).decrypt(ciphertext) == "stored-secret"
+
+
+def test_failed_validation_keeps_legacy_and_removes_unverified_copy(
+    tmp_path: Path,
+) -> None:
+    factory = _factory(tmp_path)
+    _add_credential(factory, Fernet.generate_key())
+    settings = _settings(tmp_path)
+    legacy = Path(settings.credential_legacy_key_file or "")
+    legacy.parent.mkdir(parents=True)
+    legacy.write_bytes(Fernet.generate_key() + b"\n")
+
+    with pytest.raises(CredentialVaultStartupError):
+        initialize_credential_vault(settings, session_factory=factory)
+
+    assert legacy.exists()
+    assert not Path(settings.credential_key_file).exists()
+
+
+def test_active_and_legacy_same_key_is_idempotent(tmp_path: Path) -> None:
+    factory = _factory(tmp_path)
+    key = Fernet.generate_key()
+    _add_credential(factory, key)
+    settings = _settings(tmp_path)
+    active = Path(settings.credential_key_file)
+    legacy = Path(settings.credential_legacy_key_file or "")
+    active.parent.mkdir(parents=True)
+    legacy.parent.mkdir(parents=True)
+    active.write_bytes(key + b"\n")
+    legacy.write_bytes(key + b"\n")
+
+    initialize_credential_vault(settings, session_factory=factory)
+    initialize_credential_vault(settings, session_factory=factory)
+
+    assert active.exists()
+    assert not legacy.exists()
+
+
+def test_active_and_legacy_different_keys_fail_closed(tmp_path: Path) -> None:
+    factory = _factory(tmp_path)
+    settings = _settings(tmp_path)
+    active = Path(settings.credential_key_file)
+    legacy = Path(settings.credential_legacy_key_file or "")
+    active.parent.mkdir(parents=True)
+    legacy.parent.mkdir(parents=True)
+    active.write_bytes(Fernet.generate_key() + b"\n")
+    legacy.write_bytes(Fernet.generate_key() + b"\n")
+
+    with pytest.raises(CredentialVaultStartupError) as exc_info:
+        initialize_credential_vault(settings, session_factory=factory)
+
+    assert "different encryption keys" in str(exc_info.value)
+    assert active.exists()
+    assert legacy.exists()
+
+
+def test_remote_external_key_must_decrypt_every_credential(tmp_path: Path) -> None:
+    factory = _factory(tmp_path)
+    correct_key = Fernet.generate_key()
+    _add_credential(factory, correct_key)
+
+    valid = _settings(
+        tmp_path,
+        deployment_mode="remote",
+        credential_encryption_key=correct_key.decode(),
+    )
+    initialize_credential_vault(valid, session_factory=factory)
+
+    invalid = _settings(
+        tmp_path,
+        deployment_mode="remote",
+        credential_encryption_key=Fernet.generate_key().decode(),
+    )
+    with pytest.raises(CredentialVaultStartupError):
+        initialize_credential_vault(invalid, session_factory=factory)
+
+
+def test_startup_error_never_contains_sensitive_values(tmp_path: Path) -> None:
+    factory = _factory(tmp_path)
+    canary = "applykit-secret-canary-startup-7e4f"
+    ciphertext = _add_credential(factory, Fernet.generate_key(), canary)
+    settings = _settings(
+        tmp_path,
+        deployment_mode="remote",
+        credential_encryption_key=Fernet.generate_key().decode(),
+    )
+
+    with pytest.raises(CredentialVaultStartupError) as exc_info:
+        initialize_credential_vault(settings, session_factory=factory)
+
+    message = str(exc_info.value)
+    assert canary not in message
+    assert ciphertext not in message

--- a/backend/tests/test_credential_vault_startup.py
+++ b/backend/tests/test_credential_vault_startup.py
@@ -93,6 +93,26 @@ def test_legacy_key_moves_atomically_and_credentials_remain_decryptable(
     assert CredentialCipher(active.read_bytes().strip()).decrypt(ciphertext) == "stored-secret"
 
 
+def test_stale_temporary_copy_is_cleaned_before_retry(tmp_path: Path) -> None:
+    factory = _factory(tmp_path)
+    key = Fernet.generate_key()
+    _add_credential(factory, key)
+    settings = _settings(tmp_path)
+    active = Path(settings.credential_key_file)
+    legacy = Path(settings.credential_legacy_key_file or "")
+    legacy.parent.mkdir(parents=True)
+    legacy.write_bytes(key + b"\n")
+    active.parent.mkdir(parents=True)
+    stale = active.with_name(f".{active.name}.tmp")
+    stale.write_text("interrupted-copy")
+
+    initialize_credential_vault(settings, session_factory=factory)
+
+    assert active.read_bytes().strip() == key
+    assert not stale.exists()
+    assert not legacy.exists()
+
+
 def test_failed_validation_keeps_legacy_and_removes_unverified_copy(
     tmp_path: Path,
 ) -> None:

--- a/backend/tests/test_deployment_security.py
+++ b/backend/tests/test_deployment_security.py
@@ -1,0 +1,92 @@
+import pytest
+from cryptography.fernet import Fernet
+
+from app.config import Settings
+from app.security.deployment import (
+    DeploymentSecurityError,
+    is_loopback_origin,
+    manual_bind_host,
+    validate_deployment_security,
+)
+
+
+def test_loopback_origin_accepts_localhost_ipv4_and_ipv6() -> None:
+    assert is_loopback_origin("http://localhost:5173")
+    assert is_loopback_origin("https://127.0.0.1:3000")
+    assert is_loopback_origin("http://127.42.0.8")
+    assert is_loopback_origin("http://[::1]:5173")
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "*",
+        "http://192.168.1.10:5173",
+        "https://applykit.example.com",
+        "ftp://localhost",
+        "http://user:pass@localhost:5173",
+        "http://localhost:5173/path",
+        "http://localhost:5173?debug=1",
+    ],
+)
+def test_loopback_origin_rejects_non_origin_or_non_loopback_values(
+    origin: str,
+) -> None:
+    assert not is_loopback_origin(origin)
+
+
+def test_local_mode_allows_default_loopback_configuration() -> None:
+    settings = Settings(
+        deployment_mode="local",
+        auth_mode="disabled",
+        cookie_secure=False,
+        debug=False,
+        cors_origins=["http://localhost:5173"],
+    )
+    validate_deployment_security(settings)
+    assert manual_bind_host(settings) == "127.0.0.1"
+
+
+def test_local_mode_rejects_lan_or_public_origin() -> None:
+    settings = Settings(
+        deployment_mode="local",
+        cors_origins=["http://192.168.1.20:5173"],
+    )
+    with pytest.raises(DeploymentSecurityError) as exc_info:
+        validate_deployment_security(settings)
+    assert "DEPLOYMENT_MODE=remote" in str(exc_info.value)
+
+
+def test_remote_mode_reports_all_unsafe_settings_together() -> None:
+    settings = Settings(
+        deployment_mode="remote",
+        auth_mode="disabled",
+        cookie_secure=False,
+        debug=True,
+        cors_origins=["*", "http://applykit.example.com"],
+        credential_encryption_key=None,
+        credential_encryption_key_file=None,
+    )
+    with pytest.raises(DeploymentSecurityError) as exc_info:
+        validate_deployment_security(settings)
+
+    message = str(exc_info.value)
+    assert 'AUTH_MODE must be "password"' in message
+    assert "COOKIE_SECURE must be true" in message
+    assert "DEBUG must be false" in message
+    assert "wildcard CORS" in message
+    assert "must use HTTPS" in message
+    assert "external credential encryption key" in message
+
+
+def test_remote_mode_accepts_hardened_configuration() -> None:
+    settings = Settings(
+        deployment_mode="remote",
+        auth_mode="password",
+        cookie_secure=True,
+        debug=False,
+        cors_origins=["https://applykit.example.com"],
+        credential_encryption_key=Fernet.generate_key().decode(),
+    )
+    validate_deployment_security(settings)
+    assert manual_bind_host(settings) == "0.0.0.0"

--- a/backend/tests/test_deployment_security.py
+++ b/backend/tests/test_deployment_security.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from cryptography.fernet import Fernet
 
@@ -77,6 +79,25 @@ def test_remote_mode_reports_all_unsafe_settings_together() -> None:
     assert "wildcard CORS" in message
     assert "must use HTTPS" in message
     assert "external credential encryption key" in message
+
+
+def test_remote_mode_rejects_key_file_beside_sqlite_database(
+    tmp_path: Path,
+) -> None:
+    settings = Settings(
+        deployment_mode="remote",
+        auth_mode="password",
+        cookie_secure=True,
+        debug=False,
+        cors_origins=["https://applykit.example.com"],
+        database_url=f"sqlite:///{tmp_path / 'applykit.db'}",
+        credential_encryption_key_file=str(tmp_path / "credential.key"),
+    )
+
+    with pytest.raises(DeploymentSecurityError) as exc_info:
+        validate_deployment_security(settings)
+
+    assert "separate storage location" in str(exc_info.value)
 
 
 def test_remote_mode_accepts_hardened_configuration() -> None:

--- a/backend/tests/test_error_sanitization.py
+++ b/backend/tests/test_error_sanitization.py
@@ -29,6 +29,17 @@ def test_generic_exception_response_does_not_expose_raw_error():
     assert "internal.example" not in response.body.decode()
 
 
+def test_generic_exception_log_omits_exception_message_and_canary(caplog):
+    canary = "applykit-secret-canary-generic-log-b174"
+    response = asyncio.run(
+        generic_exception_handler(None, RuntimeError(f"provider leaked {canary}"))
+    )
+
+    assert response.status_code == 500
+    assert canary not in caplog.text
+    assert "RuntimeError" in caplog.text
+
+
 def test_connection_failure_returns_safe_message(monkeypatch):
     def fail_completion(*args, **kwargs):
         raise RuntimeError(_RAW_ERROR)
@@ -47,6 +58,29 @@ def test_connection_failure_returns_safe_message(monkeypatch):
         "Connection failed. Verify the provider, model, API key, and network settings."
     )
     assert "sk-secret-value" not in response.message
+
+
+def test_connection_failure_log_omits_provider_exception_message(
+    monkeypatch,
+    caplog,
+):
+    canary = "applykit-secret-canary-provider-log-f068"
+
+    def fail_completion(*args, **kwargs):
+        raise RuntimeError(f"Authorization: Bearer {canary}")
+
+    monkeypatch.setattr(litellm, "completion", fail_completion)
+    response = check_connection(
+        UpdateSettingsRequest(
+            model="openai/gpt-4.1-mini",
+            api_key=canary,
+        )
+    )
+
+    assert response.ok is False
+    assert canary not in response.message
+    assert canary not in caplog.text
+    assert "RuntimeError" in caplog.text
 
 
 def test_llm_failure_raises_and_persists_only_safe_message(monkeypatch):

--- a/backend/tests/test_error_sanitization.py
+++ b/backend/tests/test_error_sanitization.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.exceptions.handlers import generic_exception_handler
 from app.exceptions.llm import LLMCallError
+from app.exceptions.stream import stream_error_event
 from app.routes.settings import test_connection as check_connection
 from app.schemas import UpdateSettingsRequest
 from app.services import llm as llm_service
@@ -36,6 +37,17 @@ def test_generic_exception_log_omits_exception_message_and_canary(caplog):
     )
 
     assert response.status_code == 500
+    assert canary not in caplog.text
+    assert "RuntimeError" in caplog.text
+
+
+def test_stream_exception_log_omits_exception_message_and_canary(caplog):
+    canary = "applykit-secret-canary-stream-log-384c"
+
+    event = stream_error_event(RuntimeError(f"Authorization: Bearer {canary}"))
+
+    assert event.event == "error"
+    assert canary not in json.dumps(event.data)
     assert canary not in caplog.text
     assert "RuntimeError" in caplog.text
 

--- a/backend/tests/test_provider_credential_routes.py
+++ b/backend/tests/test_provider_credential_routes.py
@@ -1,7 +1,11 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from app.credential_schemas import CreateProviderCredentialRequest
+from app.credential_schemas import (
+    CreateProviderCredentialRequest,
+    ProviderSettingsRequest,
+    UpdateProviderCredentialRequest,
+)
 from app.models import Base
 from app.routes.settings import (
     activate_credential,
@@ -17,6 +21,23 @@ def _make_session():
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     return sessionmaker(bind=engine)()
+
+
+def test_credential_request_models_hide_secret_in_repr_and_json() -> None:
+    canary = "applykit-secret-canary-schema-1f25"
+    requests = [
+        ProviderSettingsRequest(model="openai/gpt-5-mini", api_key=canary),
+        CreateProviderCredentialRequest(
+            label="Personal",
+            secret=canary,
+            activate=True,
+        ),
+        UpdateProviderCredentialRequest(secret=canary),
+    ]
+
+    for request in requests:
+        assert canary not in repr(request)
+        assert canary not in request.model_dump_json()
 
 
 def test_credentials_api_never_returns_raw_secret():

--- a/backend/tests/test_provider_credential_vault.py
+++ b/backend/tests/test_provider_credential_vault.py
@@ -1,8 +1,9 @@
+import pytest
 from cryptography.fernet import Fernet
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
-from app.models import Base, ProviderCredential
+from app.models import AppSetting, Base, ProviderCredential
 from app.services.credential_crypto import CredentialCipher
 from app.services.provider_credential_vault import (
     CredentialLimitError,
@@ -161,5 +162,29 @@ def test_legacy_plaintext_key_migrates_once_and_is_cleared():
 
         assert migrate_legacy_provider_credentials(db, cipher=cipher) == 0
         assert db.query(ProviderCredential).count() == 1
+    finally:
+        db.close()
+
+
+def test_legacy_migration_rolls_back_ciphertext_and_plaintext_together():
+    db = _make_session()
+    cipher = _cipher()
+    plaintext = "applykit-secret-canary-atomic-migration"
+    try:
+        set_setting(db, "api_key_gemini", plaintext)
+
+        def fail_when_plaintext_is_being_cleared(session) -> None:
+            row = session.query(AppSetting).filter_by(key="api_key_gemini").one()
+            if row.value == "":
+                raise RuntimeError("simulated commit failure")
+
+        event.listen(db, "before_commit", fail_when_plaintext_is_being_cleared)
+        with pytest.raises(RuntimeError, match="simulated commit failure"):
+            migrate_legacy_provider_credentials(db, cipher=cipher)
+        event.remove(db, "before_commit", fail_when_plaintext_is_being_cleared)
+        db.rollback()
+
+        assert db.query(ProviderCredential).count() == 0
+        assert get_setting(db, "api_key_gemini") == plaintext
     finally:
         db.close()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,12 @@ services:
       - "127.0.0.1:8000:8000"
     volumes:
       - applykit-data:/data
+      - applykit-secrets:/run/applykit-secrets
     environment:
+      DEPLOYMENT_MODE: local
       DATABASE_URL: sqlite:////data/applykit.db
-      CREDENTIAL_KEY_FILE: /data/credential.key
+      CREDENTIAL_KEY_FILE: /run/applykit-secrets/credential.key
+      CREDENTIAL_LEGACY_KEY_FILE: /data/credential.key
       AUTH_MODE: ${AUTH_MODE:-disabled}
       COOKIE_SECURE: ${COOKIE_SECURE:-false}
       CORS_ORIGINS: '["http://localhost:3000"]'
@@ -29,5 +32,6 @@ services:
 
 volumes:
   applykit-data:
-    # SQLite and the credential encryption key are stored here.
-    # Back up the whole volume so encrypted credentials remain recoverable.
+    # SQLite, profiles, generated documents, and usage data.
+  applykit-secrets:
+    # Local credential encryption key only. Back up separately from app data.

--- a/frontend/src/lib/components/ProviderCredentialsPanel.svelte
+++ b/frontend/src/lib/components/ProviderCredentialsPanel.svelte
@@ -79,6 +79,7 @@
   async function loadData() {
     loading = true;
     panelError = '';
+    closeAddForm();
     closeEditor();
     try {
       const response = await getProviderCredentials(providerId);
@@ -93,6 +94,22 @@
 
   async function notifyChanged() {
     await onChanged?.();
+  }
+
+  function closeAddForm() {
+    addOpen = false;
+    newLabel = '';
+    newSecret = '';
+    newSecretVisible = false;
+    activateNew = false;
+  }
+
+  function toggleAddForm() {
+    if (addOpen) {
+      closeAddForm();
+      return;
+    }
+    addOpen = true;
   }
 
   function closeEditor() {
@@ -126,9 +143,7 @@
         secret,
         activate: credentials.length === 0 || activateNew,
       });
-      newLabel = '';
-      activateNew = false;
-      addOpen = false;
+      closeAddForm();
       await loadData();
       await notifyChanged();
     } catch (error) {
@@ -276,7 +291,7 @@
       {/if}
       <button
         type="button"
-        onclick={() => (addOpen = !addOpen)}
+        onclick={toggleAddForm}
         disabled={credentials.length >= maxCredentials || operation !== ''}
         class="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
       >

--- a/frontend/src/lib/credential-secret-policy.test.ts
+++ b/frontend/src/lib/credential-secret-policy.test.ts
@@ -31,4 +31,14 @@ describe('credential secret policy', () => {
     expect(credentialsPanel).toContain("newSecret = ''");
     expect(credentialsPanel).toContain("editValue = ''");
   });
+
+  test('cancelling or changing providers clears the add-credential draft', () => {
+    expect(credentialsPanel).toContain('function closeAddForm()');
+    expect(credentialsPanel).toContain('function toggleAddForm()');
+    expect(credentialsPanel).toContain('onclick={toggleAddForm}');
+    expect(credentialsPanel).not.toContain('onclick={() => (addOpen = !addOpen)}');
+    expect(credentialsPanel).toMatch(
+      /async function loadData\(\)[\s\S]*?closeAddForm\(\);[\s\S]*?closeEditor\(\);/,
+    );
+  });
 });

--- a/frontend/src/lib/credential-secret-policy.test.ts
+++ b/frontend/src/lib/credential-secret-policy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const settingsModal = readFileSync(
+  new URL('./components/SettingsModal.svelte', import.meta.url),
+  'utf8',
+);
+const credentialsPanel = readFileSync(
+  new URL('./components/ProviderCredentialsPanel.svelte', import.meta.url),
+  'utf8',
+);
+
+describe('credential secret policy', () => {
+  test('credential components never use browser persistence or secret logging', () => {
+    for (const source of [settingsModal, credentialsPanel]) {
+      expect(source).not.toMatch(/\blocalStorage\b/);
+      expect(source).not.toMatch(/\bsessionStorage\b/);
+      expect(source).not.toMatch(
+        /console\.(log|debug|info|warn|error)\([^)]*(apiKey|secret|credential)/i,
+      );
+    }
+  });
+
+  test('secret inputs use password-manager-safe attributes', () => {
+    expect(settingsModal).toContain('autocomplete="new-password"');
+    expect(credentialsPanel).toContain('autocomplete="new-password"');
+  });
+
+  test('components contain explicit secret reset paths', () => {
+    expect(settingsModal).toContain("apiKey = ''");
+    expect(credentialsPanel).toContain("newSecret = ''");
+    expect(credentialsPanel).toContain("editValue = ''");
+  });
+});


### PR DESCRIPTION
## Summary

Hardens ApplyKit provider credential storage and deployment defaults before the onboarding readiness work.

## Deployment protection

- Adds explicit `local` and `remote` deployment modes.
- Keeps local mode loopback-only and binds the manual backend to `127.0.0.1`.
- Fails remote startup unless password auth, secure cookies, disabled debug mode, exact HTTPS CORS origins, and one external credential-encryption key are configured.
- Rejects remote SQLite key files placed beside the database.

## Credential vault

- Keeps provider secrets encrypted with Fernet and duplicate fingerprints keyed with HMAC.
- Uses secret-safe configuration and request types.
- Refuses to generate a replacement key when encrypted credentials already exist.
- Migrates the legacy Docker key atomically and validates all credentials before deleting the old key.
- Recovers safely from interrupted temporary key copies.
- Migrates legacy plaintext credentials and clears plaintext in one transaction.
- Enables SQLite secure deletion and adds database/WAL/journal canary tests.

## Secret leakage protection

- Removes provider and unexpected exception text from HTTP, streaming, and connection-test logs.
- Keeps API responses, usage records, audit events, and integration listings free of plaintext credentials.
- Clears browser credential drafts on cancel, provider change, success, and failure.
- Prevents credential persistence in browser storage.

## Docker and documentation

- Separates SQLite data and the local encryption key into different Docker volumes.
- Adds container migration and health smoke coverage.
- Documents local and remote setup, separate backups, restore behavior, provider-key limits, revocation, and security boundaries.

## Verification

- Backend lint
- Backend tests on Python 3.12 and 3.13
- 191 backend tests passed on Python 3.12
- Backend container build
- Legacy Docker key migration and split-volume health smoke
- Frontend unit tests
- Svelte/TypeScript check
- Frontend production build
- Frontend container smoke

No onboarding, OAuth, OpenAI-compatible endpoint, key-rotation UI, tag, or release is included.