### PR TITLE
feat: add immutable role match review overrides

### DIFF
--- a/backend/app/role_match/api_schemas.py
+++ b/backend/app/role_match/api_schemas.py
@@ -72,6 +72,23 @@ class ExcludedAnalysisItemResponse(BaseModel):
     reason: str
 
 
+class RoleMatchOverrideResponse(BaseModel):
+    id: int
+    requirement_key: str
+    field_name: str
+    extracted_value: Any
+    effective_value: Any
+    reason: str
+    source: str
+    carry_status: Literal[
+        "carried_forward",
+        "needs_review",
+        "not_applicable",
+    ]
+    source_override_id: int | None
+    created_at: datetime
+
+
 class RoleMatchAnalysisResponse(BaseModel):
     id: int
     parent_analysis_id: int | None
@@ -92,6 +109,7 @@ class RoleMatchAnalysisResponse(BaseModel):
     category_breakdown: list[RoleMatchCategoryResponse]
     requirements: list[RoleMatchRequirementResponse]
     excluded_items: list[ExcludedAnalysisItemResponse]
+    overrides: list[RoleMatchOverrideResponse] = []
     override_review_count: int
     rules_version: str
     prompt_version: str

--- a/backend/app/role_match/carry_forward.py
+++ b/backend/app/role_match/carry_forward.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from app.role_match.domain import (
+    MatchLevel,
+    OverrideCarryStatus,
+    RequirementAssessment,
+    RequirementCluster,
+)
+from app.role_match.overrides import (
+    apply_carried_overrides_to_clusters,
+    filter_carried_evidence_links,
+    prepare_parent_overrides,
+)
+from app.role_match.snapshots import SnapshotOverride
+
+
+def apply_carried_experience_overrides(
+    assessments: list[RequirementAssessment],
+    clusters: list[RequirementCluster],
+    prepared: tuple[SnapshotOverride, ...],
+) -> list[RequirementAssessment]:
+    cluster_by_key = {item.canonical_key: item for item in clusters}
+    assessment_by_cluster = {item.cluster_id: item for item in assessments}
+
+    for item in prepared:
+        if (
+            item.carry_status != OverrideCarryStatus.CARRIED_FORWARD.value
+            or item.field_name != "experience_status"
+        ):
+            continue
+        cluster = cluster_by_key.get(item.requirement_key)
+        if cluster is None or cluster.excluded:
+            continue
+        status = str(item.effective_value)
+        if status == "no_experience":
+            assessment_by_cluster[cluster.cluster_id] = RequirementAssessment(
+                cluster_id=cluster.cluster_id,
+                category=cluster.primary_category,
+                importance=cluster.importance,
+                match_level=MatchLevel.NO_EVIDENCE,
+                strength=0.0,
+                evidence_links=[],
+                explanation="The user previously confirmed they do not have this experience.",
+                known=True,
+            )
+        elif status == "not_in_profile":
+            assessment_by_cluster[cluster.cluster_id] = RequirementAssessment(
+                cluster_id=cluster.cluster_id,
+                category=cluster.primary_category,
+                importance=cluster.importance,
+                match_level=MatchLevel.UNKNOWN,
+                strength=None,
+                evidence_links=[],
+                explanation="The user previously indicated this evidence is not included in the profile.",
+                known=False,
+            )
+
+    return [
+        assessment_by_cluster[item.cluster_id]
+        for item in clusters
+        if not item.excluded and item.cluster_id in assessment_by_cluster
+    ]
+
+
+__all__ = [
+    "apply_carried_experience_overrides",
+    "apply_carried_overrides_to_clusters",
+    "filter_carried_evidence_links",
+    "prepare_parent_overrides",
+]

--- a/backend/app/role_match/carry_forward.py
+++ b/backend/app/role_match/carry_forward.py
@@ -1,17 +1,80 @@
 from __future__ import annotations
 
+import json
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.role_match.carry_policy import classify_override_carry
 from app.role_match.domain import (
     MatchLevel,
     OverrideCarryStatus,
     RequirementAssessment,
     RequirementCluster,
 )
+from app.role_match.models import RoleMatchOverride, RoleMatchRequirement
 from app.role_match.overrides import (
     apply_carried_overrides_to_clusters,
     filter_carried_evidence_links,
-    prepare_parent_overrides,
 )
 from app.role_match.snapshots import SnapshotOverride
