### PR TITLE
fix: correct release version to v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to ApplyKit are documented here.
 
-The project follows Semantic Versioning while it remains pre-1.0. Minor releases may introduce substantial features or configuration changes; upgrade notes call out required operator actions.
+The project follows Semantic Versioning. Minor releases add backward-compatible features, while major releases are reserved for breaking changes.
 
-## [0.2.0] - 2026-08-04
+## [1.2.0] - 2026-08-04
 
 ### Added
 
@@ -38,4 +38,4 @@ The project follows Semantic Versioning while it remains pre-1.0. Minor releases
 - Do not replace or delete the credential encryption key. Existing encrypted provider credentials require the original key.
 - Existing AI configurations require one successful connection retest after upgrading so ApplyKit can establish the new readiness fingerprint.
 
-[0.2.0]: https://github.com/wihlarkop/applykit/releases/tag/v0.2.0
+[1.2.0]: https://github.com/wihlarkop/applykit/releases/tag/v1.2.0

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "0.2.0"
+version = "1.2.0"
 description = "Add your description here"
 requires-python = ">=3.12"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.2.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/guides/ai-providers.md
+++ b/guides/ai-providers.md
@@ -45,6 +45,6 @@ AI Ready requires:
 - an active credential when the provider requires one;
 - a successful connection test for that exact configuration.
 
-The trusted fingerprint includes provider, model, normalized Base URL, and active credential ID/version. Changing any of them invalidates the prior result. Existing installations need one successful retest after upgrading to v0.2.0.
+The trusted fingerprint includes provider, model, normalized Base URL, and active credential ID/version. Changing any of them invalidates the prior result. Existing installations need one successful retest after upgrading to v1.2.0.
 
 Connection failures are exposed through sanitized public categories such as authentication failure, endpoint unreachable, unavailable model, rate limit, or configuration changed. Raw provider exceptions and secrets are not returned.

--- a/guides/upgrading.md
+++ b/guides/upgrading.md
@@ -16,7 +16,7 @@ See [Backup and restore](backup-and-restore.md) for commands.
 
 ```bash
 git fetch --tags
-git checkout v0.2.0
+git checkout v1.2.0
 docker compose up --build
 ```
 


### PR DESCRIPTION
## Summary

Correct the mistakenly prepared `v0.2.0` release metadata to continue ApplyKit's existing `v1.x` release history.

## Changes

- update backend package version from `0.2.0` to `1.2.0`
- update frontend package version from `0.2.0` to `1.2.0`
- rename the changelog entry and release link to `1.2.0` / `v1.2.0`
- remove the obsolete pre-1.0 changelog wording
- update upgrade and AI readiness documentation to reference `v1.2.0`

## Release handling

The deleted `v0.2.0` tag and release are not recreated. After this PR is merged and CI is green, the release should use tag `v1.2.0`.
