### PR TITLE
feat: add deterministic role match engine

### DIFF
--- a/backend/app/role_match/__init__.py
+++ b/backend/app/role_match/__init__.py
@@ -1,0 +1,5 @@
+"""Deterministic Role Evidence Match engine."""
+
+from app.role_match.constants import PROMPT_VERSION, RULES_VERSION
+
+__all__ = ["PROMPT_VERSION", "RULES_VERSION"]

--- a/backend/app/role_match/clustering.py
+++ b/backend/app/role_match/clustering.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from difflib import SequenceMatcher
+
+from app.role_match.constants import (
+    AUTOMATIC_CLUSTER_SIMILARITY,
+    CLUSTER_REVIEW_SIMILARITY,
+)
+from app.role_match.domain import (
+    AtomicRequirement,
+    ClusteringConflict,
+    ClusteringResult,
+    ClusteringReviewCandidate,
+    RequirementCluster,
+    RequirementImportance,
+)
+
+_IMPORTANCE_ORDER = {
+    RequirementImportance.SUPPORTING: 0,
+    RequirementImportance.IMPORTANT: 1,
+    RequirementImportance.CRITICAL: 2,
+}
+
+
+def normalize_canonical_key(value: str) -> str:
+    tokens = re.findall(r"[a-z0-9+#.]+", value.casefold())
+    return "-".join(tokens)
+
+
+def _tokens(value: str) -> set[str]:
+    return set(re.findall(r"[a-z0-9+#.]+", value.casefold()))
+
+
+def requirement_similarity(left: str, right: str) -> float:
+    left_tokens = _tokens(left)
+    right_tokens = _tokens(right)
+    if not left_tokens or not right_tokens:
+        return 0.0
+    jaccard = len(left_tokens & right_tokens) / len(left_tokens | right_tokens)
+    sequence = SequenceMatcher(None, " ".join(sorted(left_tokens)), " ".join(sorted(right_tokens))).ratio()
+    return (jaccard + sequence) / 2
+
+
+def _compatible(left: AtomicRequirement, right: AtomicRequirement) -> bool:
+    return (
+        left.primary_category == right.primary_category
+        and left.is_eligibility == right.is_eligibility
+        and left.is_trainable == right.is_trainable
+        and left.tool_specificity == right.tool_specificity
+    )
+
+
+def _build_cluster(key: str, items: list[AtomicRequirement]) -> RequirementCluster:
+    importance_mentions = {importance: 0 for importance in RequirementImportance}
+    for item in items:
+        importance_mentions[item.importance] += 1
+    importance = max((item.importance for item in items), key=_IMPORTANCE_ORDER.get)
+    importance_conflict = sum(1 for count in importance_mentions.values() if count) > 1
+    minimum_months_values = [item.minimum_months for item in items if item.minimum_months is not None]
+    minimum_months = max(minimum_months_values) if minimum_months_values else None
+    representative = items[0]
+    return RequirementCluster(
+        cluster_id=f"req:{key}",
+        canonical_requirement=representative.text,
+        canonical_key=key,
+        primary_category=representative.primary_category,
+        importance=importance,
+        mention_count=len(items),
+        importance_conflict=importance_conflict,
+        importance_mentions=importance_mentions,
+        source_quotes=[item.source_quote for item in items],
+        source_ids=[item.source_id for item in items],
+        is_eligibility=representative.is_eligibility,
+        is_trainable=representative.is_trainable,
+        volatility=representative.volatility,
+        minimum_months=minimum_months,
+        tool_specificity=representative.tool_specificity,
+        excluded=all(item.excluded for item in items),
+        exclusion_reason=next((item.exclusion_reason for item in items if item.exclusion_reason), None),
+    )
+
+
+def cluster_requirements(requirements: list[AtomicRequirement]) -> ClusteringResult:
+    grouped: dict[str, list[AtomicRequirement]] = defaultdict(list)
+    for requirement in requirements:
+        key = normalize_canonical_key(requirement.canonical_key or requirement.text)
+        grouped[key].append(requirement)
+
+    clusters: list[RequirementCluster] = []
+    conflicts: list[ClusteringConflict] = []
+    pending: list[tuple[str, list[AtomicRequirement]]] = []
+
+    for key, items in grouped.items():
+        representative = items[0]
+        if any(not _compatible(representative, item) for item in items[1:]):
+            conflicts.append(
+                ClusteringConflict(
+                    canonical_key=key,
+                    source_ids=[item.source_id for item in items],
+                    reason="same_canonical_key_has_materially_different_classification",
+                )
+            )
+            continue
+        pending.append((key, items))
+
+    review_candidates: list[ClusteringReviewCandidate] = []
+    consumed: set[str] = set()
+    for index, (key, items) in enumerate(pending):
+        if key in consumed:
+            continue
+        combined = list(items)
+        for other_key, other_items in pending[index + 1 :]:
+            if other_key in consumed:
+                continue
+            similarity = requirement_similarity(
+                " ".join(item.text for item in items),
+                " ".join(item.text for item in other_items),
+            )
+            if similarity >= AUTOMATIC_CLUSTER_SIMILARITY and _compatible(items[0], other_items[0]):
+                combined.extend(other_items)
+                consumed.add(other_key)
+            elif similarity >= CLUSTER_REVIEW_SIMILARITY:
+                review_candidates.append(
+                    ClusteringReviewCandidate(
+                        left_key=key,
+                        right_key=other_key,
+                        similarity=round(similarity, 6),
+                    )
+                )
+        clusters.append(_build_cluster(key, combined))
+
+    return ClusteringResult(
+        clusters=clusters,
+        review_candidates=review_candidates,
+        unresolved_conflicts=conflicts,
+    )

--- a/backend/app/role_match/confidence.py
+++ b/backend/app/role_match/confidence.py
@@ -1,0 +1,46 @@
+from app.role_match.constants import CONFIDENCE_WEIGHTS, DISPLAY_RULES
+from app.role_match.domain import (
+    ConfidenceAssessment,
+    ConfidenceBand,
+    ConfidenceInputs,
+    DisplayDecision,
+)
+
+
+def calculate_confidence(inputs: ConfidenceInputs) -> ConfidenceAssessment:
+    score = (
+        inputs.known_coverage * CONFIDENCE_WEIGHTS["known_coverage"]
+        + inputs.evidence_reliability * CONFIDENCE_WEIGHTS["evidence_reliability"]
+        + inputs.evidence_consistency * CONFIDENCE_WEIGHTS["evidence_consistency"]
+    )
+    if score >= 0.80:
+        band = ConfidenceBand.HIGH
+        explanation = "Based on several direct and consistent examples from the profile."
+    elif score >= 0.55:
+        band = ConfidenceBand.MEDIUM
+        explanation = "Some important requirements rely on indirect or incomplete evidence."
+    else:
+        band = ConfidenceBand.LOW
+        explanation = "Too much information is missing or inconsistent for a confident assessment."
+    return ConfidenceAssessment(score=score, band=band, explanation=explanation)
+
+
+def decide_authoritative_display(
+    *,
+    known_coverage: float,
+    confidence: float,
+    conflict_rate: float,
+    requirement_count: int,
+    scoring_succeeded: bool,
+) -> DisplayDecision:
+    if not scoring_succeeded:
+        return DisplayDecision(show_score=False, reason="scoring_failed")
+    if requirement_count < DISPLAY_RULES.minimum_atomic_requirements:
+        return DisplayDecision(show_score=False, reason="insufficient_requirements")
+    if known_coverage < DISPLAY_RULES.minimum_known_coverage:
+        return DisplayDecision(show_score=False, reason="insufficient_known_coverage")
+    if confidence < DISPLAY_RULES.minimum_confidence:
+        return DisplayDecision(show_score=False, reason="low_confidence")
+    if conflict_rate > DISPLAY_RULES.maximum_unresolved_conflict_rate:
+        return DisplayDecision(show_score=False, reason="too_many_unresolved_conflicts")
+    return DisplayDecision(show_score=True)