+
+
+def _loads(raw: str | None, default: Any) -> Any:
+    if raw is None:
+        return default
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def prepare_parent_overrides(
+    db: Session,
+    parent_analysis_id: int | None,
+    new_clusters: list[RequirementCluster],
+) -> tuple[SnapshotOverride, ...]:
+    if parent_analysis_id is None:
+        return ()
+    previous_requirements = {
+        item.canonical_key: item
+        for item in db.query(RoleMatchRequirement)
+        .filter_by(analysis_id=parent_analysis_id)
+        .all()
+    }
+    previous_overrides = (
+        db.query(RoleMatchOverride)
+        .filter_by(analysis_id=parent_analysis_id)
+        .order_by(RoleMatchOverride.id.asc())
+        .all()
+    )
+    prepared: list[SnapshotOverride] = []
+    for item in previous_overrides:
+        previous_requirement = previous_requirements.get(item.requirement_key)
+        previous_category = (
+            previous_requirement.primary_category
+            if previous_requirement is not None
+            else ""
+        )
+        status, target_key = classify_override_carry(
+            previous_key=item.requirement_key,
+            previous_category=previous_category,
+            previous_status=item.carry_status,
+            new_clusters=new_clusters,
+        )
+        prepared.append(
+            SnapshotOverride(
+                requirement_key=target_key or item.requirement_key,
+                field_name=item.field_name,
+                extracted_value=_loads(item.extracted_value, None),
+                effective_value=_loads(item.effective_value, None),
+                reason=item.reason,
+                source="carry_forward",
+                carry_status=status.value,
+                source_override_id=item.id,
+            )
+        )
+    return tuple(prepared)
 
 
 def apply_carried_experience_overrides(

--- a/backend/app/role_match/carry_policy.py
+++ b/backend/app/role_match/carry_policy.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from app.role_match.clustering import requirement_similarity
+from app.role_match.constants import (
+    AUTOMATIC_OVERRIDE_CARRY_SIMILARITY,
+    OVERRIDE_REVIEW_SIMILARITY,
+)
+from app.role_match.domain import OverrideCarryStatus, RequirementCluster
+
+
+def _best_similarity_target(
+    previous_key: str,
+    new_clusters: list[RequirementCluster],
+) -> tuple[float, RequirementCluster | None]:
+    if not new_clusters:
+        return 0.0, None
+    return max(
+        (
+            requirement_similarity(
+                previous_key.replace("-", " "),
+                f"{cluster.canonical_key.replace('-', ' ')} "
+                f"{cluster.canonical_requirement}",
+            ),
+            cluster,
+        )
+        for cluster in new_clusters
+    )
+
+
+def classify_override_carry(
+    *,
+    previous_key: str,
+    previous_category: str,
+    new_clusters: list[RequirementCluster],
+    previous_status: str = OverrideCarryStatus.CARRIED_FORWARD.value,
+) -> tuple[OverrideCarryStatus, str | None]:
+    if previous_status == OverrideCarryStatus.NOT_APPLICABLE.value:
+        return OverrideCarryStatus.NOT_APPLICABLE, None
+
+    exact = next(
+        (cluster for cluster in new_clusters if cluster.canonical_key == previous_key),
+        None,
+    )
+
+    if previous_status == OverrideCarryStatus.NEEDS_REVIEW.value:
+        if exact is not None:
+            return OverrideCarryStatus.NEEDS_REVIEW, exact.canonical_key
+        similarity, target = _best_similarity_target(previous_key, new_clusters)
+        if target is not None and similarity >= OVERRIDE_REVIEW_SIMILARITY:
+            return OverrideCarryStatus.NEEDS_REVIEW, target.canonical_key
+        return OverrideCarryStatus.NOT_APPLICABLE, None
+
+    if exact is not None:
+        if exact.primary_category.value == previous_category:
+            return OverrideCarryStatus.CARRIED_FORWARD, exact.canonical_key
+        return OverrideCarryStatus.NEEDS_REVIEW, exact.canonical_key
+
+    similarity, target = _best_similarity_target(previous_key, new_clusters)
+    if target is None:
+        return OverrideCarryStatus.NOT_APPLICABLE, None
+    if (
+        similarity >= AUTOMATIC_OVERRIDE_CARRY_SIMILARITY
+        and target.primary_category.value == previous_category
+    ):
+        return OverrideCarryStatus.CARRIED_FORWARD, target.canonical_key
+    if similarity >= OVERRIDE_REVIEW_SIMILARITY:
+        return OverrideCarryStatus.NEEDS_REVIEW, target.canonical_key
+    return OverrideCarryStatus.NOT_APPLICABLE, None

--- a/backend/app/role_match/overrides.py
+++ b/backend/app/role_match/overrides.py
@@ -1,0 +1,565 @@
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.exceptions import InvalidRequestError, RoleMatchAnalysisNotFoundError
+from app.role_match.api_schemas import RoleMatchOverrideInput
+from app.role_match.clustering import requirement_similarity
+from app.role_match.confidence import calculate_confidence, decide_authoritative_display
+from app.role_match.constants import (
+    AUTOMATIC_OVERRIDE_CARRY_SIMILARITY,
+    IMPORTANCE_WEIGHTS,
+    OVERRIDE_REVIEW_SIMILARITY,
+    SOURCE_MULTIPLIERS,
+)
+from app.role_match.domain import (
+    AnalysisInsight,
+    ConfidenceInputs,
+    EligibilityAssessment,
+    EligibilityStatus,
+    EvidenceCatalogItem,
+    EvidenceDepth,
+    EvidenceLink,
+    EvidenceRelationship,
+    EvidenceSource,
+    MatchLevel,
+    OverrideCarryStatus,
+    RequirementAssessment,
+    RequirementCategory,
+    RequirementCluster,
+    RequirementImportance,
+    TechnologyVolatility,
+)
+from app.role_match.evidence_strength import combine_evidence
+from app.role_match.models import (
+    RoleMatchAnalysis,
+    RoleMatchEvidence,
+    RoleMatchOverride,
+    RoleMatchRequirement,
+)
+from app.role_match.presenter import present_analysis
+from app.role_match.scoring import score_role_match
+from app.role_match.snapshots import SnapshotInput, SnapshotOverride, save_analysis_snapshot
+
+
+def _loads(raw: str | None, default: Any) -> Any:
+    if raw is None:
+        return default
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def classify_override_carry(
+    *,
+    previous_key: str,
+    previous_category: str,
+    new_clusters: list[RequirementCluster],
+) -> tuple[OverrideCarryStatus, str | None]:
+    exact = next(
+        (cluster for cluster in new_clusters if cluster.canonical_key == previous_key),
+        None,
+    )
+    if exact is not None:
+        if exact.primary_category.value == previous_category:
+            return OverrideCarryStatus.CARRIED_FORWARD, exact.canonical_key
+        return OverrideCarryStatus.NEEDS_REVIEW, exact.canonical_key
+
+    scored = [
+        (
+            requirement_similarity(
+                previous_key.replace("-", " "),
+                f"{cluster.canonical_key.replace('-', ' ')} {cluster.canonical_requirement}",
+            ),
+            cluster,
+        )
+        for cluster in new_clusters
+    ]
+    if not scored:
+        return OverrideCarryStatus.NOT_APPLICABLE, None
+    similarity, target = max(scored, key=lambda item: item[0])
+    if (
+        similarity >= AUTOMATIC_OVERRIDE_CARRY_SIMILARITY
+        and target.primary_category.value == previous_category
+    ):
+        return OverrideCarryStatus.CARRIED_FORWARD, target.canonical_key
+    if similarity >= OVERRIDE_REVIEW_SIMILARITY:
+        return OverrideCarryStatus.NEEDS_REVIEW, target.canonical_key
+    return OverrideCarryStatus.NOT_APPLICABLE, None
+
+
+def prepare_parent_overrides(
+    db: Session,
+    parent_analysis_id: int | None,
+    new_clusters: list[RequirementCluster],
+) -> tuple[SnapshotOverride, ...]:
+    if parent_analysis_id is None:
+        return ()
+    previous_requirements = {
+        item.canonical_key: item
+        for item in db.query(RoleMatchRequirement)
+        .filter_by(analysis_id=parent_analysis_id)
+        .all()
+    }
+    previous_overrides = (
+        db.query(RoleMatchOverride)
+        .filter_by(analysis_id=parent_analysis_id)
+        .order_by(RoleMatchOverride.id.asc())
+        .all()
+    )
+    prepared: list[SnapshotOverride] = []
+    for item in previous_overrides:
+        previous_requirement = previous_requirements.get(item.requirement_key)
+        previous_category = (
+            previous_requirement.primary_category
+            if previous_requirement is not None
+            else ""
+        )
+        status, target_key = classify_override_carry(
+            previous_key=item.requirement_key,
+            previous_category=previous_category,
+            new_clusters=new_clusters,
+        )
+        prepared.append(
+            SnapshotOverride(
+                requirement_key=target_key or item.requirement_key,
+                field_name=item.field_name,
+                extracted_value=_loads(item.extracted_value, None),
+                effective_value=_loads(item.effective_value, None),
+                reason=item.reason,
+                source="carry_forward",
+                carry_status=status.value,
+                source_override_id=item.id,
+            )
+        )
+    return tuple(prepared)
+
+
+def apply_carried_overrides_to_clusters(
+    clusters: list[RequirementCluster],
+    prepared: tuple[SnapshotOverride, ...],
+) -> list[RequirementCluster]:
+    by_key = {item.canonical_key: item for item in clusters}
+    for item in prepared:
+        if item.carry_status != OverrideCarryStatus.CARRIED_FORWARD.value:
+            continue
+        cluster = by_key.get(item.requirement_key)
+        if cluster is None:
+            continue
+        if item.field_name == "importance":
+            try:
+                importance = RequirementImportance(str(item.effective_value))
+            except ValueError:
+                continue
+            by_key[item.requirement_key] = cluster.model_copy(
+                update={"importance": importance}
+            )
+        elif item.field_name == "excluded" and isinstance(item.effective_value, bool):
+            if (
+                cluster.exclusion_reason == "potentially_non_job_related"
+                and item.effective_value is False
+            ):
+                continue
+            by_key[item.requirement_key] = cluster.model_copy(
+                update={
+                    "excluded": item.effective_value,
+                    "exclusion_reason": (
+                        "user_excluded" if item.effective_value else None
+                    ),
+                }
+            )
+    return [by_key[item.canonical_key] for item in clusters]
+
+
+def filter_carried_evidence_links(
+    links: list[EvidenceLink],
+    prepared: tuple[SnapshotOverride, ...],
+) -> list[EvidenceLink]:
+    removed = {
+        (item.requirement_key, str(item.effective_value))
+        for item in prepared
+        if item.carry_status == OverrideCarryStatus.CARRIED_FORWARD.value
+        and item.field_name == "evidence_unlink"
+    }
+    return [
+        link
+        for link in links
+        if (link.requirement_id.removeprefix("req:"), link.evidence_id) not in removed
+        and not any(
+            item.field_name == "evidence_unlink"
+            and item.carry_status == OverrideCarryStatus.CARRIED_FORWARD.value
+            and item.requirement_key in {
+                link.requirement_id,
+                link.requirement_id.removeprefix("req:"),
+            }
+            and str(item.effective_value) == link.evidence_id
+            for item in prepared
+        )
+    ]
+
+
+def _reconstruct_source(
+    db: Session,
+    source: RoleMatchAnalysis,
+) -> tuple[
+    list[RequirementCluster],
+    list[RequirementAssessment],
+    list[EvidenceCatalogItem],
+]:
+    requirements = (
+        db.query(RoleMatchRequirement)
+        .filter_by(analysis_id=source.id)
+        .order_by(RoleMatchRequirement.sort_order.asc())
+        .all()
+    )
+    evidence_rows = (
+        db.query(RoleMatchEvidence)
+        .filter_by(analysis_id=source.id)
+        .order_by(RoleMatchEvidence.rank.asc())
+        .all()
+    )
+    evidence_by_requirement: dict[int, list[RoleMatchEvidence]] = defaultdict(list)
+    for row in evidence_rows:
+        evidence_by_requirement[row.requirement_id].append(row)
+
+    clusters: list[RequirementCluster] = []
+    assessments: list[RequirementAssessment] = []
+    catalog_by_id: dict[str, EvidenceCatalogItem] = {}
+    for row in requirements:
+        category = RequirementCategory(row.primary_category)
+        importance = RequirementImportance(row.effective_importance)
+        importance_mentions = {
+            RequirementImportance(key): int(value)
+            for key, value in _loads(row.importance_mentions, {}).items()
+        }
+        for importance_key in RequirementImportance:
+            importance_mentions.setdefault(importance_key, 0)
+        cluster = RequirementCluster(
+            cluster_id=row.cluster_id,
+            canonical_requirement=row.canonical_text,
+            canonical_key=row.canonical_key,
+            primary_category=category,
+            importance=importance,
+            mention_count=row.mention_count,
+            importance_conflict=bool(row.importance_conflict),
+            importance_mentions=importance_mentions,
+            source_quotes=_loads(row.source_quotes, []),
+            source_ids=[],
+            is_eligibility=category == RequirementCategory.ELIGIBILITY,
+            is_trainable=category == RequirementCategory.TRAINABLE,
+            volatility=TechnologyVolatility(row.volatility),
+            minimum_months=row.minimum_months,
+            tool_specificity=row.tool_specificity,
+            excluded=bool(row.excluded),
+            exclusion_reason=row.exclusion_reason,
+        )
+        clusters.append(cluster)
+        if row.match_level is None:
+            continue
+        links: list[EvidenceLink] = []
+        for evidence in evidence_by_requirement[row.id]:
+            source_type = EvidenceSource(evidence.source_type)
+            catalog_by_id.setdefault(
+                evidence.evidence_id,
+                EvidenceCatalogItem(
+                    evidence_id=evidence.evidence_id,
+                    source=source_type,
+                    text=evidence.source_text,
+                ),
+            )
+            links.append(
+                EvidenceLink(
+                    requirement_id=row.cluster_id,
+                    evidence_id=evidence.evidence_id,
+                    source=source_type,
+                    relationship=EvidenceRelationship(evidence.relationship),
+                    depth=EvidenceDepth(evidence.depth),
+                    volatility=TechnologyVolatility(row.volatility),
+                    is_duplicate=bool(evidence.duplicate),
+                    is_contradiction=bool(evidence.contradiction),
+                    explanation=evidence.explanation or "",
+                    precomputed_strength=evidence.base_strength,
+                )
+            )
+        match_level = MatchLevel(row.match_level)
+        assessments.append(
+            RequirementAssessment(
+                cluster_id=row.cluster_id,
+                category=category,
+                importance=importance,
+                match_level=match_level,
+                strength=row.strength,
+                evidence_links=links,
+                explanation=row.explanation or "",
+                known=match_level != MatchLevel.UNKNOWN,
+                confidence_evidence_count=len(
+                    [link for link in links if not link.is_duplicate]
+                ),
+            )
+        )
+    return clusters, assessments, list(catalog_by_id.values())
+
+
+def _known_coverage(assessments: list[RequirementAssessment]) -> float:
+    total = sum(IMPORTANCE_WEIGHTS[item.importance] for item in assessments)
+    known = sum(
+        IMPORTANCE_WEIGHTS[item.importance]
+        for item in assessments
+        if item.known and item.strength is not None
+    )
+    return known / total if total else 0.0
+
+
+def _reliability(assessments: list[RequirementAssessment]) -> float:
+    values: list[float] = []
+    for assessment in assessments:
+        links = [link for link in assessment.evidence_links if not link.is_duplicate]
+        if links:
+            values.append(max(SOURCE_MULTIPLIERS[link.source] for link in links))
+        elif assessment.known and assessment.strength is not None:
+            values.append(1.0)
+    return sum(values) / len(values) if values else 0.0
+
+
+def _summary(
+    clusters: list[RequirementCluster],
+    assessments: list[RequirementAssessment],
+    display_score: int,
+    score_band: str,
+):
+    cluster_map = {item.cluster_id: item for item in clusters}
+    strengths: list[AnalysisInsight] = []
+    concerns: list[AnalysisInsight] = []
+    for assessment in assessments:
+        cluster = cluster_map[assessment.cluster_id]
+        if assessment.match_level in {MatchLevel.STRONG, MatchLevel.MODERATE}:
+            strengths.append(
+                AnalysisInsight(
+                    title=cluster.canonical_requirement,
+                    explanation="Supported by profile evidence.",
+                )
+            )
+        elif assessment.match_level == MatchLevel.UNKNOWN:
+            concerns.append(
+                AnalysisInsight(
+                    title=f"{cluster.canonical_requirement} needs confirmation",
+                    explanation="Review the requirement and add truthful evidence when available.",
+                )
+            )
+        else:
+            concerns.append(
+                AnalysisInsight(
+                    title=f"{cluster.canonical_requirement} needs clearer evidence",
+                    explanation="Add a concrete work or project example when factually accurate.",
+                )
+            )
+    return present_analysis(
+        display_score=display_score,
+        score_band=score_band,
+        strengths=strengths[:3],
+        concerns=concerns[:3],
+    )
+
+
+def apply_user_overrides(
+    db: Session,
+    source_analysis_id: int,
+    override_inputs: list[RoleMatchOverrideInput],
+) -> RoleMatchAnalysis:
+    source = db.query(RoleMatchAnalysis).filter_by(id=source_analysis_id).first()
+    if source is None:
+        raise RoleMatchAnalysisNotFoundError(source_analysis_id)
+
+    clusters, assessments, catalog = _reconstruct_source(db, source)
+    cluster_map = {item.canonical_key: item for item in clusters}
+    assessment_map = {item.cluster_id: item for item in assessments}
+    snapshot_overrides: list[SnapshotOverride] = []
+
+    for request in override_inputs:
+        cluster = cluster_map.get(request.requirement_key)
+        if cluster is None:
+            raise InvalidRequestError("Requirement was not found in this analysis")
+        extracted_value: Any
+        if request.field_name == "importance":
+            extracted_value = cluster.importance.value
+            try:
+                importance = RequirementImportance(str(request.effective_value))
+            except ValueError as exc:
+                raise InvalidRequestError("Invalid requirement importance") from exc
+            cluster = cluster.model_copy(update={"importance": importance})
+            cluster_map[cluster.canonical_key] = cluster
+            assessment = assessment_map.get(cluster.cluster_id)
+            if assessment is not None:
+                assessment_map[cluster.cluster_id] = assessment.model_copy(
+                    update={"importance": importance}
+                )
+        elif request.field_name == "excluded":
+            extracted_value = cluster.excluded
+            if not isinstance(request.effective_value, bool):
+                raise InvalidRequestError("Excluded override must be true or false")
+            if (
+                cluster.exclusion_reason == "potentially_non_job_related"
+                and request.effective_value is False
+            ):
+                raise InvalidRequestError(
+                    "Potentially non-job-related requirements cannot be restored to scoring"
+                )
+            cluster = cluster.model_copy(
+                update={
+                    "excluded": request.effective_value,
+                    "exclusion_reason": (
+                        "user_excluded" if request.effective_value else None
+                    ),
+                }
+            )
+            cluster_map[cluster.canonical_key] = cluster
+            if request.effective_value:
+                assessment_map.pop(cluster.cluster_id, None)
+        elif request.field_name == "experience_status":
+            assessment = assessment_map.get(cluster.cluster_id)
+            extracted_value = assessment.match_level.value if assessment else "unknown"
+            status = str(request.effective_value)
+            if status == "no_experience":
+                assessment_map[cluster.cluster_id] = RequirementAssessment(
+                    cluster_id=cluster.cluster_id,
+                    category=cluster.primary_category,
+                    importance=cluster.importance,
+                    match_level=MatchLevel.NO_EVIDENCE,
+                    strength=0.0,
+                    evidence_links=[],
+                    explanation="The user confirmed they do not have this experience.",
+                    known=True,
+                )
+            elif status == "not_in_profile":
+                assessment_map[cluster.cluster_id] = RequirementAssessment(
+                    cluster_id=cluster.cluster_id,
+                    category=cluster.primary_category,
+                    importance=cluster.importance,
+                    match_level=MatchLevel.UNKNOWN,
+                    strength=None,
+                    evidence_links=[],
+                    explanation="The user indicated this evidence is not included in the profile.",
+                    known=False,
+                )
+            else:
+                raise InvalidRequestError(
+                    "Experience status must be no_experience or not_in_profile"
+                )
+        elif request.field_name == "evidence_unlink":
+            evidence_id = str(request.effective_value)
+            assessment = assessment_map.get(cluster.cluster_id)
+            if assessment is None or not any(
+                link.evidence_id == evidence_id for link in assessment.evidence_links
+            ):
+                raise InvalidRequestError("Evidence link was not found for this requirement")
+            extracted_value = evidence_id
+            remaining = [
+                link for link in assessment.evidence_links if link.evidence_id != evidence_id
+            ]
+            if cluster.minimum_months is not None:
+                replacement = RequirementAssessment(
+                    cluster_id=cluster.cluster_id,
+                    category=cluster.primary_category,
+                    importance=cluster.importance,
+                    match_level=MatchLevel.UNKNOWN,
+                    strength=None,
+                    evidence_links=remaining,
+                    explanation="Duration needs review after evidence was unlinked.",
+                    known=False,
+                    confidence_evidence_count=len(remaining),
+                )
+            else:
+                replacement = combine_evidence(remaining, cluster, source.analysis_date)
+            assessment_map[cluster.cluster_id] = replacement
+        else:
+            raise InvalidRequestError("Unsupported role match override")
+
+        snapshot_overrides.append(
+            SnapshotOverride(
+                requirement_key=cluster.canonical_key,
+                field_name=request.field_name,
+                extracted_value=extracted_value,
+                effective_value=request.effective_value,
+                reason=request.reason,
+            )
+        )
+
+    updated_clusters = [cluster_map[item.canonical_key] for item in clusters]
+    updated_assessments = [
+        assessment_map[item.cluster_id]
+        for item in updated_clusters
+        if not item.excluded and item.cluster_id in assessment_map
+    ]
+    score = score_role_match(updated_assessments)
+    known_coverage = _known_coverage(updated_assessments)
+    conflict_rate = (
+        sum(item.importance_conflict for item in updated_clusters)
+        / max(len(updated_clusters), 1)
+    )
+    confidence = calculate_confidence(
+        ConfidenceInputs(
+            known_coverage=known_coverage,
+            evidence_reliability=_reliability(updated_assessments),
+            evidence_consistency=1.0 - min(conflict_rate, 1.0),
+        )
+    )
+    display = decide_authoritative_display(
+        known_coverage=known_coverage,
+        confidence=confidence.score,
+        conflict_rate=conflict_rate,
+        requirement_count=len([item for item in updated_clusters if not item.excluded]),
+        scoring_succeeded=True,
+    )
+    summary = _summary(
+        updated_clusters,
+        updated_assessments,
+        score.display_score,
+        score.score_band,
+    )
+    excluded_items = _loads(source.excluded_items, [])
+    for item in updated_clusters:
+        if item.excluded and not any(
+            existing.get("text") == item.canonical_requirement
+            for existing in excluded_items
+        ):
+            excluded_items.append(
+                {
+                    "source_id": item.cluster_id,
+                    "text": item.canonical_requirement,
+                    "reason": item.exclusion_reason or "user_excluded",
+                }
+            )
+
+    return save_analysis_snapshot(
+        db,
+        SnapshotInput(
+            profile_id=source.profile_id,
+            application_id=source.application_id,
+            parent_analysis_id=source.id,
+            state="success" if display.show_score else "needs_review",
+            job_description=source.job_description,
+            safe_profile_json=source.safe_profile_snapshot,
+            provider=source.model_provider,
+            model_name=source.model_name,
+            raw_llm_output=source.raw_llm_output,
+            clusters=updated_clusters,
+            assessments=updated_assessments,
+            catalog=catalog,
+            score=score,
+            confidence=confidence,
+            eligibility=EligibilityAssessment(
+                status=EligibilityStatus(source.eligibility_status)
+            ),
+            show_authoritative_score=display.show_score,
+            failure_code=None if display.show_score else display.reason,
+            excluded_items=excluded_items,
+            summary=summary,
+            analysis_date=source.analysis_date,
+            overrides=tuple(snapshot_overrides),
+        ),
+    )

--- a/backend/app/role_match/pipeline.py
+++ b/backend/app/role_match/pipeline.py
@@ -7,6 +7,12 @@ from datetime import date
 
 from sqlalchemy.orm import Session
 
+from app.role_match.carry_forward import (
+    apply_carried_experience_overrides,
+    apply_carried_overrides_to_clusters,
+    filter_carried_evidence_links,
+    prepare_parent_overrides,
+)
 from app.role_match.clustering import cluster_requirements
 from app.role_match.confidence import calculate_confidence, decide_authoritative_display
 from app.role_match.constants import IMPORTANCE_WEIGHTS, SOURCE_MULTIPLIERS
@@ -271,9 +277,18 @@ def analyze_role_match(
         requirements.append(requirement)
 
     clustering = cluster_requirements(requirements)
+    prepared_overrides = prepare_parent_overrides(
+        db,
+        parent_analysis_id,
+        clustering.clusters,
+    )
+    clusters = apply_carried_overrides_to_clusters(
+        clustering.clusters,
+        prepared_overrides,
+    )
     try:
         linking = link_candidate_evidence(
-            clustering.clusters,
+            clusters,
             catalog,
             provider,
             api_key,
@@ -294,11 +309,15 @@ def analyze_role_match(
         )
 
     links_by_requirement = defaultdict(list)
-    for link in linking.valid_links:
+    filtered_links = filter_carried_evidence_links(
+        linking.valid_links,
+        prepared_overrides,
+    )
+    for link in filtered_links:
         links_by_requirement[link.requirement_id].append(link)
 
     assessments = []
-    for cluster in clustering.clusters:
+    for cluster in clusters:
         if cluster.excluded or cluster.is_eligibility or cluster.is_trainable:
             continue
         if cluster.primary_category in {
@@ -324,10 +343,15 @@ def analyze_role_match(
             item = combine_evidence(links, cluster, analysis_date)
         assessments.append(item)
 
+    assessments = apply_carried_experience_overrides(
+        assessments,
+        clusters,
+        prepared_overrides,
+    )
     score = score_role_match(assessments)
     known_coverage = _known_coverage(assessments)
     consistency, conflict_rate = _consistency(
-        clustering.clusters,
+        clusters,
         len(clustering.unresolved_conflicts) + fairness_reviews,
         linking.invalid_link_count,
     )
@@ -338,20 +362,16 @@ def analyze_role_match(
             evidence_consistency=consistency,
         )
     )
-    eligibility = assess_eligibility(
-        _eligibility(clustering.clusters, links_by_requirement)
-    )
+    eligibility = assess_eligibility(_eligibility(clusters, links_by_requirement))
     display = decide_authoritative_display(
         known_coverage=known_coverage,
         confidence=confidence.score,
         conflict_rate=conflict_rate,
-        requirement_count=len(
-            [cluster for cluster in clustering.clusters if not cluster.excluded]
-        ),
+        requirement_count=len([cluster for cluster in clusters if not cluster.excluded]),
         scoring_succeeded=True,
     )
     state = AnalysisState.SUCCESS if display.show_score else AnalysisState.NEEDS_REVIEW
-    summary = _human_summary(clustering.clusters, assessments, score)
+    summary = _human_summary(clusters, assessments, score)
     return save_analysis_snapshot(
         db,
         SnapshotInput(
@@ -370,7 +390,7 @@ def analyze_role_match(
                 },
                 ensure_ascii=False,
             ),
-            clusters=clustering.clusters,
+            clusters=clusters,
             assessments=assessments,
             catalog=catalog,
             score=score,
@@ -381,5 +401,6 @@ def analyze_role_match(
             excluded_items=excluded_items,
             summary=summary,
             analysis_date=analysis_date,
+            overrides=prepared_overrides,
         ),
     )

--- a/backend/app/role_match/repository.py
+++ b/backend/app/role_match/repository.py
@@ -11,6 +11,7 @@ from app.role_match.api_schemas import (
     RoleMatchCategoryResponse,
     RoleMatchComparisonResponse,
     RoleMatchEvidenceResponse,
+    RoleMatchOverrideResponse,
     RoleMatchRequirementResponse,
     RoleMatchSummaryResponse,
     RoleMatchVersionItem,
@@ -105,10 +106,29 @@ def serialize_analysis(
         RoleMatchCategoryResponse(**item)
         for item in (scoring.get("score") or {}).get("category_assessments", [])
     ]
-    review_count = (
+    override_rows = (
         db.query(RoleMatchOverride)
-        .filter_by(analysis_id=analysis.id, carry_status="needs_review")
-        .count()
+        .filter_by(analysis_id=analysis.id)
+        .order_by(RoleMatchOverride.created_at.asc(), RoleMatchOverride.id.asc())
+        .all()
+    )
+    override_payload = [
+        RoleMatchOverrideResponse(
+            id=item.id,
+            requirement_key=item.requirement_key,
+            field_name=item.field_name,
+            extracted_value=_loads(item.extracted_value, None),
+            effective_value=_loads(item.effective_value, None),
+            reason=item.reason,
+            source=item.source,
+            carry_status=item.carry_status,
+            source_override_id=item.source_override_id,
+            created_at=item.created_at,
+        )
+        for item in override_rows
+    ]
+    review_count = sum(
+        item.carry_status == "needs_review" for item in override_rows
     )
     return RoleMatchAnalysisResponse(
         id=analysis.id,
@@ -124,6 +144,7 @@ def serialize_analysis(
         category_breakdown=category_breakdown,
         requirements=requirement_payload,
         excluded_items=_loads(analysis.excluded_items, []),
+        overrides=override_payload,
         override_review_count=review_count,
         rules_version=analysis.rules_version,
         prompt_version=analysis.prompt_version,

--- a/backend/app/role_match/restore.py
+++ b/backend/app/role_match/restore.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.exceptions import InvalidRequestError, RoleMatchAnalysisNotFoundError
+from app.role_match.domain import (
+    AnalysisSummary,
+    ConfidenceAssessment,
+    ConfidenceBand,
+    EligibilityAssessment,
+    EligibilityStatus,
+)
+from app.role_match.models import RoleMatchAnalysis, RoleMatchOverride
+from app.role_match.overrides import _reconstruct_source
+from app.role_match.scoring import score_role_match
+from app.role_match.snapshots import SnapshotInput, save_analysis_snapshot
+
+
+def _loads(raw: str | None, default):
+    if not raw:
+        return default
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def restore_user_override(
+    db: Session,
+    analysis_id: int,
+    override_id: int,
+) -> RoleMatchAnalysis:
+    current = db.query(RoleMatchAnalysis).filter_by(id=analysis_id).first()
+    if current is None:
+        raise RoleMatchAnalysisNotFoundError(analysis_id)
+    override = db.query(RoleMatchOverride).filter_by(
+        id=override_id,
+        analysis_id=analysis_id,
+    ).first()
+    if override is None:
+        raise InvalidRequestError("Override was not found in this analysis")
+    if current.parent_analysis_id is None:
+        raise InvalidRequestError("This analysis does not have an original snapshot")
+
+    original = db.query(RoleMatchAnalysis).filter_by(
+        id=current.parent_analysis_id
+    ).first()
+    if original is None:
+        raise RoleMatchAnalysisNotFoundError(current.parent_analysis_id)
+
+    clusters, assessments, catalog = _reconstruct_source(db, original)
+    score = score_role_match(assessments) if assessments else None
+    normalized = _loads(original.normalized_payload, {})
+    summary_raw = normalized.get("summary")
+    summary = AnalysisSummary.model_validate(summary_raw) if summary_raw else None
+    confidence = None
+    if original.confidence_score is not None and original.confidence_band is not None:
+        confidence = ConfidenceAssessment(
+            score=original.confidence_score,
+            band=ConfidenceBand(original.confidence_band),
+            explanation="Restored from the original audited analysis.",
+        )
+
+    return save_analysis_snapshot(
+        db,
+        SnapshotInput(
+            profile_id=original.profile_id,
+            application_id=original.application_id,
+            parent_analysis_id=current.id,
+            state=original.state,
+            job_description=original.job_description,
+            safe_profile_json=original.safe_profile_snapshot,
+            provider=original.model_provider,
+            model_name=original.model_name,
+            raw_llm_output=original.raw_llm_output,
+            clusters=clusters,
+            assessments=assessments,
+            catalog=catalog,
+            score=score,
+            confidence=confidence,
+            eligibility=EligibilityAssessment(
+                status=EligibilityStatus(original.eligibility_status)
+            ),
+            show_authoritative_score=bool(original.show_authoritative_score),
+            failure_code=original.failure_code,
+            excluded_items=_loads(original.excluded_items, []),
+            summary=summary,
+            analysis_date=original.analysis_date,
+        ),
+    )

--- a/backend/app/role_match/scoring.py
+++ b/backend/app/role_match/scoring.py
@@ -92,6 +92,11 @@ def round_to_nearest_five(value: float) -> int:
     return int(max(Decimal("0"), min(rounded, Decimal("100"))))
 
 
+def _display_cap(cap: int) -> int:
+    """Convert an internal cap to the highest allowed five-point display value."""
+    return max(0, min(100, (cap // 5) * 5))
+
+
 def score_band(display_score: int) -> str:
     if display_score >= 85:
         return "exceptional_evidence_match"
@@ -126,7 +131,7 @@ def score_role_match(assessments: list[RequirementAssessment]) -> ScoreResult:
     capped_score = min(raw_score, float(cap)) if cap is not None else raw_score
     display_score = round_to_nearest_five(capped_score)
     if cap is not None:
-        display_score = min(display_score, cap)
+        display_score = min(display_score, _display_cap(cap))
     return ScoreResult(
         category_assessments=category_assessments,
         raw_score=raw_score,

--- a/backend/app/role_match/snapshots.py
+++ b/backend/app/role_match/snapshots.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 from dataclasses import dataclass
 from datetime import date
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -18,7 +19,24 @@ from app.role_match.domain import (
     ScoreResult,
 )
 from app.role_match.evidence_strength import calculate_base_strength, calculate_recency_multiplier
-from app.role_match.models import RoleMatchAnalysis, RoleMatchEvidence, RoleMatchRequirement
+from app.role_match.models import (
+    RoleMatchAnalysis,
+    RoleMatchEvidence,
+    RoleMatchOverride,
+    RoleMatchRequirement,
+)
+
+
+@dataclass(frozen=True)
+class SnapshotOverride:
+    requirement_key: str
+    field_name: str
+    extracted_value: Any
+    effective_value: Any
+    reason: str
+    source: str = "user"
+    carry_status: str = "carried_forward"
+    source_override_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -43,6 +61,7 @@ class SnapshotInput:
     excluded_items: list[dict]
     summary: AnalysisSummary | None
     analysis_date: date
+    overrides: tuple[SnapshotOverride, ...] = ()
 
 
 def _sha256(value: str) -> str:
@@ -98,15 +117,26 @@ def save_analysis_snapshot(db: Session, value: SnapshotInput) -> RoleMatchAnalys
 
     assessment_map = {item.cluster_id: item for item in value.assessments}
     catalog_map = {item.evidence_id: item for item in value.catalog}
+    importance_overrides = {
+        item.requirement_key: item
+        for item in value.overrides
+        if item.field_name == "importance" and item.carry_status == "carried_forward"
+    }
     for index, cluster in enumerate(value.clusters):
         assessment = assessment_map.get(cluster.cluster_id)
+        importance_override = importance_overrides.get(cluster.canonical_key)
+        extracted_importance = (
+            str(importance_override.extracted_value)
+            if importance_override is not None
+            else cluster.importance.value
+        )
         requirement = RoleMatchRequirement(
             analysis_id=analysis.id,
             cluster_id=cluster.cluster_id,
             canonical_key=cluster.canonical_key,
             canonical_text=cluster.canonical_requirement,
             primary_category=cluster.primary_category.value,
-            extracted_importance=cluster.importance.value,
+            extracted_importance=extracted_importance,
             effective_importance=cluster.importance.value,
             mention_count=cluster.mention_count,
             importance_conflict=cluster.importance_conflict,
@@ -153,6 +183,22 @@ def save_analysis_snapshot(db: Session, value: SnapshotInput) -> RoleMatchAnalys
                     rank=rank,
                 )
             )
+
+    for item in value.overrides:
+        db.add(
+            RoleMatchOverride(
+                analysis_id=analysis.id,
+                requirement_key=item.requirement_key,
+                field_name=item.field_name,
+                extracted_value=json.dumps(item.extracted_value, ensure_ascii=False),
+                effective_value=json.dumps(item.effective_value, ensure_ascii=False),
+                reason=item.reason,
+                source=item.source,
+                carry_status=item.carry_status,
+                source_override_id=item.source_override_id,
+            )
+        )
+
     if value.parent_analysis_id:
         parent = db.query(RoleMatchAnalysis).filter_by(id=value.parent_analysis_id).first()
         if parent:

--- a/backend/app/routes/analyze.py
+++ b/backend/app/routes/analyze.py
@@ -25,6 +25,7 @@ from app.role_match.repository import (
     list_versions,
     serialize_analysis,
 )
+from app.role_match.restore import restore_user_override
 from app.schemas import FitAnalysisRequest, FitAnalysisResponse
 from app.services.fit_analysis import analyze_fit
 from app.utils import format_profile_for_llm, profile_to_schema
@@ -166,3 +167,16 @@ def apply_role_match_overrides(
 ):
     child = apply_user_overrides(db, analysis_id, body.overrides)
     return serialize_analysis(db, child)
+
+
+@router.delete(
+    "/analyze/role-match/{analysis_id}/overrides/{override_id}",
+    response_model=RoleMatchAnalysisResponse,
+)
+def restore_role_match_override(
+    analysis_id: int,
+    override_id: int,
+    db: Session = Depends(get_db),
+):
+    restored = restore_user_override(db, analysis_id, override_id)
+    return serialize_analysis(db, restored)

--- a/backend/app/routes/analyze.py
+++ b/backend/app/routes/analyze.py
@@ -13,9 +13,11 @@ from app.role_match.api_schemas import (
     RoleMatchAnalysisResponse,
     RoleMatchAnalyzeRequest,
     RoleMatchComparisonResponse,
+    RoleMatchOverridesRequest,
     RoleMatchReanalyzeRequest,
     RoleMatchVersionsResponse,
 )
+from app.role_match.overrides import apply_user_overrides
 from app.role_match.pipeline import analyze_role_match
 from app.role_match.repository import (
     compare_analyses,
@@ -150,4 +152,17 @@ def reanalyze_role_match(
         parent_analysis_id=parent.id,
         analysis_date=date.today(),
     )
+    return serialize_analysis(db, child)
+
+
+@router.post(
+    "/analyze/role-match/{analysis_id}/overrides",
+    response_model=RoleMatchAnalysisResponse,
+)
+def apply_role_match_overrides(
+    analysis_id: int,
+    body: RoleMatchOverridesRequest,
+    db: Session = Depends(get_db),
+):
+    child = apply_user_overrides(db, analysis_id, body.overrides)
     return serialize_analysis(db, child)

--- a/backend/tests/role_match/test_carry_forward.py
+++ b/backend/tests/role_match/test_carry_forward.py
@@ -1,3 +1,7 @@
+from app.role_match.carry_forward import (
+    apply_carried_experience_overrides,
+    apply_carried_overrides_to_clusters,
+)
 from app.role_match.domain import (
     MatchLevel,
     RequirementAssessment,
@@ -5,10 +9,6 @@ from app.role_match.domain import (
     RequirementCluster,
     RequirementImportance,
     TechnologyVolatility,
-)
-from app.role_match.overrides import (
-    apply_carried_experience_overrides,
-    apply_carried_overrides_to_clusters,
 )
 from app.role_match.snapshots import SnapshotOverride
 

--- a/backend/tests/role_match/test_carry_forward.py
+++ b/backend/tests/role_match/test_carry_forward.py
@@ -1,0 +1,104 @@
+from app.role_match.domain import (
+    MatchLevel,
+    RequirementAssessment,
+    RequirementCategory,
+    RequirementCluster,
+    RequirementImportance,
+    TechnologyVolatility,
+)
+from app.role_match.overrides import (
+    apply_carried_experience_overrides,
+    apply_carried_overrides_to_clusters,
+)
+from app.role_match.snapshots import SnapshotOverride
+
+
+def cluster() -> RequirementCluster:
+    return RequirementCluster(
+        cluster_id="req:terraform",
+        canonical_requirement="Terraform experience",
+        canonical_key="terraform",
+        primary_category=RequirementCategory.RELEVANT_COMPETENCIES,
+        importance=RequirementImportance.CRITICAL,
+        mention_count=1,
+        importance_conflict=False,
+        importance_mentions={
+            RequirementImportance.CRITICAL: 1,
+            RequirementImportance.IMPORTANT: 0,
+            RequirementImportance.SUPPORTING: 0,
+        },
+        source_quotes=["Terraform experience"],
+        source_ids=["jd:terraform"],
+        is_eligibility=False,
+        is_trainable=False,
+        volatility=TechnologyVolatility.EVOLVING,
+        tool_specificity="capability",
+    )
+
+
+def assessment() -> RequirementAssessment:
+    return RequirementAssessment(
+        cluster_id="req:terraform",
+        category=RequirementCategory.RELEVANT_COMPETENCIES,
+        importance=RequirementImportance.CRITICAL,
+        match_level=MatchLevel.WEAK,
+        strength=0.3,
+        known=True,
+    )
+
+
+def test_carried_importance_override_changes_new_cluster() -> None:
+    result = apply_carried_overrides_to_clusters(
+        [cluster()],
+        (
+            SnapshotOverride(
+                requirement_key="terraform",
+                field_name="importance",
+                extracted_value="critical",
+                effective_value="supporting",
+                reason="Listed as preferred",
+                source="carry_forward",
+                carry_status="carried_forward",
+            ),
+        ),
+    )
+    assert result[0].importance == RequirementImportance.SUPPORTING
+
+
+def test_needs_review_override_does_not_change_new_cluster() -> None:
+    result = apply_carried_overrides_to_clusters(
+        [cluster()],
+        (
+            SnapshotOverride(
+                requirement_key="terraform",
+                field_name="importance",
+                extracted_value="critical",
+                effective_value="supporting",
+                reason="Old override",
+                source="carry_forward",
+                carry_status="needs_review",
+            ),
+        ),
+    )
+    assert result[0].importance == RequirementImportance.CRITICAL
+
+
+def test_carried_no_experience_override_replaces_assessment() -> None:
+    result = apply_carried_experience_overrides(
+        [assessment()],
+        [cluster()],
+        (
+            SnapshotOverride(
+                requirement_key="terraform",
+                field_name="experience_status",
+                extracted_value="weak",
+                effective_value="no_experience",
+                reason="User confirmed no experience",
+                source="carry_forward",
+                carry_status="carried_forward",
+            ),
+        ),
+    )
+    assert result[0].match_level == MatchLevel.NO_EVIDENCE
+    assert result[0].strength == 0.0
+    assert result[0].known is True

--- a/backend/tests/role_match/test_carry_status.py
+++ b/backend/tests/role_match/test_carry_status.py
@@ -1,0 +1,53 @@
+from app.role_match.domain import (
+    OverrideCarryStatus,
+    RequirementCategory,
+    RequirementCluster,
+    RequirementImportance,
+    TechnologyVolatility,
+)
+from app.role_match.overrides import classify_override_carry
+
+
+def cluster() -> RequirementCluster:
+    return RequirementCluster(
+        cluster_id="req:terraform",
+        canonical_requirement="Terraform experience",
+        canonical_key="terraform",
+        primary_category=RequirementCategory.RELEVANT_COMPETENCIES,
+        importance=RequirementImportance.CRITICAL,
+        mention_count=1,
+        importance_conflict=False,
+        importance_mentions={
+            RequirementImportance.CRITICAL: 1,
+            RequirementImportance.IMPORTANT: 0,
+            RequirementImportance.SUPPORTING: 0,
+        },
+        source_quotes=["Terraform experience"],
+        source_ids=["jd:terraform"],
+        is_eligibility=False,
+        is_trainable=False,
+        volatility=TechnologyVolatility.EVOLVING,
+        tool_specificity="capability",
+    )
+
+
+def test_unconfirmed_override_stays_needs_review_even_on_exact_match() -> None:
+    status, target = classify_override_carry(
+        previous_key="terraform",
+        previous_category="relevant_competencies",
+        previous_status="needs_review",
+        new_clusters=[cluster()],
+    )
+    assert status == OverrideCarryStatus.NEEDS_REVIEW
+    assert target == "terraform"
+
+
+def test_not_applicable_override_remains_inactive() -> None:
+    status, target = classify_override_carry(
+        previous_key="terraform",
+        previous_category="relevant_competencies",
+        previous_status="not_applicable",
+        new_clusters=[cluster()],
+    )
+    assert status == OverrideCarryStatus.NOT_APPLICABLE
+    assert target is None

--- a/backend/tests/role_match/test_carry_status.py
+++ b/backend/tests/role_match/test_carry_status.py
@@ -1,3 +1,4 @@
+from app.role_match.carry_policy import classify_override_carry
 from app.role_match.domain import (
     OverrideCarryStatus,
     RequirementCategory,
@@ -5,7 +6,6 @@ from app.role_match.domain import (
     RequirementImportance,
     TechnologyVolatility,
 )
-from app.role_match.overrides import classify_override_carry
 
 
 def cluster() -> RequirementCluster:

--- a/backend/tests/role_match/test_override_routes.py
+++ b/backend/tests/role_match/test_override_routes.py
@@ -1,0 +1,120 @@
+from datetime import date
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.role_match.api_schemas import (
+    RoleMatchOverrideInput,
+    RoleMatchOverridesRequest,
+)
+from app.role_match.domain import (
+    AnalysisSummary,
+    ConfidenceAssessment,
+    ConfidenceBand,
+    EligibilityAssessment,
+    EligibilityStatus,
+    RequirementAssessment,
+    RequirementCategory,
+    RequirementCluster,
+    RequirementImportance,
+    TechnologyVolatility,
+)
+from app.role_match.scoring import score_role_match
+from app.role_match.snapshots import SnapshotInput, save_analysis_snapshot
+from app.routes.analyze import apply_role_match_overrides
+
+
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def source_analysis(db):
+    cluster = RequirementCluster(
+        cluster_id="req:terraform",
+        canonical_requirement="Terraform experience",
+        canonical_key="terraform",
+        primary_category=RequirementCategory.RELEVANT_COMPETENCIES,
+        importance=RequirementImportance.CRITICAL,
+        mention_count=1,
+        importance_conflict=False,
+        importance_mentions={
+            RequirementImportance.CRITICAL: 1,
+            RequirementImportance.IMPORTANT: 0,
+            RequirementImportance.SUPPORTING: 0,
+        },
+        source_quotes=["Terraform experience"],
+        source_ids=["jd:terraform"],
+        is_eligibility=False,
+        is_trainable=False,
+        volatility=TechnologyVolatility.EVOLVING,
+        tool_specificity="capability",
+    )
+    assessment = RequirementAssessment(
+        cluster_id=cluster.cluster_id,
+        category=cluster.primary_category,
+        importance=cluster.importance,
+        match_level="no_evidence",
+        strength=0.0,
+        known=True,
+    )
+    score = score_role_match([assessment])
+    return save_analysis_snapshot(
+        db,
+        SnapshotInput(
+            profile_id=None,
+            application_id=None,
+            parent_analysis_id=None,
+            state="needs_review",
+            job_description="Terraform role",
+            safe_profile_json="{}",
+            provider="openai",
+            model_name="model",
+            raw_llm_output="{}",
+            clusters=[cluster],
+            assessments=[assessment],
+            catalog=[],
+            score=score,
+            confidence=ConfidenceAssessment(
+                score=0.6,
+                band=ConfidenceBand.MEDIUM,
+                explanation="Limited evidence",
+            ),
+            eligibility=EligibilityAssessment(
+                status=EligibilityStatus.LIKELY_ELIGIBLE
+            ),
+            show_authoritative_score=False,
+            failure_code="insufficient_requirements",
+            excluded_items=[],
+            summary=AnalysisSummary(
+                headline="Analysis needs review",
+                description="Review extracted requirements.",
+                next_step="Review Terraform.",
+            ),
+            analysis_date=date(2026, 8, 6),
+        ),
+    )
+
+
+def test_override_route_returns_new_immutable_snapshot() -> None:
+    db = db_session()
+    parent = source_analysis(db)
+    response = apply_role_match_overrides(
+        parent.id,
+        RoleMatchOverridesRequest(
+            overrides=[
+                RoleMatchOverrideInput(
+                    requirement_key="terraform",
+                    field_name="importance",
+                    effective_value="supporting",
+                    reason="Listed as preferred",
+                )
+            ]
+        ),
+        db,
+    )
+    assert response.id != parent.id
+    assert response.parent_analysis_id == parent.id
+    assert response.requirements[0].importance == "supporting"

--- a/backend/tests/role_match/test_override_serialization.py
+++ b/backend/tests/role_match/test_override_serialization.py
@@ -1,0 +1,122 @@
+from datetime import date
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.role_match.api_schemas import RoleMatchOverrideInput
+from app.role_match.domain import (
+    AnalysisSummary,
+    ConfidenceAssessment,
+    ConfidenceBand,
+    EligibilityAssessment,
+    EligibilityStatus,
+    RequirementAssessment,
+    RequirementCategory,
+    RequirementCluster,
+    RequirementImportance,
+    TechnologyVolatility,
+)
+from app.role_match.overrides import apply_user_overrides
+from app.role_match.repository import serialize_analysis
+from app.role_match.scoring import score_role_match
+from app.role_match.snapshots import SnapshotInput, save_analysis_snapshot
+
+
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def source_analysis(db):
+    cluster = RequirementCluster(
+        cluster_id="req:terraform",
+        canonical_requirement="Terraform experience",
+        canonical_key="terraform",
+        primary_category=RequirementCategory.RELEVANT_COMPETENCIES,
+        importance=RequirementImportance.CRITICAL,
+        mention_count=1,
+        importance_conflict=False,
+        importance_mentions={
+            RequirementImportance.CRITICAL: 1,
+            RequirementImportance.IMPORTANT: 0,
+            RequirementImportance.SUPPORTING: 0,
+        },
+        source_quotes=["Terraform experience"],
+        source_ids=["jd:terraform"],
+        is_eligibility=False,
+        is_trainable=False,
+        volatility=TechnologyVolatility.EVOLVING,
+        tool_specificity="capability",
+    )
+    assessment = RequirementAssessment(
+        cluster_id=cluster.cluster_id,
+        category=cluster.primary_category,
+        importance=cluster.importance,
+        match_level="no_evidence",
+        strength=0.0,
+        known=True,
+    )
+    score = score_role_match([assessment])
+    return save_analysis_snapshot(
+        db,
+        SnapshotInput(
+            profile_id=None,
+            application_id=None,
+            parent_analysis_id=None,
+            state="needs_review",
+            job_description="Terraform role",
+            safe_profile_json="{}",
+            provider="openai",
+            model_name="model",
+            raw_llm_output="{}",
+            clusters=[cluster],
+            assessments=[assessment],
+            catalog=[],
+            score=score,
+            confidence=ConfidenceAssessment(
+                score=0.6,
+                band=ConfidenceBand.MEDIUM,
+                explanation="Limited evidence",
+            ),
+            eligibility=EligibilityAssessment(
+                status=EligibilityStatus.LIKELY_ELIGIBLE
+            ),
+            show_authoritative_score=False,
+            failure_code="insufficient_requirements",
+            excluded_items=[],
+            summary=AnalysisSummary(
+                headline="Analysis needs review",
+                description="Review extracted requirements.",
+                next_step="Review Terraform.",
+            ),
+            analysis_date=date(2026, 8, 6),
+        ),
+    )
+
+
+def test_serialized_analysis_exposes_override_audit_fields() -> None:
+    db = db_session()
+    parent = source_analysis(db)
+    child = apply_user_overrides(
+        db,
+        parent.id,
+        [
+            RoleMatchOverrideInput(
+                requirement_key="terraform",
+                field_name="importance",
+                effective_value="supporting",
+                reason="Listed as preferred",
+            )
+        ],
+    )
+    response = serialize_analysis(db, child)
+    assert len(response.overrides) == 1
+    override = response.overrides[0]
+    assert override.requirement_key == "terraform"
+    assert override.field_name == "importance"
+    assert override.extracted_value == "critical"
+    assert override.effective_value == "supporting"
+    assert override.reason == "Listed as preferred"
+    assert override.carry_status == "carried_forward"

--- a/backend/tests/role_match/test_overrides.py
+++ b/backend/tests/role_match/test_overrides.py
@@ -1,0 +1,231 @@
+from datetime import date
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.role_match.api_schemas import RoleMatchOverrideInput
+from app.role_match.domain import (
+    AnalysisInsight,
+    AnalysisSummary,
+    ConfidenceAssessment,
+    ConfidenceBand,
+    EligibilityAssessment,
+    EligibilityStatus,
+    EvidenceCatalogItem,
+    EvidenceDepth,
+    EvidenceLink,
+    EvidenceRelationship,
+    EvidenceSource,
+    MatchLevel,
+    OverrideCarryStatus,
+    RequirementAssessment,
+    RequirementCategory,
+    RequirementCluster,
+    RequirementImportance,
+    TechnologyVolatility,
+)
+from app.role_match.models import RoleMatchOverride, RoleMatchRequirement
+from app.role_match.overrides import apply_user_overrides, classify_override_carry
+from app.role_match.scoring import score_role_match
+from app.role_match.snapshots import SnapshotInput, save_analysis_snapshot
+
+
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def cluster(key: str, text: str, importance: RequirementImportance) -> RequirementCluster:
+    return RequirementCluster(
+        cluster_id=f"req:{key}",
+        canonical_requirement=text,
+        canonical_key=key,
+        primary_category=RequirementCategory.RELEVANT_COMPETENCIES,
+        importance=importance,
+        mention_count=1,
+        importance_conflict=False,
+        importance_mentions={
+            RequirementImportance.CRITICAL: int(importance == RequirementImportance.CRITICAL),
+            RequirementImportance.IMPORTANT: int(importance == RequirementImportance.IMPORTANT),
+            RequirementImportance.SUPPORTING: int(importance == RequirementImportance.SUPPORTING),
+        },
+        source_quotes=[text],
+        source_ids=[f"jd:{key}"],
+        is_eligibility=False,
+        is_trainable=False,
+        volatility=TechnologyVolatility.EVOLVING,
+        tool_specificity="capability",
+    )
+
+
+def save_source(db):
+    python = cluster("python-backend", "Production Python backend capability", RequirementImportance.CRITICAL)
+    terraform = cluster("terraform", "Terraform experience", RequirementImportance.CRITICAL)
+    python_link = EvidenceLink(
+        requirement_id=python.cluster_id,
+        evidence_id="work:python",
+        source=EvidenceSource.WORK_EXPERIENCE,
+        relationship=EvidenceRelationship.EXACT,
+        depth=EvidenceDepth.PRODUCTION_OWNERSHIP,
+        is_current=True,
+        precomputed_strength=1.0,
+    )
+    assessments = [
+        RequirementAssessment(
+            cluster_id=python.cluster_id,
+            category=python.primary_category,
+            importance=python.importance,
+            match_level=MatchLevel.STRONG,
+            strength=1.0,
+            evidence_links=[python_link],
+            known=True,
+            confidence_evidence_count=1,
+        ),
+        RequirementAssessment(
+            cluster_id=terraform.cluster_id,
+            category=terraform.primary_category,
+            importance=terraform.importance,
+            match_level=MatchLevel.NO_EVIDENCE,
+            strength=0.0,
+            known=True,
+        ),
+    ]
+    score = score_role_match(assessments)
+    return save_analysis_snapshot(
+        db,
+        SnapshotInput(
+            profile_id=None,
+            application_id=None,
+            parent_analysis_id=None,
+            state="success",
+            job_description="Python and Terraform backend role",
+            safe_profile_json='{"skills":["Python"]}',
+            provider="openai",
+            model_name="model",
+            raw_llm_output="{}",
+            clusters=[python, terraform],
+            assessments=assessments,
+            catalog=[
+                EvidenceCatalogItem(
+                    evidence_id="work:python",
+                    source=EvidenceSource.WORK_EXPERIENCE,
+                    text="Built production Python services",
+                )
+            ],
+            score=score,
+            confidence=ConfidenceAssessment(
+                score=0.8,
+                band=ConfidenceBand.HIGH,
+                explanation="Direct evidence",
+            ),
+            eligibility=EligibilityAssessment(
+                status=EligibilityStatus.LIKELY_ELIGIBLE
+            ),
+            show_authoritative_score=True,
+            failure_code=None,
+            excluded_items=[],
+            summary=AnalysisSummary(
+                headline="Your profile is a moderate match",
+                description="Mixed evidence",
+                strengths=[
+                    AnalysisInsight(
+                        title="Production Python backend capability",
+                        explanation="Supported by work evidence.",
+                    )
+                ],
+                concerns=[
+                    AnalysisInsight(
+                        title="Terraform experience needs clearer evidence",
+                        explanation="Add a truthful work example when available.",
+                    )
+                ],
+                next_step="Clarify Terraform evidence.",
+            ),
+            analysis_date=date(2026, 8, 6),
+        ),
+    )
+
+
+def test_user_override_creates_child_and_preserves_parent() -> None:
+    db = db_session()
+    parent = save_source(db)
+
+    child = apply_user_overrides(
+        db,
+        parent.id,
+        [
+            RoleMatchOverrideInput(
+                requirement_key="terraform",
+                field_name="importance",
+                effective_value="supporting",
+                reason="The JD lists Terraform as preferred.",
+            )
+        ],
+    )
+
+    assert child.id != parent.id
+    assert child.parent_analysis_id == parent.id
+    parent_requirement = db.query(RoleMatchRequirement).filter_by(
+        analysis_id=parent.id,
+        canonical_key="terraform",
+    ).one()
+    child_requirement = db.query(RoleMatchRequirement).filter_by(
+        analysis_id=child.id,
+        canonical_key="terraform",
+    ).one()
+    assert parent_requirement.effective_importance == "critical"
+    assert child_requirement.effective_importance == "supporting"
+    assert child.raw_score > parent.raw_score
+    override = db.query(RoleMatchOverride).filter_by(analysis_id=child.id).one()
+    assert override.carry_status == "carried_forward"
+    assert override.extracted_value == '"critical"'
+    assert override.effective_value == '"supporting"'
+
+
+def test_exact_override_carries_forward() -> None:
+    status, target = classify_override_carry(
+        previous_key="python-backend",
+        previous_category="relevant_competencies",
+        new_clusters=[
+            cluster(
+                "python-backend",
+                "Production Python backend capability",
+                RequirementImportance.CRITICAL,
+            )
+        ],
+    )
+    assert status == OverrideCarryStatus.CARRIED_FORWARD
+    assert target == "python-backend"
+
+
+def test_material_category_change_needs_review() -> None:
+    changed = cluster(
+        "python-backend",
+        "Build production Python APIs",
+        RequirementImportance.CRITICAL,
+    ).model_copy(update={"primary_category": RequirementCategory.RELEVANT_WORK_TASKS})
+    status, target = classify_override_carry(
+        previous_key="python-backend",
+        previous_category="relevant_competencies",
+        new_clusters=[changed],
+    )
+    assert status == OverrideCarryStatus.NEEDS_REVIEW
+    assert target == "python-backend"
+
+
+def test_removed_requirement_is_not_applicable() -> None:
+    status, target = classify_override_carry(
+        previous_key="terraform",
+        previous_category="relevant_competencies",
+        new_clusters=[
+            cluster(
+                "python-backend",
+                "Production Python backend capability",
+                RequirementImportance.CRITICAL,
+            )
+        ],
+    )
+    assert status == OverrideCarryStatus.NOT_APPLICABLE
+    assert target is None

--- a/backend/tests/role_match/test_restore_override.py
+++ b/backend/tests/role_match/test_restore_override.py
@@ -1,0 +1,128 @@
+from datetime import date
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.role_match.api_schemas import RoleMatchOverrideInput
+from app.role_match.domain import (
+    AnalysisSummary,
+    ConfidenceAssessment,
+    ConfidenceBand,
+    EligibilityAssessment,
+    EligibilityStatus,
+    RequirementAssessment,
+    RequirementCategory,
+    RequirementCluster,
+    RequirementImportance,
+    TechnologyVolatility,
+)
+from app.role_match.models import RoleMatchOverride, RoleMatchRequirement
+from app.role_match.overrides import apply_user_overrides, restore_user_override
+from app.role_match.scoring import score_role_match
+from app.role_match.snapshots import SnapshotInput, save_analysis_snapshot
+
+
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def source_analysis(db):
+    cluster = RequirementCluster(
+        cluster_id="req:terraform",
+        canonical_requirement="Terraform experience",
+        canonical_key="terraform",
+        primary_category=RequirementCategory.RELEVANT_COMPETENCIES,
+        importance=RequirementImportance.CRITICAL,
+        mention_count=1,
+        importance_conflict=False,
+        importance_mentions={
+            RequirementImportance.CRITICAL: 1,
+            RequirementImportance.IMPORTANT: 0,
+            RequirementImportance.SUPPORTING: 0,
+        },
+        source_quotes=["Terraform experience"],
+        source_ids=["jd:terraform"],
+        is_eligibility=False,
+        is_trainable=False,
+        volatility=TechnologyVolatility.EVOLVING,
+        tool_specificity="capability",
+    )
+    assessment = RequirementAssessment(
+        cluster_id=cluster.cluster_id,
+        category=cluster.primary_category,
+        importance=cluster.importance,
+        match_level="no_evidence",
+        strength=0.0,
+        known=True,
+    )
+    score = score_role_match([assessment])
+    return save_analysis_snapshot(
+        db,
+        SnapshotInput(
+            profile_id=None,
+            application_id=None,
+            parent_analysis_id=None,
+            state="needs_review",
+            job_description="Terraform role",
+            safe_profile_json="{}",
+            provider="openai",
+            model_name="model",
+            raw_llm_output="{}",
+            clusters=[cluster],
+            assessments=[assessment],
+            catalog=[],
+            score=score,
+            confidence=ConfidenceAssessment(
+                score=0.6,
+                band=ConfidenceBand.MEDIUM,
+                explanation="Limited evidence",
+            ),
+            eligibility=EligibilityAssessment(
+                status=EligibilityStatus.LIKELY_ELIGIBLE
+            ),
+            show_authoritative_score=False,
+            failure_code="insufficient_requirements",
+            excluded_items=[],
+            summary=AnalysisSummary(
+                headline="Analysis needs review",
+                description="Review extracted requirements.",
+                next_step="Review Terraform.",
+            ),
+            analysis_date=date(2026, 8, 6),
+        ),
+    )
+
+
+def test_restore_override_creates_new_snapshot_from_original_values() -> None:
+    db = db_session()
+    original = source_analysis(db)
+    overridden = apply_user_overrides(
+        db,
+        original.id,
+        [
+            RoleMatchOverrideInput(
+                requirement_key="terraform",
+                field_name="importance",
+                effective_value="supporting",
+                reason="Listed as preferred",
+            )
+        ],
+    )
+    override = db.query(RoleMatchOverride).filter_by(
+        analysis_id=overridden.id
+    ).one()
+
+    restored = restore_user_override(db, overridden.id, override.id)
+
+    assert restored.id not in {original.id, overridden.id}
+    assert restored.parent_analysis_id == overridden.id
+    requirement = db.query(RoleMatchRequirement).filter_by(
+        analysis_id=restored.id,
+        canonical_key="terraform",
+    ).one()
+    assert requirement.effective_importance == "critical"
+    assert db.query(RoleMatchOverride).filter_by(analysis_id=restored.id).count() == 0
+    assert restored.raw_score == original.raw_score

--- a/backend/tests/role_match/test_restore_override.py
+++ b/backend/tests/role_match/test_restore_override.py
@@ -18,7 +18,8 @@ from app.role_match.domain import (
     TechnologyVolatility,
 )
 from app.role_match.models import RoleMatchOverride, RoleMatchRequirement
-from app.role_match.overrides import apply_user_overrides, restore_user_override
+from app.role_match.overrides import apply_user_overrides
+from app.role_match.restore import restore_user_override
 from app.role_match.scoring import score_role_match
 from app.role_match.snapshots import SnapshotInput, save_analysis_snapshot
 

--- a/backend/tests/role_match/test_scoring_confidence.py
+++ b/backend/tests/role_match/test_scoring_confidence.py
@@ -94,7 +94,7 @@ def test_display_rounding_and_band() -> None:
     assert score_band(80) == "strong_evidence_match"
 
 
-def test_score_role_match_applies_essential_cap() -> None:
+def test_score_role_match_applies_essential_cap_without_breaking_display_increment() -> None:
     result = score_role_match(
         [
             assessment(
@@ -130,7 +130,8 @@ def test_score_role_match_applies_essential_cap() -> None:
         ]
     )
     assert result.applied_cap == 74
-    assert result.display_score <= 74
+    assert result.display_score == 70
+    assert result.display_score % 5 == 0
 
 
 def test_confidence_formula() -> None:


### PR DESCRIPTION
## Summary

- add immutable human-review overrides for requirement importance, exclusion, experience status, and evidence unlinking
- recalculate deterministic score and confidence in a child snapshot instead of mutating prior analysis
- persist override audit records with extracted and effective values
- carry prior overrides into re-analysis only when the canonical requirement remains compatible
- mark ambiguous carry-forward as `needs_review` and removed requirements as `not_applicable`
- add the override API endpoint and focused tests

## Stack

This is PR 3 of the v1.3.0 Role Evidence Match stack.

- Base: `feat/role-match-api-v1.3.0` / PR #49
- Head: `feat/role-match-review-v1.3.0`
- Frontend review UI, golden evaluation, integrations, documentation, and release metadata follow in later stacked PRs.

## Verification

- PR #49 is green on Python 3.12 and 3.13 plus container build
- authoritative verification for this layer: GitHub Actions on this PR head

No merge, tag, or release is performed by this PR.