### PR TITLE
chore: prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to ApplyKit are documented here.
+
+The project follows Semantic Versioning while it remains pre-1.0. Minor releases may introduce substantial features or configuration changes; upgrade notes call out required operator actions.
+
+## [0.2.0] - 2026-08-04
+
+### Added
+
+- Curated AI provider and model catalog with searchable selection, custom model IDs, provider credential links, and configured integration testing.
+- Encrypted multi-credential vault with masked metadata, duplicate detection, per-provider limits, and migration from legacy plaintext settings.
+- Manual, automatic failover, and round-robin credential routing with bounded retries, cooldowns, and safe streaming behavior.
+- Optional single-owner authentication with Argon2id passwords, opaque sessions, CSRF and Origin protection, login lockout, session revocation, and CLI password reset.
+- Browser authentication flows, Security settings, session-expiry warnings, and per-tab draft recovery after reauthentication.
+- Guided onboarding with active-profile completeness, fingerprint-verified AI readiness, dashboard guidance, and focused notices on AI-dependent pages.
+- Configurable Ollama Base URL and complete provider disconnect behavior.
+
+### Changed
+
+- Redesigned AI integration settings around compact connected-provider views, searchable model browsing, credential management, and responsive accessible editing.
+- Hardened local and remote deployment boundaries, CORS validation, error sanitization, prompt boundaries, structured output validation, and scraper SSRF protection.
+- Separated Docker application data and credential-key storage, with safe legacy-key migration and container smoke coverage.
+- Improved Docker image reliability, frontend production runtime packaging, usage logging, request client reuse, and generation/history durability.
+- Clarified that stable installations should use published Git tags while `main` remains the development branch.
+
+### Fixed
+
+- Database schemas that have not been migrated now report clear `make migrate` guidance instead of being misreported as invalid encryption keys.
+- Provider settings refresh immediately after saves, and keyless providers such as Ollama remain usable throughout configuration and CV enhancement.
+- Corrected usage date filtering and totals, internal error disclosure, connection-test sanitization, and several CV import edge cases.
+
+### Upgrade notes
+
+- Back up the SQLite database and credential encryption key separately before upgrading.
+- Docker installations run Alembic migrations automatically at backend startup.
+- Manual installations must run `make install` followed by `make migrate` before starting the backend.
+- Do not replace or delete the credential encryption key. Existing encrypted provider credentials require the original key.
+- Existing AI configurations require one successful connection retest after upgrading so ApplyKit can establish the new readiness fingerprint.
+
+[0.2.0]: https://github.com/wihlarkop/applykit/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -8,33 +8,25 @@
 
 **Self-hosted, local-first tools for creating tailored resumes, cover letters, and job applications with AI.**
 
-ApplyKit stores profiles, generated documents, application history, and provider credentials on infrastructure you control. No subscription is required.
-
-> ApplyKit defaults to `DEPLOYMENT_MODE=local`, binds the manual backend to loopback, and rejects non-loopback browser origins. Remote deployments fail startup unless the required authentication, HTTPS, cookie, CORS, and credential-key protections are configured.
+ApplyKit keeps profiles, generated documents, application history, and provider credentials on infrastructure you control. It supports hosted AI providers and local Ollama models without requiring an ApplyKit subscription.
 
 ## Highlights
 
-- Multiple role-specific profiles
+- Multiple role-specific career profiles
 - Resume import from PDF, DOCX, or pasted text
-- ATS-focused resume enhancement and PDF export
-- Tailored cover letters with streaming output
-- Job URL parsing, fit analysis, and Smart Apply
-- Kanban application tracker and generation history
-- Token, cost, latency, and error usage reporting
-- Curated and custom models across hosted and local providers
-- Multiple encrypted credentials per provider
-- Manual, automatic failover, and round-robin credential routing
-- Optional single-owner password protection
+- ATS-focused CV enhancement with live preview and PDF export
+- Tailored cover letters and Smart Apply workflows
+- Application tracker, history, and AI usage reporting
+- Curated and custom AI models across hosted and local providers
+- Encrypted multi-credential storage with manual, failover, and round-robin routing
+- Optional single-owner password protection for self-hosted deployments
+- Guided Profile Ready and AI Ready setup
 
-## Quick Start
+## Stable installation with Docker
 
-> **Stable installations:** `main` contains ongoing development. For normal use,
-> check out the latest published Git tag. Contributors who want the newest
-> development changes may use `main`.
+`main` contains ongoing development. For normal self-hosted use, check out the latest published Git tag.
 