--- a/backend/app/role_match/constants.py
+++ b/backend/app/role_match/constants.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass
+
+from app.role_match.domain import (
+    EvidenceDepth,
+    EvidenceRelationship,
+    EvidenceSource,
+    RequirementCategory,
+    RequirementImportance,
+)
+
+RULES_VERSION = "role-match-v1"
+PROMPT_VERSION = "role-match-extraction-v1"
+
+CATEGORY_WEIGHTS = {
+    RequirementCategory.ESSENTIAL_QUALIFICATIONS: 0.30,
+    RequirementCategory.RELEVANT_COMPETENCIES: 0.30,
+    RequirementCategory.RELEVANT_WORK_TASKS: 0.25,
+    RequirementCategory.PREFERRED_QUALIFICATIONS: 0.10,
+    RequirementCategory.CONTEXTUAL_ALIGNMENT: 0.05,
+}
+
+IMPORTANCE_WEIGHTS = {
+    RequirementImportance.CRITICAL: 1.00,
+    RequirementImportance.IMPORTANT: 0.70,
+    RequirementImportance.SUPPORTING: 0.40,
+}
+
+SOURCE_MULTIPLIERS = {
+    EvidenceSource.WORK_EXPERIENCE: 1.00,
+    EvidenceSource.PROJECT: 0.80,
+    EvidenceSource.CERTIFICATION_EDUCATION: 0.60,
+    EvidenceSource.SKILLS_LIST: 0.35,
+}
+
+DEPTH_MULTIPLIERS = {
+    EvidenceDepth.PRODUCTION_OWNERSHIP: 1.00,
+    EvidenceDepth.HANDS_ON_CONTRIBUTION: 0.80,
+    EvidenceDepth.EXPOSURE_ONLY: 0.45,
+}
+
+RELATIONSHIP_MULTIPLIERS = {
+    EvidenceRelationship.EXACT: 1.00,
+    EvidenceRelationship.FUNCTIONAL_EQUIVALENT: 0.75,
+    EvidenceRelationship.ADJACENT: 0.40,
+    EvidenceRelationship.UNRELATED: 0.00,
+}
+
+CONFIDENCE_WEIGHTS = {
+    "known_coverage": 0.45,
+    "evidence_reliability": 0.35,
+    "evidence_consistency": 0.20,
+}
+
+UNSUPPORTED_ESSENTIAL_CAPS = {1: 74, 2: 59, 3: 44}
+UNKNOWN_ESSENTIAL_CAPS = {1: 89, 2: 79, 3: 69}
+
+AUTOMATIC_CLUSTER_SIMILARITY = 0.88
+CLUSTER_REVIEW_SIMILARITY = 0.72
+AUTOMATIC_OVERRIDE_CARRY_SIMILARITY = 0.92
+OVERRIDE_REVIEW_SIMILARITY = 0.75
+EXTRACTION_ATTEMPTS = 2
+
+
+@dataclass(frozen=True)
+class DisplayRules:
+    minimum_known_coverage: float = 0.60
+    minimum_confidence: float = 0.55
+    maximum_unresolved_conflict_rate: float = 0.20
+    minimum_atomic_requirements: int = 3
+
+
+DISPLAY_RULES = DisplayRules()

--- a/backend/app/role_match/dates.py
+++ b/backend/app/role_match/dates.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+
+from app.role_match.domain import EvidenceCatalogItem, EvidenceSource
+
+_OPEN_ENDED = {"present", "current", "now", "ongoing"}
+_FORMATS = ("%Y-%m-%d", "%Y-%m", "%b %Y", "%B %Y", "%Y")
+
+
+@dataclass(frozen=True, order=True)
+class MonthInterval:
+    start: date
+    end: date
+
+
+def _month_start(value: date) -> date:
+    return date(value.year, value.month, 1)
+
+
+def parse_profile_date(value: str | None, *, end_of_period: bool) -> date | None:
+    del end_of_period
+    if value is None:
+        return None
+    text = value.strip()
+    if not text or text.casefold() in _OPEN_ENDED:
+        return None
+    for fmt in _FORMATS:
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _next_month(value: date) -> date:
+    if value.month == 12:
+        return date(value.year + 1, 1, 1)
+    return date(value.year, value.month + 1, 1)
+
+
+def merge_month_intervals(intervals: list[MonthInterval]) -> list[MonthInterval]:
+    if not intervals:
+        return []
+    normalized = sorted(
+        MonthInterval(_month_start(item.start), _month_start(item.end))
+        for item in intervals
+    )
+    merged: list[MonthInterval] = [normalized[0]]
+    for current in normalized[1:]:
+        previous = merged[-1]
+        if current.start <= _next_month(previous.end):
+            merged[-1] = MonthInterval(previous.start, max(previous.end, current.end))
+        else:
+            merged.append(current)
+    return merged
+
+
+def count_inclusive_months(intervals: list[MonthInterval]) -> int:
+    return sum(
+        (item.end.year - item.start.year) * 12
+        + item.end.month
+        - item.start.month
+        + 1
+        for item in intervals
+    )
+
+
+def calculate_relevant_months(
+    items: list[EvidenceCatalogItem],
+    evidence_ids: set[str],
+    analysis_date: date,
+) -> int | None:
+    intervals: list[MonthInterval] = []
+    matched = [item for item in items if item.evidence_id in evidence_ids]
+    if not matched:
+        return None
+
+    for item in matched:
+        if item.source != EvidenceSource.WORK_EXPERIENCE:
+            continue
+        start = parse_profile_date(item.start_date, end_of_period=False)
+        if start is None:
+            return None
+        if item.end_date and item.end_date.strip().casefold() not in _OPEN_ENDED:
+            end = parse_profile_date(item.end_date, end_of_period=True)
+            if end is None:
+                return None
+        else:
+            end = analysis_date
+        if end < start:
+            return None
+        intervals.append(MonthInterval(start, end))
+
+    if not intervals:
+        return None
+    return count_inclusive_months(merge_month_intervals(intervals))

--- a/backend/app/role_match/domain.py
+++ b/backend/app/role_match/domain.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+from datetime import date
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RequirementCategory(str, Enum):
+    ESSENTIAL_QUALIFICATIONS = "essential_qualifications"
+    RELEVANT_COMPETENCIES = "relevant_competencies"
+    RELEVANT_WORK_TASKS = "relevant_work_tasks"
+    PREFERRED_QUALIFICATIONS = "preferred_qualifications"
+    CONTEXTUAL_ALIGNMENT = "contextual_alignment"
+    ELIGIBILITY = "eligibility"
+    TRAINABLE = "trainable"
+
+
+class RequirementImportance(str, Enum):
+    CRITICAL = "critical"
+    IMPORTANT = "important"
+    SUPPORTING = "supporting"
+
+
+class EvidenceSource(str, Enum):
+    WORK_EXPERIENCE = "work_experience"
+    PROJECT = "project"
+    CERTIFICATION_EDUCATION = "certification_education"
+    SKILLS_LIST = "skills_list"
+
+
+class EvidenceDepth(str, Enum):
+    PRODUCTION_OWNERSHIP = "production_ownership"
+    HANDS_ON_CONTRIBUTION = "hands_on_contribution"
+    EXPOSURE_ONLY = "exposure_only"
+
+
+class EvidenceRelationship(str, Enum):
+    EXACT = "exact"
+    FUNCTIONAL_EQUIVALENT = "functional_equivalent"
+    ADJACENT = "adjacent"
+    UNRELATED = "unrelated"
+
+
+class TechnologyVolatility(str, Enum):
+    STABLE = "stable"
+    EVOLVING = "evolving"
+    FAST_MOVING = "fast_moving"
+
+
+class MatchLevel(str, Enum):
+    STRONG = "strong"
+    MODERATE = "moderate"
+    WEAK = "weak"
+    NO_EVIDENCE = "no_evidence"
+    UNKNOWN = "unknown"
+    CONTRADICTORY = "contradictory_evidence"
+
+
+class EligibilityStatus(str, Enum):
+    ELIGIBLE = "eligible"
+    LIKELY_ELIGIBLE = "likely_eligible"
+    UNCLEAR = "eligibility_unclear"
+    LIKELY_INELIGIBLE = "likely_ineligible"
+    INELIGIBLE = "ineligible"
+
+
+class ConfidenceBand(str, Enum):
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class AnalysisState(str, Enum):
+    SUCCESS = "success"
+    NEEDS_REVIEW = "needs_review"
+    FAILED = "failed"
+    EXTRACTED = "extracted"
+
+
+class OverrideCarryStatus(str, Enum):
+    CARRIED_FORWARD = "carried_forward"
+    NEEDS_REVIEW = "needs_review"
+    NOT_APPLICABLE = "not_applicable"
+
+
+ToolSpecificity = Literal["capability", "example_set", "specific", "operational"]
+
+
+class AtomicRequirement(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    source_id: str
+    text: str
+    canonical_key: str
+    primary_category: RequirementCategory
+    importance: RequirementImportance
+    source_quote: str
+    is_eligibility: bool = False
+    is_trainable: bool = False
+    volatility: TechnologyVolatility = TechnologyVolatility.EVOLVING
+    minimum_months: int | None = Field(default=None, ge=0)
+    tool_specificity: ToolSpecificity = "capability"
+    excluded: bool = False
+    exclusion_reason: str | None = None
+
+
+class RequirementCluster(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    cluster_id: str
+    canonical_requirement: str
+    canonical_key: str
+    primary_category: RequirementCategory
+    importance: RequirementImportance
+    mention_count: int = Field(ge=1)
+    importance_conflict: bool
+    importance_mentions: dict[RequirementImportance, int]
+    source_quotes: list[str]
+    source_ids: list[str]
+    is_eligibility: bool
+    is_trainable: bool
+    volatility: TechnologyVolatility
+    minimum_months: int | None = Field(default=None, ge=0)
+    tool_specificity: ToolSpecificity
+    excluded: bool = False
+    exclusion_reason: str | None = None
+
+
+class ClusteringConflict(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    canonical_key: str
+    source_ids: list[str]
+    reason: str
+
+
+class ClusteringReviewCandidate(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    left_key: str
+    right_key: str
+    similarity: float
+
+
+class ClusteringResult(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    clusters: list[RequirementCluster]
+    review_candidates: list[ClusteringReviewCandidate] = []
+    unresolved_conflicts: list[ClusteringConflict] = []
+
+
+class SafeWorkExperience(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    company: str
+    role: str
+    start_date: str | None = None
+    end_date: str | None = None
+    bullets: list[str] = []
+
+
+class SafeEducation(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    institution: str
+    degree: str | None = None
+    field: str | None = None
+    start_date: str | None = None
+    end_date: str | None = None
+
+
+class SafeProject(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    description: str | None = None
+    tech_stack: list[str] = []
+
+
+class SafeCertification(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str | None = None
+    issuer: str | None = None
+    date: str | None = None
+
+
+class SafeProfile(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    location: str | None = None
+    summary: str | None = None
+    work_experience: list[SafeWorkExperience] = []
+    education: list[SafeEducation] = []
+    skills: list[str] = []
+    projects: list[SafeProject] = []
+    certifications: list[SafeCertification] = []
+
+
+class EvidenceCatalogItem(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    evidence_id: str
+    source: EvidenceSource
+    text: str
+    start_date: str | None = None
+    end_date: str | None = None
+    metadata: dict[str, Any] = {}
+    duplicate_key: str | None = None
+
+
+class EvidenceLink(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    requirement_id: str
+    evidence_id: str
+    source: EvidenceSource
+    relationship: EvidenceRelationship
+    depth: EvidenceDepth
+    volatility: TechnologyVolatility = TechnologyVolatility.EVOLVING
+    last_used_date: date | None = None
+    is_current: bool = False
+    is_duplicate: bool = False
+    is_contradiction: bool = False
+    explanation: str = ""
+    precomputed_strength: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
+class RequirementAssessment(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    cluster_id: str
+    category: RequirementCategory
+    importance: RequirementImportance
+    match_level: MatchLevel
+    strength: float | None = Field(default=None, ge=0.0, le=1.0)
+    evidence_links: list[EvidenceLink] = []
+    explanation: str = ""
+    known: bool = True
+    confidence_evidence_count: int = 0
+
+
+class CategoryAssessment(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    category: RequirementCategory
+    score: float = Field(ge=0.0, le=1.0)
+    known_coverage: float = Field(ge=0.0, le=1.0)
+    unknown_coverage: float = Field(ge=0.0, le=1.0)
+    known_match: float = Field(ge=0.0, le=1.0)
+    requirement_count: int = Field(ge=0)
+
+
+class ScoreResult(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    category_assessments: list[CategoryAssessment]
+    raw_score: float = Field(ge=0.0, le=100.0)
+    capped_score: float = Field(ge=0.0, le=100.0)
+    display_score: int = Field(ge=0, le=100)
+    score_band: str
+    applied_cap: int | None = None
+    unsupported_essential_count: int = 0
+    unknown_essential_count: int = 0
+
+
+class ConfidenceInputs(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    known_coverage: float = Field(ge=0.0, le=1.0)
+    evidence_reliability: float = Field(ge=0.0, le=1.0)
+    evidence_consistency: float = Field(ge=0.0, le=1.0)
+
+
+class ConfidenceAssessment(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    score: float = Field(ge=0.0, le=1.0)
+    band: ConfidenceBand
+    explanation: str
+
+
+class EligibilitySignal(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    requirement_id: str
+    mandatory: bool = True
+    explicit_support: bool = False
+    explicit_contradiction: bool = False
+    likely_contradiction: bool = False
+    unknown: bool = True
+    reason: str = ""
+
+
+class EligibilityAssessment(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    status: EligibilityStatus
+    reasons: list[str] = []
+
+
+class DisplayDecision(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    show_score: bool
+    reason: str | None = None
+
+
+class FairnessDecision(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    excluded: bool
+    action: Literal["include", "review", "exclude_warn_continue"]
+    reason: str
+
+
+class AnalysisInsight(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    title: str
+    explanation: str
+    evidence_label: str | None = None
+
+
+class AnalysisSummary(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    headline: str
+    description: str
+    strengths: list[AnalysisInsight] = []
+    concerns: list[AnalysisInsight] = []
+    next_step: str

--- a/backend/app/role_match/eligibility.py
+++ b/backend/app/role_match/eligibility.py
@@ -1,0 +1,32 @@
+from app.role_match.domain import (
+    EligibilityAssessment,
+    EligibilitySignal,
+    EligibilityStatus,
+)
+
+
+def assess_eligibility(signals: list[EligibilitySignal]) -> EligibilityAssessment:
+    mandatory = [signal for signal in signals if signal.mandatory]
+    if not mandatory:
+        return EligibilityAssessment(status=EligibilityStatus.LIKELY_ELIGIBLE)
+    explicit = [signal for signal in mandatory if signal.explicit_contradiction]
+    if explicit:
+        return EligibilityAssessment(
+            status=EligibilityStatus.INELIGIBLE,
+            reasons=[signal.reason for signal in explicit if signal.reason],
+        )
+    likely = [signal for signal in mandatory if signal.likely_contradiction]
+    if likely:
+        return EligibilityAssessment(
+            status=EligibilityStatus.LIKELY_INELIGIBLE,
+            reasons=[signal.reason for signal in likely if signal.reason],
+        )
+    unknown = [signal for signal in mandatory if signal.unknown]
+    if unknown:
+        return EligibilityAssessment(
+            status=EligibilityStatus.UNCLEAR,
+            reasons=[signal.reason for signal in unknown if signal.reason],
+        )
+    if all(signal.explicit_support for signal in mandatory):
+        return EligibilityAssessment(status=EligibilityStatus.ELIGIBLE)
+    return EligibilityAssessment(status=EligibilityStatus.LIKELY_ELIGIBLE)

--- a/backend/app/role_match/evidence_catalog.py
+++ b/backend/app/role_match/evidence_catalog.py
@@ -23,7 +23,7 @@ def build_evidence_catalog(profile: SafeProfile) -> list[EvidenceCatalogItem]:
         items.append(
             EvidenceCatalogItem(
                 evidence_id="summary:0",
-                source=EvidenceSource.WORK_EXPERIENCE,
+                source=EvidenceSource.SKILLS_LIST,
                 text=profile.summary,
                 duplicate_key=_duplicate_key(profile.summary),
                 metadata={"kind": "summary"},

--- a/backend/app/role_match/evidence_catalog.py
+++ b/backend/app/role_match/evidence_catalog.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from app.role_match.domain import EvidenceCatalogItem, EvidenceSource, SafeProfile
+
+
+def _duplicate_key(text: str) -> str:
+    normalized = unicodedata.normalize("NFKC", text).casefold()
+    return " ".join(re.findall(r"[a-z0-9+#.-]+", normalized))
+
+
+def _slug(text: str) -> str:
+    value = _duplicate_key(text).replace(" ", "-")
+    return value or "unnamed"
+
+
+def build_evidence_catalog(profile: SafeProfile) -> list[EvidenceCatalogItem]:
+    items: list[EvidenceCatalogItem] = []
+
+    if profile.summary:
+        items.append(
+            EvidenceCatalogItem(
+                evidence_id="summary:0",
+                source=EvidenceSource.WORK_EXPERIENCE,
+                text=profile.summary,
+                duplicate_key=_duplicate_key(profile.summary),
+                metadata={"kind": "summary"},
+            )
+        )
+
+    for work_index, work in enumerate(profile.work_experience):
+        role_text = f"{work.role} at {work.company}".strip()
+        if role_text:
+            items.append(
+                EvidenceCatalogItem(
+                    evidence_id=f"work:{work_index}:role",
+                    source=EvidenceSource.WORK_EXPERIENCE,
+                    text=role_text,
+                    start_date=work.start_date,
+                    end_date=work.end_date,
+                    duplicate_key=_duplicate_key(role_text),
+                    metadata={"company": work.company, "role": work.role, "kind": "role"},
+                )
+            )
+        for bullet_index, bullet in enumerate(work.bullets):
+            items.append(
+                EvidenceCatalogItem(
+                    evidence_id=f"work:{work_index}:bullet:{bullet_index}",
+                    source=EvidenceSource.WORK_EXPERIENCE,
+                    text=bullet,
+                    start_date=work.start_date,
+                    end_date=work.end_date,
+                    duplicate_key=_duplicate_key(bullet),
+                    metadata={"company": work.company, "role": work.role, "kind": "bullet"},
+                )
+            )
+
+    for project_index, project in enumerate(profile.projects):
+        if project.description:
+            items.append(
+                EvidenceCatalogItem(
+                    evidence_id=f"project:{project_index}:description",
+                    source=EvidenceSource.PROJECT,
+                    text=project.description,
+                    duplicate_key=_duplicate_key(project.description),
+                    metadata={"project": project.name, "kind": "description"},
+                )
+            )
+        for tech_index, tech in enumerate(project.tech_stack):
+            items.append(
+                EvidenceCatalogItem(
+                    evidence_id=f"project:{project_index}:tech:{tech_index}",
+                    source=EvidenceSource.PROJECT,
+                    text=tech,
+                    duplicate_key=_duplicate_key(tech),
+                    metadata={"project": project.name, "kind": "technology"},
+                )
+            )
+
+    for education_index, education in enumerate(profile.education):
+        parts = [education.degree, education.field, education.institution]
+        text = " — ".join(part for part in parts if part)
+        if text:
+            items.append(
+                EvidenceCatalogItem(
+                    evidence_id=f"education:{education_index}",
+                    source=EvidenceSource.CERTIFICATION_EDUCATION,
+                    text=text,
+                    start_date=education.start_date,
+                    end_date=education.end_date,
+                    duplicate_key=_duplicate_key(text),
+                    metadata={"kind": "education"},
+                )
+            )
+
+    for certification_index, certification in enumerate(profile.certifications):
+        parts = [certification.name, certification.issuer]
+        text = " — ".join(part for part in parts if part)
+        if text:
+            items.append(
+                EvidenceCatalogItem(
+                    evidence_id=f"certification:{certification_index}",
+                    source=EvidenceSource.CERTIFICATION_EDUCATION,
+                    text=text,
+                    end_date=certification.date,
+                    duplicate_key=_duplicate_key(text),
+                    metadata={"kind": "certification"},
+                )
+            )
+
+    used_skill_ids: dict[str, int] = {}
+    for skill in profile.skills:
+        base = _slug(skill)
+        occurrence = used_skill_ids.get(base, 0)
+        used_skill_ids[base] = occurrence + 1
+        suffix = "" if occurrence == 0 else f"-{occurrence + 1}"
+        items.append(
+            EvidenceCatalogItem(
+                evidence_id=f"skill:{base}{suffix}",
+                source=EvidenceSource.SKILLS_LIST,
+                text=skill,
+                duplicate_key=_duplicate_key(skill),
+                metadata={"kind": "skill"},
+            )
+        )
+
+    return items

--- a/backend/app/role_match/evidence_strength.py
+++ b/backend/app/role_match/evidence_strength.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from datetime import date
+
+from app.role_match.constants import (
+    DEPTH_MULTIPLIERS,
+    RELATIONSHIP_MULTIPLIERS,
+    SOURCE_MULTIPLIERS,
+)
+from app.role_match.domain import (
+    EvidenceLink,
+    EvidenceRelationship,
+    MatchLevel,
+    RequirementAssessment,
+    RequirementCluster,
+    RequirementImportance,
+    TechnologyVolatility,
+)
+
+
+def _years_since(last_used: date, analysis_date: date) -> float:
+    days = max((analysis_date - last_used).days, 0)
+    return days / 365.2425
+
+
+def calculate_recency_multiplier(
+    volatility: TechnologyVolatility,
+    last_used_date: date | None,
+    analysis_date: date,
+    *,
+    is_current: bool = False,
+) -> float:
+    if is_current or last_used_date is None:
+        return 1.0
+    years = _years_since(last_used_date, analysis_date)
+    if volatility == TechnologyVolatility.STABLE:
+        return 1.0 if years <= 5 else 0.90
+    if volatility == TechnologyVolatility.EVOLVING:
+        if years <= 3:
+            return 1.0
+        if years <= 6:
+            return 0.85
+        return 0.70
+    if years <= 2:
+        return 1.0
+    if years <= 4:
+        return 0.75
+    return 0.50
+
+
+def calculate_base_strength(link: EvidenceLink, analysis_date: date) -> float:
+    if link.precomputed_strength is not None:
+        return link.precomputed_strength
+    recency = calculate_recency_multiplier(
+        link.volatility,
+        link.last_used_date,
+        analysis_date,
+        is_current=link.is_current,
+    )
+    return (
+        RELATIONSHIP_MULTIPLIERS[link.relationship]
+        * SOURCE_MULTIPLIERS[link.source]
+        * DEPTH_MULTIPLIERS[link.depth]
+        * recency
+    )
+
+
+def strength_to_match_level(value: float) -> MatchLevel:
+    if value >= 0.75:
+        return MatchLevel.STRONG
+    if value >= 0.45:
+        return MatchLevel.MODERATE
+    if value >= 0.10:
+        return MatchLevel.WEAK
+    return MatchLevel.NO_EVIDENCE
+
+
+def _relationship_ceiling(
+    requirement: RequirementCluster,
+    links: list[EvidenceLink],
+) -> float:
+    if not links:
+        return 1.0
+    strongest_relationship = max(
+        links,
+        key=lambda item: RELATIONSHIP_MULTIPLIERS[item.relationship],
+    ).relationship
+    if strongest_relationship == EvidenceRelationship.UNRELATED:
+        return 0.0
+    if strongest_relationship == EvidenceRelationship.ADJACENT:
+        return 0.449
+    if strongest_relationship == EvidenceRelationship.FUNCTIONAL_EQUIVALENT:
+        if requirement.tool_specificity == "operational":
+            return 0.449
+        if requirement.tool_specificity == "specific":
+            return 0.749
+    return 1.0
+
+
+def combine_evidence(
+    links: list[EvidenceLink],
+    requirement: RequirementCluster,
+    analysis_date: date,
+) -> RequirementAssessment:
+    if any(link.is_contradiction for link in links):
+        return RequirementAssessment(
+            cluster_id=requirement.cluster_id,
+            category=requirement.primary_category,
+            importance=requirement.importance,
+            match_level=MatchLevel.CONTRADICTORY,
+            strength=0.0,
+            evidence_links=links,
+            explanation="Explicit contradictory evidence was found.",
+            known=True,
+            confidence_evidence_count=len(links),
+        )
+    independent = [link for link in links if not link.is_duplicate]
+    if not independent:
+        return RequirementAssessment(
+            cluster_id=requirement.cluster_id,
+            category=requirement.primary_category,
+            importance=requirement.importance,
+            match_level=MatchLevel.UNKNOWN,
+            strength=None,
+            evidence_links=links,
+            explanation="The available profile information is not sufficient to assess this requirement.",
+            known=False,
+            confidence_evidence_count=len(links),
+        )
+    scored = sorted(
+        (calculate_base_strength(link, analysis_date) for link in independent),
+        reverse=True,
+    )
+    combined = scored[0]
+    if len(scored) > 1:
+        combined += scored[1] * 0.10
+    if len(scored) > 2:
+        combined += scored[2] * 0.03
+    combined = min(combined, 1.0, _relationship_ceiling(requirement, independent))
+    return RequirementAssessment(
+        cluster_id=requirement.cluster_id,
+        category=requirement.primary_category,
+        importance=requirement.importance,
+        match_level=strength_to_match_level(combined),
+        strength=combined,
+        evidence_links=links,
+        explanation="Evidence strength was calculated from relationship, source, depth, recency, and independent corroboration.",
+        known=True,
+        confidence_evidence_count=len(independent),
+    )
+
+
+def assess_duration_requirement(
+    required_months: int,
+    actual_months: int | None,
+    *,
+    cluster_id: str = "duration",
+    category=None,
+    importance: RequirementImportance = RequirementImportance.CRITICAL,
+) -> RequirementAssessment:
+    from app.role_match.domain import RequirementCategory
+
+    resolved_category = category or RequirementCategory.ESSENTIAL_QUALIFICATIONS
+    if actual_months is None:
+        return RequirementAssessment(
+            cluster_id=cluster_id,
+            category=resolved_category,
+            importance=importance,
+            match_level=MatchLevel.UNKNOWN,
+            strength=None,
+            known=False,
+            explanation="The relevant experience duration could not be verified.",
+        )
+    ratio = actual_months / required_months if required_months > 0 else 1.0
+    if ratio >= 1.0:
+        level, strength = MatchLevel.STRONG, 1.0
+        explanation = "Meets or exceeds the stated experience requirement."
+    elif ratio >= 0.85:
+        level, strength = MatchLevel.MODERATE, 0.70
+        years = required_months / 12
+        years_text = str(int(years)) if years.is_integer() else f"{years:g}"
+        explanation = (
+            "Slightly below the stated experience requirement; "
+            f"relevant experience is close to the requested {years_text} years."
+        )
+    elif ratio >= 0.60:
+        level, strength = MatchLevel.WEAK, 0.35
+        explanation = "Relevant experience is meaningfully below the stated duration."
+    else:
+        level, strength = MatchLevel.NO_EVIDENCE, 0.0
+        explanation = "Relevant experience is substantially below the stated duration."
+    return RequirementAssessment(
+        cluster_id=cluster_id,
+        category=resolved_category,
+        importance=importance,
+        match_level=level,
+        strength=strength,
+        known=True,
+        explanation=explanation,
+    )

--- a/backend/app/role_match/fairness.py
+++ b/backend/app/role_match/fairness.py
@@ -1,0 +1,41 @@
+import re
+
+from app.role_match.domain import FairnessDecision
+
+_EXCLUDE_PATTERNS = [
+    re.compile(r"\b(under|below|younger than)\s+\d{2}\b", re.IGNORECASE),
+    re.compile(r"\b(unmarried|single applicants?|marital status|married only)\b", re.IGNORECASE),
+    re.compile(r"\b(male|female|man|woman)\s+(candidate|applicant)?\s*(preferred|required|only)?\b", re.IGNORECASE),
+    re.compile(r"\b(recent|professional)?\s*photo(graph)?\b", re.IGNORECASE),
+    re.compile(r"\b(religion|race|ethnicity)\b", re.IGNORECASE),
+]
+_CITIZENSHIP_PATTERN = re.compile(r"\b(citizen|citizenship|nationality)\b", re.IGNORECASE)
+_LANGUAGE_PATTERN = re.compile(r"\b(language|fluency|fluent|speaking|speakers?)\b", re.IGNORECASE)
+_TASK_REASON_PATTERN = re.compile(r"\b(customer|client|support|translate|translation|localization|work)\b", re.IGNORECASE)
+
+
+def evaluate_requirement_fairness(requirement_text: str) -> FairnessDecision:
+    text = requirement_text.strip()
+    if any(pattern.search(text) for pattern in _EXCLUDE_PATTERNS):
+        return FairnessDecision(
+            excluded=True,
+            action="exclude_warn_continue",
+            reason="potentially_non_job_related",
+        )
+    if _CITIZENSHIP_PATTERN.search(text):
+        return FairnessDecision(
+            excluded=False,
+            action="review",
+            reason="citizenship_or_nationality_requires_job_related_review",
+        )
+    if _LANGUAGE_PATTERN.search(text) and _TASK_REASON_PATTERN.search(text):
+        return FairnessDecision(
+            excluded=False,
+            action="include",
+            reason="explicit_job_related_language_requirement",
+        )
+    return FairnessDecision(
+        excluded=False,
+        action="include",
+        reason="no_fairness_exclusion_detected",
+    )

--- a/backend/app/role_match/presenter.py
+++ b/backend/app/role_match/presenter.py
@@ -1,0 +1,39 @@
+from app.role_match.domain import AnalysisInsight, AnalysisSummary
+
+_HEADLINES = {
+    "exceptional_evidence_match": "Your profile is an exceptional match",
+    "strong_evidence_match": "Your profile is a strong match",
+    "moderate_evidence_match": "Your profile is a moderate match",
+    "limited_evidence_match": "Your profile has limited alignment",
+    "weak_evidence_match": "Your profile is not yet a strong match",
+}
+_DESCRIPTIONS = {
+    "exceptional_evidence_match": "Your background strongly supports nearly all important requirements for this role.",
+    "strong_evidence_match": "Your background supports most of the role's important requirements. A few areas need clearer evidence, but they do not outweigh your core strengths.",
+    "moderate_evidence_match": "You meet several important requirements, while some meaningful gaps deserve attention before applying.",
+    "limited_evidence_match": "There is relevant experience, but several core requirements need stronger evidence.",
+    "weak_evidence_match": "The current profile does not show enough support for the role's most important requirements.",
+}
+
+
+def present_analysis(
+    *,
+    display_score: int,
+    score_band: str,
+    strengths: list[AnalysisInsight],
+    concerns: list[AnalysisInsight],
+) -> AnalysisSummary:
+    del display_score
+    if concerns:
+        next_step = concerns[0].explanation
+    elif strengths:
+        next_step = "Use the strongest evidence in your tailored CV and cover letter."
+    else:
+        next_step = "Review the extracted requirements and add truthful profile evidence where it is missing."
+    return AnalysisSummary(
+        headline=_HEADLINES[score_band],
+        description=_DESCRIPTIONS[score_band],
+        strengths=strengths,
+        concerns=concerns,
+        next_step=next_step,
+    )

--- a/backend/app/role_match/privacy.py
+++ b/backend/app/role_match/privacy.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.role_match.domain import (
+    SafeCertification,
+    SafeEducation,
+    SafeProfile,
+    SafeProject,
+    SafeWorkExperience,
+)
+
+_SENSITIVE_LINE_PATTERNS = [
+    re.compile(r"\b(date of birth|dob|born|age|aged)\b", re.IGNORECASE),
+    re.compile(r"\b(marital status|married|single|children)\b", re.IGNORECASE),
+    re.compile(r"\b(gender|male|female|religion|race|ethnicity)\b", re.IGNORECASE),
+]
+
+
+def _safe_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _filter_summary(value: str | None) -> str | None:
+    if not value:
+        return None
+    kept = [
+        line.strip()
+        for line in value.splitlines()
+        if line.strip()
+        and not any(pattern.search(line) for pattern in _SENSITIVE_LINE_PATTERNS)
+    ]
+    return "\n".join(kept) or None
+
+
+def build_safe_profile(profile: Any, include_location: bool) -> SafeProfile:
+    return SafeProfile(
+        location=_safe_text(getattr(profile, "location", None)) if include_location else None,
+        summary=_filter_summary(_safe_text(getattr(profile, "summary", None))),
+        work_experience=[
+            SafeWorkExperience(
+                company=_safe_text(item.company) or "",
+                role=_safe_text(item.role) or "",
+                start_date=_safe_text(item.start_date),
+                end_date=_safe_text(item.end_date),
+                bullets=[str(b).strip() for b in item.bullets if str(b).strip()],
+            )
+            for item in getattr(profile, "work_experience", [])
+        ],
+        education=[
+            SafeEducation(
+                institution=_safe_text(item.institution) or "",
+                degree=_safe_text(item.degree),
+                field=_safe_text(item.field),
+                start_date=_safe_text(item.start_date),
+                end_date=_safe_text(item.end_date),
+            )
+            for item in getattr(profile, "education", [])
+        ],
+        skills=[str(skill).strip() for skill in getattr(profile, "skills", []) if str(skill).strip()],
+        projects=[
+            SafeProject(
+                name=_safe_text(item.name) or "",
+                description=_safe_text(item.description),
+                tech_stack=[str(t).strip() for t in item.tech_stack if str(t).strip()],
+            )
+            for item in getattr(profile, "projects", [])
+        ],
+        certifications=[
+            SafeCertification(
+                name=_safe_text(item.name),
+                issuer=_safe_text(item.issuer),
+                date=_safe_text(item.date),
+            )
+            for item in getattr(profile, "certifications", [])
+        ],
+    )

--- a/backend/app/role_match/scoring.py
+++ b/backend/app/role_match/scoring.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP
+
+from app.role_match.constants import (
+    CATEGORY_WEIGHTS,
+    IMPORTANCE_WEIGHTS,
+    UNKNOWN_ESSENTIAL_CAPS,
+    UNSUPPORTED_ESSENTIAL_CAPS,
+)
+from app.role_match.domain import (
+    CategoryAssessment,
+    MatchLevel,
+    RequirementAssessment,
+    RequirementCategory,
+    ScoreResult,
+)
+
+
+def shrink_toward_neutral(
+    known_match: float,
+    known_coverage: float,
+    unknown_coverage: float,
+) -> float:
+    return known_match * known_coverage + 0.50 * unknown_coverage
+
+
+def score_category(
+    category: RequirementCategory,
+    assessments: list[RequirementAssessment],
+) -> CategoryAssessment:
+    relevant = [item for item in assessments if item.category == category]
+    if not relevant:
+        return CategoryAssessment(
+            category=category,
+            score=0.50,
+            known_coverage=0.0,
+            unknown_coverage=1.0,
+            known_match=0.50,
+            requirement_count=0,
+        )
+    total_weight = sum(IMPORTANCE_WEIGHTS[item.importance] for item in relevant)
+    known = [item for item in relevant if item.known and item.strength is not None]
+    known_weight = sum(IMPORTANCE_WEIGHTS[item.importance] for item in known)
+    unknown_weight = total_weight - known_weight
+    known_coverage = known_weight / total_weight if total_weight else 0.0
+    unknown_coverage = unknown_weight / total_weight if total_weight else 1.0
+    if known_weight:
+        known_match = sum(
+            (item.strength or 0.0) * IMPORTANCE_WEIGHTS[item.importance]
+            for item in known
+        ) / known_weight
+    else:
+        known_match = 0.50
+    score = shrink_toward_neutral(known_match, known_coverage, unknown_coverage)
+    return CategoryAssessment(
+        category=category,
+        score=max(0.0, min(score, 1.0)),
+        known_coverage=known_coverage,
+        unknown_coverage=unknown_coverage,
+        known_match=max(0.0, min(known_match, 1.0)),
+        requirement_count=len(relevant),
+    )
+
+
+def weighted_overall_score(categories: dict[RequirementCategory, float]) -> float:
+    return sum(categories[category] * weight for category, weight in CATEGORY_WEIGHTS.items())
+
+
+def _cap_for_count(caps: dict[int, int], count: int) -> int | None:
+    if count <= 0:
+        return None
+    return caps[min(count, max(caps))]
+
+
+def essential_score_cap(unsupported_count: int, unknown_count: int) -> int | None:
+    candidates = [
+        value
+        for value in (
+            _cap_for_count(UNSUPPORTED_ESSENTIAL_CAPS, unsupported_count),
+            _cap_for_count(UNKNOWN_ESSENTIAL_CAPS, unknown_count),
+        )
+        if value is not None
+    ]
+    return min(candidates) if candidates else None
+
+
+def round_to_nearest_five(value: float) -> int:
+    rounded = (Decimal(str(value)) / Decimal("5")).quantize(
+        Decimal("1"), rounding=ROUND_HALF_UP
+    ) * Decimal("5")
+    return int(max(Decimal("0"), min(rounded, Decimal("100"))))
+
+
+def score_band(display_score: int) -> str:
+    if display_score >= 85:
+        return "exceptional_evidence_match"
+    if display_score >= 70:
+        return "strong_evidence_match"
+    if display_score >= 55:
+        return "moderate_evidence_match"
+    if display_score >= 40:
+        return "limited_evidence_match"
+    return "weak_evidence_match"
+
+
+def score_role_match(assessments: list[RequirementAssessment]) -> ScoreResult:
+    category_assessments = [
+        score_category(category, assessments) for category in CATEGORY_WEIGHTS
+    ]
+    raw_fraction = weighted_overall_score(
+        {item.category: item.score for item in category_assessments}
+    )
+    raw_score = raw_fraction * 100
+    essential = [
+        item
+        for item in assessments
+        if item.category == RequirementCategory.ESSENTIAL_QUALIFICATIONS
+    ]
+    unsupported = sum(
+        item.match_level in {MatchLevel.NO_EVIDENCE, MatchLevel.CONTRADICTORY}
+        for item in essential
+    )
+    unknown = sum(item.match_level == MatchLevel.UNKNOWN for item in essential)
+    cap = essential_score_cap(unsupported, unknown)
+    capped_score = min(raw_score, float(cap)) if cap is not None else raw_score
+    display_score = round_to_nearest_five(capped_score)
+    if cap is not None:
+        display_score = min(display_score, cap)
+    return ScoreResult(
+        category_assessments=category_assessments,
+        raw_score=raw_score,
+        capped_score=capped_score,
+        display_score=display_score,
+        score_band=score_band(display_score),
+        applied_cap=cap,
+        unsupported_essential_count=unsupported,
+        unknown_essential_count=unknown,
+    )

--- a/backend/app/role_match/scoring.py
+++ b/backend/app/role_match/scoring.py
@@ -92,6 +92,11 @@ def round_to_nearest_five(value: float) -> int:
     return int(max(Decimal("0"), min(rounded, Decimal("100"))))
 
 
+def _display_cap(cap: int) -> int:
+    """Convert an internal cap to the highest allowed five-point display value."""
+    return max(0, min(100, (cap // 5) * 5))
+
+
 def score_band(display_score: int) -> str:
     if display_score >= 85:
         return "exceptional_evidence_match"
@@ -126,7 +131,7 @@ def score_role_match(assessments: list[RequirementAssessment]) -> ScoreResult:
     capped_score = min(raw_score, float(cap)) if cap is not None else raw_score
     display_score = round_to_nearest_five(capped_score)
     if cap is not None:
-        display_score = min(display_score, cap)
+        display_score = min(display_score, _display_cap(cap))
     return ScoreResult(
         category_assessments=category_assessments,
         raw_score=raw_score,

--- a/backend/tests/role_match/test_clustering.py
+++ b/backend/tests/role_match/test_clustering.py
@@ -1,0 +1,76 @@
+from app.role_match.clustering import cluster_requirements
+from app.role_match.domain import (
+    AtomicRequirement,
+    RequirementCategory,
+    RequirementImportance,
+)
+
+
+def atomic(
+    text: str,
+    key: str,
+    importance: RequirementImportance = RequirementImportance.CRITICAL,
+    category: RequirementCategory = RequirementCategory.RELEVANT_COMPETENCIES,
+    source_id: str | None = None,
+) -> AtomicRequirement:
+    return AtomicRequirement(
+        source_id=source_id or text.lower().replace(" ", "-")[:20],
+        text=text,
+        canonical_key=key,
+        primary_category=category,
+        importance=importance,
+        source_quote=text,
+    )
+
+
+def test_repeated_requirement_becomes_one_cluster_with_count() -> None:
+    result = cluster_requirements(
+        [
+            atomic("Strong Python experience", "python-backend", source_id="a"),
+            atomic("Build backend services using Python", "python-backend", source_id="b"),
+            atomic("Python proficiency is required", "python-backend", source_id="c"),
+        ]
+    )
+    assert len(result.clusters) == 1
+    cluster = result.clusters[0]
+    assert cluster.mention_count == 3
+    assert cluster.importance == RequirementImportance.CRITICAL
+    assert cluster.importance_conflict is False
+    assert len(cluster.source_quotes) == 3
+
+
+def test_conflicting_importance_uses_highest_and_records_counts() -> None:
+    cluster = cluster_requirements(
+        [
+            atomic("Python required", "python-backend", RequirementImportance.CRITICAL, source_id="a"),
+            atomic("Python preferred", "python-backend", RequirementImportance.SUPPORTING, source_id="b"),
+        ]
+    ).clusters[0]
+    assert cluster.importance == RequirementImportance.CRITICAL
+    assert cluster.importance_conflict is True
+    assert cluster.importance_mentions == {
+        RequirementImportance.CRITICAL: 1,
+        RequirementImportance.IMPORTANT: 0,
+        RequirementImportance.SUPPORTING: 1,
+    }
+
+
+def test_same_cluster_key_with_different_primary_categories_requires_review() -> None:
+    result = cluster_requirements(
+        [
+            atomic(
+                "Python capability",
+                "python-backend",
+                category=RequirementCategory.RELEVANT_COMPETENCIES,
+                source_id="a",
+            ),
+            atomic(
+                "Build Python APIs",
+                "python-backend",
+                category=RequirementCategory.RELEVANT_WORK_TASKS,
+                source_id="b",
+            ),
+        ]
+    )
+    assert result.unresolved_conflicts
+    assert result.clusters == []

--- a/backend/tests/role_match/test_dates.py
+++ b/backend/tests/role_match/test_dates.py
@@ -1,0 +1,78 @@
+from datetime import date
+
+import pytest
+
+from app.role_match.dates import (
+    MonthInterval,
+    calculate_relevant_months,
+    count_inclusive_months,
+    merge_month_intervals,
+    parse_profile_date,
+)
+from app.role_match.domain import EvidenceCatalogItem, EvidenceSource
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("2024-01", date(2024, 1, 1)),
+        ("2024-01-15", date(2024, 1, 15)),
+        ("Jan 2024", date(2024, 1, 1)),
+        ("January 2024", date(2024, 1, 1)),
+        ("2024", date(2024, 1, 1)),
+        ("Present", None),
+        ("Current", None),
+        ("", None),
+    ],
+)
+def test_parse_profile_start_date(raw: str, expected: date | None) -> None:
+    assert parse_profile_date(raw, end_of_period=False) == expected
+
+
+def test_overlapping_roles_are_not_double_counted() -> None:
+    intervals = [
+        MonthInterval(start=date(2020, 1, 1), end=date(2022, 12, 1)),
+        MonthInterval(start=date(2021, 6, 1), end=date(2023, 6, 1)),
+    ]
+    merged = merge_month_intervals(intervals)
+    assert merged == [MonthInterval(start=date(2020, 1, 1), end=date(2023, 6, 1))]
+    assert count_inclusive_months(merged) == 42
+
+
+def test_calculate_relevant_months_uses_work_intervals_once() -> None:
+    items = [
+        EvidenceCatalogItem(
+            evidence_id="work:0:bullet:0",
+            source=EvidenceSource.WORK_EXPERIENCE,
+            text="Built APIs",
+            start_date="2020-01",
+            end_date="2022-12",
+        ),
+        EvidenceCatalogItem(
+            evidence_id="work:1:bullet:0",
+            source=EvidenceSource.WORK_EXPERIENCE,
+            text="Built services",
+            start_date="2021-06",
+            end_date="2023-06",
+        ),
+    ]
+    assert calculate_relevant_months(
+        items,
+        {"work:0:bullet:0", "work:1:bullet:0"},
+        date(2026, 8, 6),
+    ) == 42
+
+
+def test_unverifiable_dates_return_unknown_duration() -> None:
+    items = [
+        EvidenceCatalogItem(
+            evidence_id="work:0:bullet:0",
+            source=EvidenceSource.WORK_EXPERIENCE,
+            text="Built APIs",
+            start_date="Spring 2020",
+            end_date="Later",
+        )
+    ]
+    assert calculate_relevant_months(
+        items, {"work:0:bullet:0"}, date(2026, 8, 6)
+    ) is None

--- a/backend/tests/role_match/test_domain_constants.py
+++ b/backend/tests/role_match/test_domain_constants.py
@@ -1,0 +1,52 @@
+from app.role_match.constants import (
+    CATEGORY_WEIGHTS,
+    CONFIDENCE_WEIGHTS,
+    DISPLAY_RULES,
+    IMPORTANCE_WEIGHTS,
+)
+from app.role_match.domain import (
+    EvidenceRelationship,
+    RequirementCategory,
+    RequirementImportance,
+)
+
+
+def test_category_weights_sum_to_one() -> None:
+    assert CATEGORY_WEIGHTS == {
+        RequirementCategory.ESSENTIAL_QUALIFICATIONS: 0.30,
+        RequirementCategory.RELEVANT_COMPETENCIES: 0.30,
+        RequirementCategory.RELEVANT_WORK_TASKS: 0.25,
+        RequirementCategory.PREFERRED_QUALIFICATIONS: 0.10,
+        RequirementCategory.CONTEXTUAL_ALIGNMENT: 0.05,
+    }
+    assert sum(CATEGORY_WEIGHTS.values()) == 1.0
+
+
+def test_fixed_importance_weights() -> None:
+    assert IMPORTANCE_WEIGHTS == {
+        RequirementImportance.CRITICAL: 1.00,
+        RequirementImportance.IMPORTANT: 0.70,
+        RequirementImportance.SUPPORTING: 0.40,
+    }
+
+
+def test_confidence_weights_are_fixed() -> None:
+    assert CONFIDENCE_WEIGHTS == {
+        "known_coverage": 0.45,
+        "evidence_reliability": 0.35,
+        "evidence_consistency": 0.20,
+    }
+
+
+def test_display_rules_match_approved_thresholds() -> None:
+    assert DISPLAY_RULES.minimum_known_coverage == 0.60
+    assert DISPLAY_RULES.minimum_confidence == 0.55
+    assert DISPLAY_RULES.maximum_unresolved_conflict_rate == 0.20
+    assert DISPLAY_RULES.minimum_atomic_requirements == 3
+
+
+def test_relationship_values_are_stable() -> None:
+    assert EvidenceRelationship.EXACT.value == "exact"
+    assert EvidenceRelationship.FUNCTIONAL_EQUIVALENT.value == "functional_equivalent"
+    assert EvidenceRelationship.ADJACENT.value == "adjacent"
+    assert EvidenceRelationship.UNRELATED.value == "unrelated"

--- a/backend/tests/role_match/test_eligibility_fairness_presenter.py
+++ b/backend/tests/role_match/test_eligibility_fairness_presenter.py
@@ -1,0 +1,102 @@
+import pytest
+
+from app.role_match.domain import (
+    AnalysisInsight,
+    EligibilitySignal,
+    EligibilityStatus,
+    FairnessDecision,
+)
+from app.role_match.eligibility import assess_eligibility
+from app.role_match.fairness import evaluate_requirement_fairness
+from app.role_match.presenter import present_analysis
+
+
+def test_missing_work_authorization_is_unclear_not_ineligible() -> None:
+    result = assess_eligibility(
+        [
+            EligibilitySignal(
+                requirement_id="work-auth",
+                mandatory=True,
+                unknown=True,
+                reason="Work authorization is not stated",
+            )
+        ]
+    )
+    assert result.status == EligibilityStatus.UNCLEAR
+
+
+def test_explicit_contradiction_can_be_ineligible() -> None:
+    result = assess_eligibility(
+        [
+            EligibilitySignal(
+                requirement_id="sponsorship",
+                mandatory=True,
+                explicit_contradiction=True,
+                unknown=False,
+                reason="Candidate requires sponsorship but none is available",
+            )
+        ]
+    )
+    assert result.status == EligibilityStatus.INELIGIBLE
+
+
+def test_no_eligibility_requirements_is_likely_eligible() -> None:
+    assert assess_eligibility([]).status == EligibilityStatus.LIKELY_ELIGIBLE
+
+
+@pytest.mark.parametrize(
+    "requirement_text",
+    [
+        "Candidate must be under 30",
+        "Only unmarried applicants",
+        "Female candidate preferred",
+        "Include a recent photo",
+    ],
+)
+def test_non_job_related_requirement_is_excluded(requirement_text: str) -> None:
+    decision = evaluate_requirement_fairness(requirement_text)
+    assert decision == FairnessDecision(
+        excluded=True,
+        action="exclude_warn_continue",
+        reason="potentially_non_job_related",
+    )
+
+
+def test_job_related_language_requirement_is_not_excluded() -> None:
+    decision = evaluate_requirement_fairness(
+        "Japanese fluency is required to support Japanese-speaking customers"
+    )
+    assert decision.excluded is False
+    assert decision.action == "include"
+
+
+def test_nationality_requirement_needs_review_not_proxy_scoring() -> None:
+    decision = evaluate_requirement_fairness("Applicant must be a Japanese citizen")
+    assert decision.excluded is False
+    assert decision.action == "review"
+
+
+def test_presenter_uses_human_friendly_language() -> None:
+    summary = present_analysis(
+        display_score=80,
+        score_band="strong_evidence_match",
+        strengths=[
+            AnalysisInsight(
+                title="Strong production Python backend experience",
+                explanation="Supported by recent work examples.",
+                evidence_label="Work experience",
+            )
+        ],
+        concerns=[
+            AnalysisInsight(
+                title="Terraform experience needs clearer proof",
+                explanation="Add a real work example if available.",
+                evidence_label="Preferred skill",
+            )
+        ],
+    )
+    assert summary.headline == "Your profile is a strong match"
+    assert summary.concerns[0].title == "Terraform experience needs clearer proof"
+    serialized = summary.model_dump_json()
+    for forbidden in ["raw_score", "soft cap", "unsupported essential", "contradictory evidence"]:
+        assert forbidden not in serialized

--- a/backend/tests/role_match/test_evidence_strength.py
+++ b/backend/tests/role_match/test_evidence_strength.py
@@ -1,0 +1,166 @@
+from datetime import date
+
+import pytest
+
+from app.role_match.domain import (
+    EvidenceDepth,
+    EvidenceLink,
+    EvidenceRelationship,
+    EvidenceSource,
+    MatchLevel,
+    RequirementCategory,
+    RequirementCluster,
+    RequirementImportance,
+    TechnologyVolatility,
+)
+from app.role_match.evidence_strength import (
+    assess_duration_requirement,
+    calculate_base_strength,
+    calculate_recency_multiplier,
+    combine_evidence,
+    strength_to_match_level,
+)
+
+ANALYSIS_DATE = date(2026, 8, 6)
+
+
+def cluster(**updates) -> RequirementCluster:
+    payload = {
+        "cluster_id": "req:python",
+        "canonical_requirement": "Production Python backend capability",
+        "canonical_key": "python-backend",
+        "primary_category": RequirementCategory.RELEVANT_COMPETENCIES,
+        "importance": RequirementImportance.CRITICAL,
+        "mention_count": 1,
+        "importance_conflict": False,
+        "importance_mentions": {
+            RequirementImportance.CRITICAL: 1,
+            RequirementImportance.IMPORTANT: 0,
+            RequirementImportance.SUPPORTING: 0,
+        },
+        "source_quotes": ["Python required"],
+        "source_ids": ["a"],
+        "is_eligibility": False,
+        "is_trainable": False,
+        "volatility": TechnologyVolatility.EVOLVING,
+        "minimum_months": None,
+        "tool_specificity": "capability",
+    }
+    payload.update(updates)
+    return RequirementCluster(**payload)
+
+
+def link(**updates) -> EvidenceLink:
+    payload = {
+        "requirement_id": "req:python",
+        "evidence_id": "work:0:bullet:0",
+        "source": EvidenceSource.WORK_EXPERIENCE,
+        "relationship": EvidenceRelationship.EXACT,
+        "depth": EvidenceDepth.PRODUCTION_OWNERSHIP,
+        "volatility": TechnologyVolatility.EVOLVING,
+        "last_used_date": ANALYSIS_DATE,
+        "is_current": True,
+    }
+    payload.update(updates)
+    return EvidenceLink(**payload)
+
+
+def test_direct_recent_work_ownership_is_full_strength() -> None:
+    assert calculate_base_strength(link(), ANALYSIS_DATE) == 1.0
+
+
+def test_skill_only_exposure_is_weak() -> None:
+    value = calculate_base_strength(
+        link(
+            source=EvidenceSource.SKILLS_LIST,
+            depth=EvidenceDepth.EXPOSURE_ONLY,
+        ),
+        ANALYSIS_DATE,
+    )
+    assert value == pytest.approx(0.1575)
+    assert strength_to_match_level(value) == MatchLevel.WEAK
+
+
+def test_adjacent_skill_only_evidence_is_too_weak_to_count() -> None:
+    value = calculate_base_strength(
+        link(
+            relationship=EvidenceRelationship.ADJACENT,
+            source=EvidenceSource.SKILLS_LIST,
+            depth=EvidenceDepth.EXPOSURE_ONLY,
+        ),
+        ANALYSIS_DATE,
+    )
+    assert value == pytest.approx(0.063)
+    assert strength_to_match_level(value) == MatchLevel.NO_EVIDENCE
+
+
+def test_tool_specific_equivalent_is_capped_at_moderate() -> None:
+    assessment = combine_evidence(
+        [link(relationship=EvidenceRelationship.FUNCTIONAL_EQUIVALENT)],
+        cluster(tool_specificity="specific"),
+        ANALYSIS_DATE,
+    )
+    assert assessment.match_level == MatchLevel.MODERATE
+    assert assessment.strength == pytest.approx(0.749)
+
+
+def test_operational_equivalent_is_capped_at_weak() -> None:
+    assessment = combine_evidence(
+        [link(relationship=EvidenceRelationship.FUNCTIONAL_EQUIVALENT)],
+        cluster(tool_specificity="operational"),
+        ANALYSIS_DATE,
+    )
+    assert assessment.match_level == MatchLevel.WEAK
+    assert assessment.strength == pytest.approx(0.449)
+
+
+def test_top_three_independent_links_add_capped_bonus() -> None:
+    links = [
+        link(evidence_id="a", precomputed_strength=0.72),
+        link(evidence_id="b", precomputed_strength=0.60),
+        link(evidence_id="c", precomputed_strength=0.40),
+        link(evidence_id="d", precomputed_strength=0.20),
+    ]
+    assessment = combine_evidence(links, cluster(), ANALYSIS_DATE)
+    assert assessment.strength == pytest.approx(0.792)
+    assert assessment.confidence_evidence_count == 4
+
+
+def test_duplicate_evidence_does_not_receive_bonus() -> None:
+    assessment = combine_evidence(
+        [
+            link(evidence_id="work:a", precomputed_strength=0.72),
+            link(evidence_id="summary:a", precomputed_strength=0.72, is_duplicate=True),
+        ],
+        cluster(),
+        ANALYSIS_DATE,
+    )
+    assert assessment.strength == pytest.approx(0.72)
+
+
+@pytest.mark.parametrize(
+    ("volatility", "last_used", "expected"),
+    [
+        (TechnologyVolatility.STABLE, date(2018, 1, 1), 0.90),
+        (TechnologyVolatility.EVOLVING, date(2021, 8, 6), 0.85),
+        (TechnologyVolatility.EVOLVING, date(2018, 8, 6), 0.70),
+        (TechnologyVolatility.FAST_MOVING, date(2023, 8, 6), 0.75),
+        (TechnologyVolatility.FAST_MOVING, date(2020, 8, 6), 0.50),
+    ],
+)
+def test_recency_tables(volatility, last_used, expected) -> None:
+    assert calculate_recency_multiplier(volatility, last_used, ANALYSIS_DATE) == expected
+
+
+@pytest.mark.parametrize(
+    ("required", "actual", "expected"),
+    [
+        (60, 60, MatchLevel.STRONG),
+        (60, 51, MatchLevel.MODERATE),
+        (60, 36, MatchLevel.WEAK),
+        (60, 35, MatchLevel.NO_EVIDENCE),
+        (60, None, MatchLevel.UNKNOWN),
+    ],
+)
+def test_duration_thresholds(required, actual, expected) -> None:
+    assert assess_duration_requirement(required, actual).match_level == expected

--- a/backend/tests/role_match/test_privacy_catalog.py
+++ b/backend/tests/role_match/test_privacy_catalog.py
@@ -1,0 +1,74 @@
+from app.role_match.evidence_catalog import build_evidence_catalog
+from app.role_match.privacy import build_safe_profile
+from app.schemas import ProfileData
+
+
+def make_profile(**updates) -> ProfileData:
+    payload = {
+        "name": "Candidate A",
+        "email": "a@example.com",
+        "phone": "+62 812",
+        "location": "Jakarta, Indonesia",
+        "linkedin": "https://linkedin.example/a",
+        "github": "https://github.example/a",
+        "portfolio": "https://portfolio.example/a",
+        "summary": "Backend engineer",
+        "work_experience": [
+            {
+                "company": "Example",
+                "role": "Backend Engineer",
+                "start_date": "2023-01",
+                "end_date": None,
+                "bullets": ["Built asynchronous services using Google Pub/Sub."],
+            }
+        ],
+        "education": [],
+        "skills": ["Python", "FastAPI"],
+        "projects": [],
+        "certifications": [],
+    }
+    payload.update(updates)
+    return ProfileData(**payload)
+
+
+def test_safe_profile_excludes_identity_and_contact_fields() -> None:
+    safe = build_safe_profile(make_profile(), include_location=False)
+    serialized = safe.model_dump_json()
+    for forbidden in [
+        "Candidate A",
+        "a@example.com",
+        "+62 812",
+        "linkedin.example",
+        "github.example",
+        "portfolio.example",
+        "Jakarta",
+    ]:
+        assert forbidden not in serialized
+
+
+def test_name_and_contact_changes_do_not_change_catalog() -> None:
+    first = build_evidence_catalog(build_safe_profile(make_profile(), False))
+    second = build_evidence_catalog(
+        build_safe_profile(
+            make_profile(name="Candidate B", email="b@example.com", phone="000"),
+            False,
+        )
+    )
+    assert first == second
+
+
+def test_location_is_only_included_when_job_related() -> None:
+    profile = make_profile()
+    assert build_safe_profile(profile, include_location=False).location is None
+    assert build_safe_profile(profile, include_location=True).location == "Jakarta, Indonesia"
+
+
+def test_catalog_uses_stable_ids_and_source_hierarchy() -> None:
+    catalog = build_evidence_catalog(build_safe_profile(make_profile(), False))
+    assert [item.evidence_id for item in catalog] == [
+        "summary:0",
+        "work:0:role",
+        "work:0:bullet:0",
+        "skill:python",
+        "skill:fastapi",
+    ]

--- a/backend/tests/role_match/test_scoring_confidence.py
+++ b/backend/tests/role_match/test_scoring_confidence.py
@@ -1,0 +1,168 @@
+import pytest
+
+from app.role_match.confidence import calculate_confidence, decide_authoritative_display
+from app.role_match.domain import (
+    ConfidenceBand,
+    ConfidenceInputs,
+    MatchLevel,
+    RequirementAssessment,
+    RequirementCategory,
+    RequirementImportance,
+)
+from app.role_match.scoring import (
+    essential_score_cap,
+    round_to_nearest_five,
+    score_band,
+    score_category,
+    score_role_match,
+    shrink_toward_neutral,
+    weighted_overall_score,
+)
+
+
+def assessment(category, importance, level, strength=None) -> RequirementAssessment:
+    return RequirementAssessment(
+        cluster_id=f"{category.value}:{importance.value}:{level.value}",
+        category=category,
+        importance=importance,
+        match_level=level,
+        strength=strength,
+        known=level != MatchLevel.UNKNOWN,
+    )
+
+
+def test_unknown_weight_shrinks_known_score_toward_neutral() -> None:
+    assert shrink_toward_neutral(0.80, 0.80, 0.20) == pytest.approx(0.74)
+
+
+def test_category_scoring_uses_importance_and_unknown_coverage() -> None:
+    result = score_category(
+        RequirementCategory.RELEVANT_COMPETENCIES,
+        [
+            assessment(
+                RequirementCategory.RELEVANT_COMPETENCIES,
+                RequirementImportance.CRITICAL,
+                MatchLevel.STRONG,
+                0.80,
+            ),
+            assessment(
+                RequirementCategory.RELEVANT_COMPETENCIES,
+                RequirementImportance.IMPORTANT,
+                MatchLevel.UNKNOWN,
+                None,
+            ),
+        ],
+    )
+    assert result.known_coverage == pytest.approx(1 / 1.7)
+    assert result.unknown_coverage == pytest.approx(0.7 / 1.7)
+    assert result.known_match == pytest.approx(0.80)
+    assert result.score == pytest.approx(0.6764705882)
+
+
+def test_category_weights_produce_raw_score() -> None:
+    categories = {
+        RequirementCategory.ESSENTIAL_QUALIFICATIONS: 0.80,
+        RequirementCategory.RELEVANT_COMPETENCIES: 0.90,
+        RequirementCategory.RELEVANT_WORK_TASKS: 0.70,
+        RequirementCategory.PREFERRED_QUALIFICATIONS: 0.60,
+        RequirementCategory.CONTEXTUAL_ALIGNMENT: 0.50,
+    }
+    assert weighted_overall_score(categories) == pytest.approx(0.77)
+
+
+@pytest.mark.parametrize(
+    ("unsupported", "unknown", "expected_cap"),
+    [
+        (0, 0, None),
+        (1, 0, 74),
+        (2, 0, 59),
+        (3, 0, 44),
+        (0, 1, 89),
+        (0, 2, 79),
+        (0, 3, 69),
+        (1, 1, 74),
+    ],
+)
+def test_essential_caps(unsupported, unknown, expected_cap) -> None:
+    assert essential_score_cap(unsupported, unknown) == expected_cap
+
+
+def test_display_rounding_and_band() -> None:
+    assert round_to_nearest_five(82.4) == 80
+    assert round_to_nearest_five(82.5) == 85
+    assert score_band(85) == "exceptional_evidence_match"
+    assert score_band(80) == "strong_evidence_match"
+
+
+def test_score_role_match_applies_essential_cap() -> None:
+    result = score_role_match(
+        [
+            assessment(
+                RequirementCategory.ESSENTIAL_QUALIFICATIONS,
+                RequirementImportance.CRITICAL,
+                MatchLevel.NO_EVIDENCE,
+                0.0,
+            ),
+            assessment(
+                RequirementCategory.RELEVANT_COMPETENCIES,
+                RequirementImportance.CRITICAL,
+                MatchLevel.STRONG,
+                1.0,
+            ),
+            assessment(
+                RequirementCategory.RELEVANT_WORK_TASKS,
+                RequirementImportance.CRITICAL,
+                MatchLevel.STRONG,
+                1.0,
+            ),
+            assessment(
+                RequirementCategory.PREFERRED_QUALIFICATIONS,
+                RequirementImportance.CRITICAL,
+                MatchLevel.STRONG,
+                1.0,
+            ),
+            assessment(
+                RequirementCategory.CONTEXTUAL_ALIGNMENT,
+                RequirementImportance.CRITICAL,
+                MatchLevel.STRONG,
+                1.0,
+            ),
+        ]
+    )
+    assert result.applied_cap == 74
+    assert result.display_score <= 74
+
+
+def test_confidence_formula() -> None:
+    result = calculate_confidence(
+        ConfidenceInputs(
+            known_coverage=0.80,
+            evidence_reliability=0.90,
+            evidence_consistency=0.70,
+        )
+    )
+    assert result.score == pytest.approx(0.815)
+    assert result.band == ConfidenceBand.HIGH
+
+
+def test_low_coverage_hides_authoritative_score() -> None:
+    decision = decide_authoritative_display(
+        known_coverage=0.59,
+        confidence=0.80,
+        conflict_rate=0.0,
+        requirement_count=10,
+        scoring_succeeded=True,
+    )
+    assert decision.show_score is False
+    assert decision.reason == "insufficient_known_coverage"
+
+
+def test_medium_confidence_is_enough_to_show_score() -> None:
+    decision = decide_authoritative_display(
+        known_coverage=0.70,
+        confidence=0.55,
+        conflict_rate=0.10,
+        requirement_count=3,
+        scoring_succeeded=True,
+    )
+    assert decision.show_score is True

--- a/backend/tests/role_match/test_scoring_confidence.py
+++ b/backend/tests/role_match/test_scoring_confidence.py
@@ -94,7 +94,7 @@ def test_display_rounding_and_band() -> None:
     assert score_band(80) == "strong_evidence_match"
 
 
-def test_score_role_match_applies_essential_cap() -> None:
+def test_score_role_match_applies_essential_cap_without_breaking_display_increment() -> None:
     result = score_role_match(
         [
             assessment(
@@ -130,7 +130,8 @@ def test_score_role_match_applies_essential_cap() -> None:
         ]
     )
     assert result.applied_cap == 74
-    assert result.display_score <= 74
+    assert result.display_score == 70
+    assert result.display_score % 5 == 0
 
 
 def test_confidence_formula() -> None:


### PR DESCRIPTION
## Summary

- add versioned Role Evidence Match domain contracts and scoring constants
- sanitize protected profile fields before analysis and build stable evidence IDs
- add atomic requirement clustering with mention counts and importance-conflict tracking
- implement duration handling, volatility-aware recency, equivalence ceilings, corroboration, unknown adjustment, essential caps, confidence, eligibility, fairness, and human-friendly presentation
- add 66 focused backend tests for the deterministic engine

## Stack

This is PR 1 of the v1.3.0 Role Evidence Match stack. It intentionally does not change the existing API, database, or frontend yet. Follow-up PRs will add LLM extraction/persistence/API, then UI/integration, then docs/release metadata.

## Verification

- focused local suite: `66 passed`
- full authoritative verification: GitHub Actions on this PR head

No tag or release is created by this PR.