-### Docker from the latest stable tag
-
-POSIX shells (Linux, macOS, Git Bash, or WSL):
+### Linux, macOS, Git Bash, or WSL
 
 ```bash
 git clone https://github.com/wihlarkop/applykit.git
@@ -44,7 +36,7 @@ git checkout "$(git describe --tags --abbrev=0)"
 docker compose up --build
 ```
 
-Windows PowerShell:
+### Windows PowerShell
 
 ```powershell
 git clone https://github.com/wihlarkop/applykit.git
@@ -55,18 +47,42 @@ git checkout $tag
 docker compose up --build
 ```
 
-A detached `HEAD` is expected when running a stable tag. When intentionally upgrading, back up ApplyKit first, stop the containers, run `git fetch --tags`, check out the newer tag, and rebuild. Do not switch a production installation to `main` merely to receive unreleased changes.
-
 Open `http://localhost:3000`. The backend is available at `http://localhost:8000`.
 
-Docker uses two persistent volumes:
+A detached `HEAD` is expected when running a stable tag. Docker stores application data and the credential encryption key in separate persistent volumes.
 
-- `applykit_applykit-data` for SQLite and application data;
-- `applykit_applykit-secrets` for the local credential encryption key.
+See [Installation](guides/installation.md) for first-run, storage, and manual development instructions.
 
-### Manual development setup from `main`
+## Updating an existing installation
 
-This path is intended for contributors and development testing. Requirements: [uv](https://docs.astral.sh/uv/) and [Bun](https://bun.sh/).
+Back up both the database and credential encryption key before upgrading.
+
+Docker upgrades run database migrations automatically when the backend starts. Manual installations must run:
+
+```bash
+git pull --ff-only
+make install
+make migrate
+```
+
+Then restart the backend and frontend. Existing AI configurations need one successful connection retest after upgrading to establish the trusted readiness fingerprint.
+
+Read [Upgrading](guides/upgrading.md) before changing tags or restoring data.
+
+## Documentation
+
+- [Installation](guides/installation.md) — Docker, manual development, first launch, and storage
+- [Upgrading](guides/upgrading.md) — backups, migrations, tag upgrades, and rollback cautions
+- [Configuration](guides/configuration.md) — environment variables, local mode, remote mode, and CORS
+- [Authentication](guides/authentication.md) — owner setup, sessions, lockout, and password recovery
+- [AI providers](guides/ai-providers.md) — models, credentials, routing, Ollama, and readiness
+- [Security](guides/security.md) — deployment boundaries, credential encryption, and limitations
+- [Backup and restore](guides/backup-and-restore.md) — separate data/key backups and recovery order
+- [Changelog](CHANGELOG.md) — release history and upgrade notes
+
+## Development setup
+
+This path follows `main` and is intended for contributors. Requirements: [uv](https://docs.astral.sh/uv/) and [Bun](https://bun.sh/).
 
 ```bash
 git clone https://github.com/wihlarkop/applykit.git
@@ -87,290 +103,7 @@ make frontend    # http://localhost:5173
 
 The manual backend binds to `127.0.0.1` in local mode.
 
-## Guided Setup and Readiness
-
-A fresh installation opens the guided setup once. **Skip for now** records that the setup was seen and opens the dashboard without locking Profile, Tracker, history, or other non-AI features. The dashboard keeps a readiness checklist available until the active profile and AI connection are ready.
-
-Existing installations are detected from meaningful profile data, generated documents, applications, selected models, or saved provider credentials. Upgrading does not force those installations through onboarding and does not alter existing profile or provider configuration.
-
-**Profile Ready** follows the profile currently selected in the UI. It requires:
-
-- a name;
-- an email address;
-- at least one work-experience or education entry;
-- at least one skill.
-
-The separate 0–100% completeness score is advisory. Optional recommendations such as a professional summary, projects, or certifications do not block readiness and do not guarantee hiring outcomes.
-
-**AI Ready** requires an active provider and model, an active credential when the provider needs one, and a successful connection test for that exact configuration. Existing provider configurations require one connection retest after upgrading so ApplyKit can establish the new trusted fingerprint. Ollama remains supported without an API key.
-
-A successful result becomes stale when the provider, model, normalized Base URL, active credential, or credential secret version changes. The checklist can be dismissed globally, but it reappears automatically when its readiness fingerprint changes. Readiness responses contain only identifiers, status, timestamps, and sanitized public messages; they never return provider secrets or raw provider exceptions.
-
-## Deployment Modes
-
-ApplyKit has an explicit deployment boundary:
-
-```env
-DEPLOYMENT_MODE=local   # default; loopback-only browser origins
-DEPLOYMENT_MODE=remote  # protected HTTPS deployment
-```
-
-Local mode allows:
-
-```env
-AUTH_MODE=disabled
-COOKIE_SECURE=false
-CORS_ORIGINS=["http://localhost:5173"]
-```
-
-Local mode rejects LAN addresses, public domains, wildcard origins, credential-bearing URLs, and origins containing paths, queries, or fragments. Switch deliberately to remote mode before exposing ApplyKit beyond loopback.
-
-### Optional protected mode
-
-```env
-AUTH_MODE=disabled  # local mode only
-AUTH_MODE=password  # single-owner protected mode
-```
-
-Protected mode secures the whole installation and every career profile with one owner password. It does not create separate accounts for individual profiles.
-
-When password mode is enabled, the browser redirects an unclaimed installation to `/setup` and an existing protected installation to `/login`.
-
-### First owner setup
-
-Run migrations, start ApplyKit with `AUTH_MODE=password`, then read the backend log:
-
-```bash
-# Docker
-docker compose logs backend
-
-# Manual
-cd backend
-uv run alembic upgrade head
-uv run main.py
-```
-
-Open ApplyKit, paste the one-time token into the setup page, and create the owner password. The token:
-
-- expires after 30 minutes;
-- is stored only as a hash;
-- is replaced when an unclaimed backend restarts;
-- becomes invalid immediately after owner setup.
-
-Owner passwords must contain 12–128 characters. Passphrases are supported without forced uppercase, number, or symbol rules. Passwords are stored as Argon2id PHC hashes.
-
-### Sessions and request protection
-
-- Normal sessions expire 7 days after login.
-- **Remember this device** sessions expire after 30 days.
-- Expiry is absolute and does not extend with activity.
-- The browser warns during the final five minutes and can reauthenticate in a separate tab.
-- Session and CSRF token hashes are stored in SQLite; raw session tokens stay in cookies.
-- Session cookies are `HttpOnly` and `SameSite=Lax`.
-- Mutating requests require a session-bound CSRF token and an allowed `Origin`.
-- Five failed attempts within 10 minutes lock authentication for 15 minutes.
-- Logout revokes the current session. Password reset revokes every session.
-
-Only health checks and the required setup/login endpoints remain public. Application data, AI settings, credentials, and API documentation require authentication in protected mode.
-
-Password changes and signing out other devices are available under **Settings → Security**. ApplyKit displays only the count of other active sessions and does not collect device, IP, or location details for this view.
-
-### Remote HTTPS deployment
-
-Remote mode is fail-closed. The backend will not start unless all required protections are present:
-
-```env
-DEPLOYMENT_MODE=remote
-AUTH_MODE=password
-COOKIE_SECURE=true
-DEBUG=false
-CORS_ORIGINS=["https://applykit.example.com"]
-CREDENTIAL_ENCRYPTION_KEY_FILE=/run/secrets/applykit_credential_key
-```
-
-You may provide `CREDENTIAL_ENCRYPTION_KEY` directly instead of a mounted key file, but configure exactly one source. Prefer a platform-managed secret file where available.
-
-Serve the frontend and API from the same hostname. A reverse proxy can expose the frontend at `/` and forward `/api` to the backend. Build the frontend with the browser-reachable same-origin API path:
-
-```bash
-VITE_API_BASE_URL=https://applykit.example.com/api docker compose up --build
-```
-
-Remote startup is rejected when:
-
-- authentication is disabled;
-- secure cookies are disabled;
-- debug mode is enabled;
-- a CORS origin uses HTTP or a wildcard;
-- an origin contains credentials, paths, queries, or fragments;
-- no external credential encryption key is configured;
-- two encryption-key sources are configured at the same time.
-
-Do not place the browser UI at `app.example.com` while using a host-only API cookie from `api.example.com`. Do not expose ApplyKit through public plain HTTP.
-
-### Forgotten password
-
-There is no email recovery or recovery key. The login page shows these same recovery commands, which must be run from the machine hosting ApplyKit:
-
-```bash
-# Docker
-docker compose exec backend uv run python -m app.cli auth reset-password
-
-# Manual
-cd backend
-uv run python -m app.cli auth reset-password
-```
-
-The reset command asks for the new password twice, clears login lockout, and signs out every active session.
-
-### API documentation
-
-```text
-DEBUG=false
-→ /docs, /redoc, and /openapi.json are disabled
-
-DEBUG=true + DEPLOYMENT_MODE=local + AUTH_MODE=disabled
-→ API documentation is public on loopback
-
-DEPLOYMENT_MODE=remote
-→ DEBUG=true is rejected at startup
-```
-
-## AI Providers and Credentials
-
-Open **AI Settings** from the gear icon to:
-
-- connect and test providers;
-- choose a catalog or supported custom model;
-- save multiple labeled credentials;
-- select an active credential manually;
-- enable automatic failover or round robin.
-
-Manual routing is the default. Automatic modes require at least two enabled credentials and allow 2–5 attempts per operation. Streaming requests are never retried after output has started.
-
-Ollama does not require an API key. Some non-AI features remain usable without configuring a provider.
-
-### Provider-key precautions
-
-Use a dedicated API key for ApplyKit rather than reusing an administrator key. Where the provider supports them, apply:
-
-- the minimum required permissions;
-- spending and rate limits;
-- separate keys for personal and work environments;
-- periodic rotation;
-- immediate revocation after suspected exposure.
-
-## Credential Security
-
-Provider secrets are encrypted with Fernet before database persistence. The database stores encrypted ciphertext, a masked display value, a keyed duplicate-detection fingerprint, and operational metadata. API responses and the frontend receive masked values only.
-
-Credential input remains in component-local browser state and is not written to `localStorage` or `sessionStorage`. Provider failures return fixed public messages, and credential-bearing exception text is excluded from application logs and usage records.
-
-Local installations create a persistent fallback key at:
-
-```text
-backend/.applykit/credential.key
-```
-
-Docker stores the active key separately at:
-
-```text
-/run/applykit-secrets/credential.key
-```
-
-During an upgrade, ApplyKit can migrate the old Docker key from `/data/credential.key`. It copies the key atomically, verifies every encrypted credential, and removes the old key only after successful validation. If validation fails, startup stops and the old key is preserved.
-
-ApplyKit will not create a replacement key when encrypted credentials already exist. A missing, wrong, or corrupted key causes startup to fail rather than silently making stored credentials unreadable.
-
-Generate a Fernet key with:
-
-```bash
-python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-```
-
-Never commit an encryption key, bake it into a container image, or print it in CI logs.
-
-## Backup and Restore
-
-Treat the database and encryption key as separate sensitive assets. Both are needed to restore encrypted provider credentials, but they should not be kept in the same unrestricted backup location.
-
-Back up Docker application data:
-
-```bash
-mkdir -p backups/data backups/secrets
-
-docker run --rm \
-  -v applykit_applykit-data:/source:ro \
-  -v "$(pwd)/backups/data":/backup \
-  alpine tar czf /backup/applykit-data.tar.gz -C /source .
-```
-
-Back up the local Docker encryption key separately:
-
-```bash
-docker run --rm \
-  -v applykit_applykit-secrets:/source:ro \
-  -v "$(pwd)/backups/secrets":/backup \
-  alpine tar czf /backup/applykit-secrets.tar.gz -C /source .
-```
-
-Store and access-control these archives separately. A database backup alone cannot decrypt provider credentials. A key alone does not contain the credentials. Anyone who obtains both may be able to decrypt them.
-
-Losing the encryption key makes existing encrypted credentials unrecoverable. Revoke and replace the affected keys at each provider.
-
-Do not change or delete the encryption key without a supported credential-rotation procedure. ApplyKit does not yet provide encryption-key rotation or a rotation UI.
-
-## Security Boundaries
-
-Credential encryption materially reduces exposure from a database-only leak, but it cannot protect against every threat. ApplyKit does not claim protection from:
-
-- an administrator or attacker with access to both the database and encryption key;
-- malware or a malicious browser extension observing a key while it is entered;
-- memory inspection by a privileged attacker during a provider request;
-- a compromised AI provider account;
-- secrets already copied into historical backups or external logs before an upgrade.
-
-## Configuration
-
-Common local backend variables in `backend/.env`:
-
-```env
-DEPLOYMENT_MODE=local
-DATABASE_URL=sqlite:///./applykit.db
-AUTH_MODE=disabled
-COOKIE_SECURE=false
-DEBUG=false
-CORS_ORIGINS=["http://localhost:5173"]
-CREDENTIAL_KEY_FILE=.applykit/credential.key
-MAX_PROVIDER_CREDENTIALS=20
-```
-
-Managed remote deployments must configure either:
-
-```env
-CREDENTIAL_ENCRYPTION_KEY=<persistent-fernet-key>
-```
-
-or:
-
-```env
-CREDENTIAL_ENCRYPTION_KEY_FILE=/run/secrets/applykit_credential_key
-```
-
-For a remote frontend build, use the browser-reachable same-host API URL described under remote HTTPS deployment.
-
-## Stack
-
-- **Frontend:** SvelteKit 2, Svelte 5, TypeScript, Tailwind CSS
-- **Backend:** FastAPI, Python 3.12, SQLAlchemy, Alembic
-- **Database:** SQLite by default
-- **Authentication:** optional Argon2id owner password and opaque database sessions
-- **Credential encryption:** Fernet authenticated encryption
-- **AI:** LiteLLM
-- **PDF:** WeasyPrint
-- **Scraping:** direct ATS APIs, Jina Reader, and Crawl4AI fallback
-
-## Useful Commands
+## Useful commands
 
 ```bash
 make install
@@ -385,13 +118,19 @@ docker compose exec backend uv run alembic upgrade head
 docker compose exec backend uv run python -m app.cli auth reset-password
 ```
 
-## Supported Job Sources
+## Stack
 
-ApplyKit has direct parsing for Greenhouse, Lever, and Ashby. Other accessible job pages use the generic scraping and LLM extraction flow.
+- **Frontend:** SvelteKit 2, Svelte 5, TypeScript, Tailwind CSS
+- **Backend:** FastAPI, Python 3.12, SQLAlchemy, Alembic
+- **Database:** SQLite by default
+- **Authentication:** optional Argon2id owner password and opaque database sessions
+- **Credential encryption:** Fernet authenticated encryption
+- **AI:** LiteLLM with hosted providers and Ollama support
+- **PDF:** WeasyPrint
 
 ## Contributing
 
-Focused pull requests are welcome. Follow the existing FastAPI and Svelte 5 patterns, add tests for behavior changes, and keep the local-first design intact.
+Focused pull requests are welcome. Follow existing FastAPI and Svelte patterns, add regression coverage for behavior changes, and keep the local-first design intact.
 
 ```bash
 bun install

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "0.1.0"
+version = "0.2.0"
 description = "Add your description here"
 requires-python = ">=3.12"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/guides/ai-providers.md
+++ b/guides/ai-providers.md
@@ -1,0 +1,50 @@
+# AI providers
+
+Open **AI Settings** to connect providers, select models, manage credentials, configure routing, and test the active configuration.
+
+## Models
+
+ApplyKit includes a release-managed provider/model catalog and supports validated custom model IDs where the provider allows them. A selected model is shown as Catalog, Custom, or Unavailable when it is no longer present in the current catalog.
+
+## Credentials
+
+Remote providers can store multiple labeled credentials. Secrets are encrypted before database persistence and returned to the frontend only as masked metadata.
+
+Available operations include:
+
+- add, rename, replace, test, activate, and remove credentials;
+- enable or disable credentials;
+- inspect health, cooldown, priority, and last-used metadata;
+- disconnect a provider and remove its provider-specific configuration.
+
+Ollama is keyless and does not require a placeholder API key.
+
+## Routing strategies
+
+- **Manual:** use only the active credential.
+- **Automatic failover:** try the active credential, then eligible credentials by priority.
+- **Round robin:** begin at the persisted cursor and advance after a successful request.
+
+Automatic strategies require at least two enabled credentials and use bounded attempts. Authentication failures disable the affected credential; rate limits and safe transient failures use cooldowns. Streaming requests are never retried after output has begun.
+
+## Ollama
+
+The default Base URL is:
+
+```text
+http://localhost:11434
+```
+
+You may configure local, LAN, domain, or reverse-proxy HTTP/HTTPS endpoints. ApplyKit normalizes trailing slashes, rejects malformed URLs, and does not append `/v1` automatically.
+
+## AI readiness
+
+AI Ready requires:
+
+- an active provider and model;
+- an active credential when the provider requires one;
+- a successful connection test for that exact configuration.
+
+The trusted fingerprint includes provider, model, normalized Base URL, and active credential ID/version. Changing any of them invalidates the prior result. Existing installations need one successful retest after upgrading to v0.2.0.
+
+Connection failures are exposed through sanitized public categories such as authentication failure, endpoint unreachable, unavailable model, rate limit, or configuration changed. Raw provider exceptions and secrets are not returned.

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -1,0 +1,61 @@
+# Authentication
+
+ApplyKit provides optional single-owner authentication. It protects one installation and all career profiles with one owner password; it is not a multi-user account system.
+
+## Modes
+
+```env
+AUTH_MODE=disabled
+AUTH_MODE=password
+```
+
+`disabled` is allowed only for local mode. Remote deployments require `password`.
+
+## First owner setup
+
+Run migrations and start ApplyKit with `AUTH_MODE=password`. Read the backend log for the one-time setup token:
+
+```bash
+# Docker
+docker compose logs backend
+
+# Manual
+cd backend
+uv run alembic upgrade head
+uv run main.py
+```
+
+Open `/setup`, enter the token, and create the owner password. The token expires after 30 minutes, is stored only as a hash, and becomes invalid after owner setup.
+
+Passwords support 12–128 character passphrases and are stored as Argon2id hashes.
+
+## Sessions and request protection
+
+- Normal sessions expire after 7 days.
+- **Remember this device** sessions expire after 30 days.
+- Expiry is absolute and does not extend with activity.
+- Session and CSRF token hashes are stored in SQLite; raw session tokens remain in `HttpOnly`, `SameSite=Lax` cookies.
+- Mutating requests require a session-bound CSRF token and an allowed `Origin`.
+- Five failed login attempts within 10 minutes trigger a 15-minute lockout.
+- Password reset revokes all sessions.
+
+The browser warns during the final five minutes. Supported forms can recover temporary per-tab drafts after reauthentication; uploaded files are never persisted for draft recovery.
+
+## Forgotten password
+
+There is no email recovery. Run the reset command on the machine hosting ApplyKit:
+
+```bash
+# Docker
+docker compose exec backend uv run python -m app.cli auth reset-password
+
+# Manual
+cd backend
+uv run python -m app.cli auth reset-password
+```
+
+The command asks for the new password twice, clears login lockout, and revokes every active session.
+
+## Remote deployment requirement
+
+Use HTTPS and serve the frontend and API from the same hostname. Do not expose password mode over public plain HTTP or split the UI and API across hostnames that cannot share the required cookie boundary.

--- a/guides/backup-and-restore.md
+++ b/guides/backup-and-restore.md
@@ -1,0 +1,60 @@
+# Backup and restore
+
+The database and credential encryption key are separate sensitive assets. Both are required to restore encrypted provider credentials, but they should not be stored together in one unrestricted location.
+
+## Docker backup
+
+Create local backup directories:
+
+```bash
+mkdir -p backups/data backups/secrets
+```
+
+Back up application data:
+
+```bash
+docker run --rm \
+  -v applykit_applykit-data:/source:ro \
+  -v "$(pwd)/backups/data":/backup \
+  alpine tar czf /backup/applykit-data.tar.gz -C /source .
+```
+
+Back up the credential key separately:
+
+```bash
+docker run --rm \
+  -v applykit_applykit-secrets:/source:ro \
+  -v "$(pwd)/backups/secrets":/backup \
+  alpine tar czf /backup/applykit-secrets.tar.gz -C /source .
+```
+
+Store the archives separately and restrict access to both.
+
+## Manual backup
+
+Stop the backend before copying SQLite files. Back up:
+
+```text
+backend/applykit.db
+backend/.applykit/credential.key
+```
+
+Keep the database and key in separate protected locations. Also preserve the deployed Git tag and a copy of non-secret configuration values.
+
+## Restore order
+
+1. Stop ApplyKit.
+2. Restore application data to its original path or volume.
+3. Restore the matching credential key to its original path or volume.
+4. Apply restrictive file permissions where supported.
+5. Check out the same Git tag used when the backup was created.
+6. Start ApplyKit and verify it can decrypt credentials.
+7. Upgrade only after the restored installation works.
+
+Do not allow the application to generate a new local key before restoring the original one.
+
+## Lost key
+
+Losing the credential encryption key makes existing encrypted provider credentials unrecoverable. Profile, CV, history, and tracker data may still be recoverable from the database, but affected provider credentials must be revoked and replaced.
+
+Anyone who obtains both the database and key may be able to decrypt provider credentials. Treat both backups as sensitive even when stored separately.

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -1,0 +1,69 @@
+# Configuration
+
+Backend configuration is loaded from `backend/.env` for manual installations and from Docker Compose environment values for containers.
+
+## Common local settings
+
+```env
+DEPLOYMENT_MODE=local
+DATABASE_URL=sqlite:///./applykit.db
+AUTH_MODE=disabled
+COOKIE_SECURE=false
+DEBUG=false
+CORS_ORIGINS=["http://localhost:5173"]
+CREDENTIAL_KEY_FILE=.applykit/credential.key
+MAX_PROVIDER_CREDENTIALS=20
+```
+
+Local mode is intentionally loopback-only. It rejects public domains, LAN origins, wildcard origins, and malformed browser origins.
+
+## Deployment modes
+
+### Local
+
+```env
+DEPLOYMENT_MODE=local
+AUTH_MODE=disabled
+COOKIE_SECURE=false
+```
+
+Use this for a single machine accessed through localhost.
+
+### Remote
+
+Remote mode is fail-closed and requires all of the following:
+
+```env
+DEPLOYMENT_MODE=remote
+AUTH_MODE=password
+COOKIE_SECURE=true
+DEBUG=false
+CORS_ORIGINS=["https://applykit.example.com"]
+CREDENTIAL_ENCRYPTION_KEY_FILE=/run/secrets/applykit_credential_key
+```
+
+You may configure `CREDENTIAL_ENCRYPTION_KEY` instead of a key file, but configure exactly one external key source. Prefer a platform-managed secret file.
+
+Serve the frontend and API from the same hostname. Build the frontend with a browser-reachable API URL, for example:
+
+```bash
+VITE_API_BASE_URL=https://applykit.example.com/api docker compose up --build
+```
+
+Remote startup is rejected when authentication or secure cookies are disabled, debug mode is enabled, HTTPS/CORS rules are invalid, or no external credential key is configured.
+
+## Database
+
+SQLite is the default:
+
+```env
+DATABASE_URL=sqlite:///./applykit.db
+```
+
+Manual commands resolve this relative to the `backend` directory. Use the provided `make` targets from the repository root to keep working directories consistent.
+
+## API documentation
+
+- `DEBUG=false`: `/docs`, `/redoc`, and `/openapi.json` are disabled.
+- Local, unauthenticated development with `DEBUG=true`: API documentation is available on loopback.
+- Remote mode rejects `DEBUG=true`.

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -1,0 +1,84 @@
+# Installation
+
+ApplyKit supports a stable Docker setup and a manual development setup. For normal self-hosted use, prefer a published Git tag rather than `main`.
+
+## Docker installation from the latest stable tag
+
+### Linux, macOS, Git Bash, or WSL
+
+```bash
+git clone https://github.com/wihlarkop/applykit.git
+cd applykit
+git fetch --tags
+git checkout "$(git describe --tags --abbrev=0)"
+docker compose up --build
+```
+
+### Windows PowerShell
+
+```powershell
+git clone https://github.com/wihlarkop/applykit.git
+cd applykit
+git fetch --tags
+$tag = git describe --tags --abbrev=0
+git checkout $tag
+docker compose up --build
+```
+
+Open:
+
+- frontend: `http://localhost:3000`
+- backend: `http://localhost:8000`
+
+The backend container runs `alembic upgrade head` before serving requests.
+
+## Persistent Docker storage
+
+Docker Compose uses separate volumes:
+
+- `applykit_applykit-data` for SQLite and application data;
+- `applykit_applykit-secrets` for the local credential encryption key.
+
+Both are required to restore encrypted provider credentials. Keep their backups separate and access-controlled.
+
+## Manual development setup
+
+Requirements:
+
+- Python 3.12 managed through `uv`;
+- Bun;
+- system libraries required by WeasyPrint on your operating system.
+
+```bash
+git clone https://github.com/wihlarkop/applykit.git
+cd applykit
+git switch main
+cp backend/.env.example backend/.env
+make install
+make migrate
+```
+
+Run each service in a separate terminal:
+
+```bash
+make backend
+make frontend
+```
+
+The development frontend is available at `http://localhost:5173`; the backend is at `http://localhost:8000`.
+
+## First launch
+
+A genuinely fresh installation opens guided setup once. You may configure a career profile and AI provider or choose **Skip for now**. Skipping does not lock non-AI features.
+
+Profile Ready requires a name, email, at least one work-experience or education entry, and at least one skill. AI Ready requires a selected provider/model and a successful connection test for the active configuration.
+
+## Local files
+
+With the default manual configuration:
+
+- database: `backend/applykit.db`;
+- credential key: `backend/.applykit/credential.key`;
+- environment file: `backend/.env`.
+
+Never commit `.env`, the database, or the credential key.

--- a/guides/security.md
+++ b/guides/security.md
@@ -1,0 +1,50 @@
+# Security
+
+ApplyKit is local-first and self-hosted, but secure operation still depends on correct deployment, backups, provider-key permissions, and host security.
+
+## Credential encryption
+
+Provider secrets are encrypted with Fernet before database persistence. The database stores ciphertext, a masked display value, a keyed duplicate-detection fingerprint, and operational metadata.
+
+Local manual installations create the key at:
+
+```text
+backend/.applykit/credential.key
+```
+
+Docker stores it separately from application data at:
+
+```text
+/run/applykit-secrets/credential.key
+```
+
+During an upgrade, ApplyKit can migrate a legacy Docker key from `/data/credential.key`. It copies the key atomically, validates encrypted credentials, and removes the old copy only after successful validation.
+
+ApplyKit refuses to create a replacement key when encrypted credentials already exist. A missing, corrupted, or incorrect key stops startup rather than making stored credentials unreadable.
+
+## Deployment boundary
+
+- Local mode accepts loopback browser origins only.
+- Remote mode requires password authentication, HTTPS origins, secure cookies, disabled debug mode, and an external encryption key.
+- Scraping rejects private-network and unsafe URLs before network access.
+- Public errors, usage records, audit events, and connection results exclude raw provider exceptions and plaintext secrets.
+- Untrusted CV and job-description content is isolated in LLM prompts and structured responses are validated.
+
+## Provider-key precautions
+
+Use a dedicated provider key with:
+
+- minimum required permissions;
+- spending and rate limits;
+- separate personal and work credentials;
+- immediate revocation after suspected exposure.
+
+## Limitations
+
+Credential encryption does not protect against an administrator or attacker who obtains both the database and key, privileged memory inspection, malware observing a key during entry, compromised provider accounts, or secrets already present in old external logs/backups.
+
+ApplyKit does not currently provide encryption-key rotation or a rotation UI. Do not change or delete the key without a supported migration procedure.
+
+## Reporting
+
+When reporting a security problem, do not include API keys, passwords, session tokens, encryption keys, private CV content, or database files in public issues.

--- a/guides/upgrading.md
+++ b/guides/upgrading.md
@@ -1,0 +1,63 @@
+# Upgrading
+
+Upgrade the database and credential key as a matched installation. A database backup alone cannot restore encrypted provider credentials.
+
+## Before upgrading
+
+1. Stop ApplyKit.
+2. Back up application data.
+3. Back up the credential encryption key separately.
+4. Record the currently deployed Git tag.
+5. Read the target release notes and migration guidance.
+
+See [Backup and restore](backup-and-restore.md) for commands.
+
+## Docker tag upgrade
+
+```bash
+git fetch --tags
+git checkout v0.2.0
+docker compose up --build
+```
+
+The backend entrypoint runs Alembic migrations automatically before startup. Watch the backend logs:
+
+```bash
+docker compose logs -f backend
+```
+
+Do not switch a stable installation to `main` merely to receive unreleased changes.
+
+## Manual upgrade
+
+From the repository root:
+
+```bash
+git switch main
+git pull --ff-only
+make install
+make migrate
+```
+
+Then restart:
+
+```bash
+make backend
+make frontend
+```
+
+Running `make backend` before `make migrate` may stop startup with a database-schema message. Do not replace the credential key in response; migrate the database first.
+
+## After upgrading
+
+- Sign in and verify profiles, history, and tracker data.
+- Open AI Settings and test the configured provider.
+- Existing configurations need one successful retest to establish the readiness fingerprint.
+- Generate a small CV or cover-letter test before relying on the installation.
+- Confirm Docker volumes or manual storage paths still point to the expected data and key.
+
+## Rollback cautions
+
+Application code can be checked out at an older tag, but database downgrades are not performed automatically. Do not point older code at a schema it does not understand.
+
+The safest rollback is restoring both the pre-upgrade database backup and its matching credential-key backup, then checking out the previous tag. Keep the failed upgrade data untouched until recovery is confirmed.


### PR DESCRIPTION
## Summary

Prepare ApplyKit for the `v0.2.0` release without creating a tag or GitHub Release yet.

- synchronize backend and frontend package versions to `0.2.0`
- replace the long README with a concise project overview and quick start
- add focused installation, configuration, upgrade, migration, development, troubleshooting, and release guides
- add a changelog covering the upcoming `v0.2.0` release
- document stable installs from Git tags while keeping `main` identified as the development branch

## Release boundary

This PR only prepares the repository. It does **not** create a tag or GitHub Release.

## Verification

- [ ] backend tests
- [ ] frontend tests/check/build
- [ ] lockfile consistency
- [ ] documentation link review
- [ ] GitHub Actions green