### PR TITLE
feat: add human-friendly role match UI

### DIFF
--- a/backend/app/role_match/scoring.py
+++ b/backend/app/role_match/scoring.py
@@ -92,6 +92,11 @@ def round_to_nearest_five(value: float) -> int:
     return int(max(Decimal("0"), min(rounded, Decimal("100"))))
 
 
+def _display_cap(cap: int) -> int:
+    """Convert an internal cap to the highest allowed five-point display value."""
+    return max(0, min(100, (cap // 5) * 5))
+
+
 def score_band(display_score: int) -> str:
     if display_score >= 85:
         return "exceptional_evidence_match"
@@ -126,7 +131,7 @@ def score_role_match(assessments: list[RequirementAssessment]) -> ScoreResult:
     capped_score = min(raw_score, float(cap)) if cap is not None else raw_score
     display_score = round_to_nearest_five(capped_score)
     if cap is not None:
-        display_score = min(display_score, cap)
+        display_score = min(display_score, _display_cap(cap))
     return ScoreResult(
         category_assessments=category_assessments,
         raw_score=raw_score,

--- a/backend/tests/role_match/test_scoring_confidence.py
+++ b/backend/tests/role_match/test_scoring_confidence.py
@@ -94,7 +94,7 @@ def test_display_rounding_and_band() -> None:
     assert score_band(80) == "strong_evidence_match"
 
 
-def test_score_role_match_applies_essential_cap() -> None:
+def test_score_role_match_applies_essential_cap_without_breaking_display_increment() -> None:
     result = score_role_match(
         [
             assessment(
@@ -130,7 +130,8 @@ def test_score_role_match_applies_essential_cap() -> None:
         ]
     )
     assert result.applied_cap == 74
-    assert result.display_score <= 74
+    assert result.display_score == 70
+    assert result.display_score % 5 == 0
 
 
 def test_confidence_formula() -> None:

--- a/frontend/src/lib/components/role-match/AnalysisNeedsReview.svelte
+++ b/frontend/src/lib/components/role-match/AnalysisNeedsReview.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import type { RoleMatchViewModel } from '$lib/role-match-presenter';
+  import { CircleAlert, ListChecks, RefreshCw } from '@lucide/svelte';
+
+  interface Props {
+    view: RoleMatchViewModel;
+    onReview?: () => void;
+    onRetry?: () => void;
+    retrying?: boolean;
+  }
+
+  let { view, onReview, onRetry, retrying = false }: Props = $props();
+</script>
+
+<section class="rounded-2xl border border-amber-500/25 bg-card p-5 shadow-sm sm:p-6" aria-labelledby="analysis-review-title">
+  <div class="flex gap-4">
+    <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-amber-500/10 text-amber-700 dark:text-amber-300">
+      <CircleAlert class="h-5 w-5" aria-hidden="true" />
+    </span>
+    <div class="min-w-0">
+      <h2 id="analysis-review-title" class="text-lg font-semibold text-foreground">Analysis needs review</h2>
+      <p class="mt-1.5 text-sm leading-6 text-muted-foreground">{view.reviewReason}</p>
+    </div>
+  </div>
+
+  {#if view.requirements.length}
+    <div class="mt-5 rounded-xl bg-muted/25 p-4">
+      <p class="flex items-center gap-2 text-xs font-semibold text-foreground">
+        <ListChecks class="h-4 w-4 text-primary" aria-hidden="true" />
+        What we could identify
+      </p>
+      <ul class="mt-3 grid gap-2 sm:grid-cols-2">
+        {#each view.requirements.slice(0, 6) as requirement}
+          <li class="text-xs leading-5 text-muted-foreground">• {requirement.canonical_text}</li>
+        {/each}
+      </ul>
+    </div>
+  {/if}
+
+  <div class="mt-5 flex flex-wrap gap-2">
+    {#if onReview}
+      <button
+        type="button"
+        onclick={onReview}
+        class="rounded-lg bg-primary px-3.5 py-2 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+      >
+        Review requirements
+      </button>
+    {/if}
+    {#if onRetry}
+      <button
+        type="button"
+        onclick={onRetry}
+        disabled={retrying}
+        class="inline-flex items-center gap-2 rounded-lg border border-border px-3.5 py-2 text-xs font-semibold text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <RefreshCw class="h-3.5 w-3.5 {retrying ? 'animate-spin' : ''}" aria-hidden="true" />
+        {retrying ? 'Trying again…' : 'Try again'}
+      </button>
+    {/if}
+  </div>
+</section>

--- a/frontend/src/lib/components/role-match/LegacyFitAnalysisNotice.svelte
+++ b/frontend/src/lib/components/role-match/LegacyFitAnalysisNotice.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { Info } from '@lucide/svelte';
+
+  interface Props {
+    score?: number | null;
+  }
+
+  let { score = null }: Props = $props();
+</script>
+
+<div class="rounded-xl border border-border bg-muted/20 p-4">
+  <div class="flex items-start gap-3">
+    <Info class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+    <div>
+      <p class="text-sm font-semibold text-foreground">Legacy AI fit score{score !== null ? ` · ${score}/100` : ''}</p>
+      <p class="mt-1 text-xs leading-5 text-muted-foreground">
+        This older result was generated before evidence-based scoring was introduced. It remains visible for history but is not recalculated or compared directly with the new metric.
+      </p>
+    </div>
+  </div>
+</div>

--- a/frontend/src/lib/components/role-match/RoleMatchBreakdown.svelte
+++ b/frontend/src/lib/components/role-match/RoleMatchBreakdown.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+  import type { RoleMatchAnalysisResponse } from '$lib/role-match-types';
+  import { ChevronDown, ChevronUp, Info } from '@lucide/svelte';
+
+  interface Props {
+    analysis: RoleMatchAnalysisResponse;
+  }
+
+  let { analysis }: Props = $props();
+  let open = $state(false);
+  let methodologyOpen = $state(false);
+
+  const categoryLabels: Record<string, string> = {
+    essential_qualifications: 'Essential qualifications',
+    relevant_competencies: 'Relevant competencies',
+    relevant_work_tasks: 'Relevant work and tasks',
+    preferred_qualifications: 'Preferred qualifications',
+    contextual_alignment: 'Contextual alignment',
+  };
+
+  const matchLabels: Record<string, string> = {
+    strong: 'Strong match',
+    moderate: 'Moderate match',
+    weak: 'Weak match',
+    no_evidence: 'No supporting evidence',
+    unknown: 'Needs confirmation',
+    contradictory_evidence: 'Conflicting information',
+  };
+</script>
+
+<section class="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+  <button
+    type="button"
+    class="flex w-full items-center justify-between gap-4 px-5 py-4 text-left transition-colors hover:bg-muted/30"
+    onclick={() => (open = !open)}
+    aria-expanded={open}
+  >
+    <span>
+      <span class="block text-sm font-semibold text-foreground">See detailed breakdown</span>
+      <span class="mt-0.5 block text-xs text-muted-foreground">
+        Review categories, requirements, and the evidence used for each assessment.
+      </span>
+    </span>
+    {#if open}
+      <ChevronUp class="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+    {:else}
+      <ChevronDown class="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+    {/if}
+  </button>
+
+  {#if open}
+    <div class="space-y-6 border-t border-border px-5 py-5">
+      {#if analysis.category_breakdown.length}
+        <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {#each analysis.category_breakdown as category}
+            <div class="rounded-xl border border-border bg-muted/20 p-3.5">
+              <div class="flex items-start justify-between gap-3">
+                <p class="text-xs font-semibold text-foreground">
+                  {categoryLabels[category.category] ?? category.category.replaceAll('_', ' ')}
+                </p>
+                <span class="text-sm font-semibold text-primary">{Math.round(category.score * 100)}</span>
+              </div>
+              <div class="mt-3 h-1.5 overflow-hidden rounded-full bg-muted">
+                <div
+                  class="h-full rounded-full bg-primary"
+                  style={`width: ${Math.round(category.score * 100)}%`}
+                ></div>
+              </div>
+              <p class="mt-2 text-[11px] text-muted-foreground">
+                {category.requirement_count} requirement{category.requirement_count === 1 ? '' : 's'} reviewed
+              </p>
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      <div class="space-y-3">
+        {#each analysis.requirements as requirement}
+          <article class="rounded-xl border border-border p-4">
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <p class="text-sm font-medium text-foreground">{requirement.canonical_text}</p>
+                <p class="mt-1 text-xs text-muted-foreground">
+                  {categoryLabels[requirement.primary_category] ?? requirement.primary_category.replaceAll('_', ' ')}
+                  · {requirement.importance}
+                  {requirement.mention_count > 1 ? ` · mentioned ${requirement.mention_count} times` : ''}
+                </p>
+              </div>
+              <span class="w-fit rounded-full bg-muted px-2.5 py-1 text-[11px] font-semibold text-foreground">
+                {matchLabels[requirement.match_level ?? 'unknown'] ?? 'Needs review'}
+              </span>
+            </div>
+
+            {#if requirement.explanation}
+              <p class="mt-3 text-xs leading-5 text-muted-foreground">{requirement.explanation}</p>
+            {/if}
+
+            {#if requirement.importance_conflict}
+              <p class="mt-3 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-xs text-amber-800 dark:text-amber-200">
+                This requirement is emphasized inconsistently in the job description and was treated using its strongest explicit wording.
+              </p>
+            {/if}
+
+            {#if requirement.evidence.length}
+              <div class="mt-3 space-y-2">
+                {#each requirement.evidence as evidence}
+                  <div class="rounded-lg bg-muted/25 px-3 py-2.5">
+                    <p class="text-xs text-foreground">{evidence.source_text}</p>
+                    <p class="mt-1 text-[11px] text-muted-foreground">
+                      {evidence.source_type.replaceAll('_', ' ')} · {evidence.relationship.replaceAll('_', ' ')}
+                    </p>
+                  </div>
+                {/each}
+              </div>
+            {/if}
+          </article>
+        {/each}
+      </div>
+
+      {#if analysis.excluded_items.length}
+        <div class="rounded-xl border border-border bg-muted/20 p-4">
+          <p class="text-xs font-semibold text-foreground">
+            {analysis.excluded_items.length} requirement{analysis.excluded_items.length === 1 ? '' : 's'} excluded from scoring
+          </p>
+          <ul class="mt-2 space-y-1.5">
+            {#each analysis.excluded_items as item}
+              <li class="text-xs leading-5 text-muted-foreground">{item.text}</li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+
+      <div class="rounded-xl border border-border">
+        <button
+          type="button"
+          class="flex w-full items-center justify-between gap-3 px-4 py-3 text-left"
+          onclick={() => (methodologyOpen = !methodologyOpen)}
+          aria-expanded={methodologyOpen}
+        >
+          <span class="flex items-center gap-2 text-xs font-semibold text-foreground">
+            <Info class="h-4 w-4 text-primary" aria-hidden="true" />
+            How this assessment works
+          </span>
+          {#if methodologyOpen}
+            <ChevronUp class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          {:else}
+            <ChevronDown class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          {/if}
+        </button>
+        {#if methodologyOpen}
+          <div class="border-t border-border px-4 py-4 text-xs leading-5 text-muted-foreground">
+            ApplyKit identifies job-related requirements, links them to evidence from your profile, and applies fixed rules for evidence source, depth, relevance, and recency. Eligibility and confidence are reported separately. This is guidance for tailoring an application, not a prediction of a hiring decision.
+          </div>
+        {/if}
+      </div>
+    </div>
+  {/if}
+</section>

--- a/frontend/src/lib/components/role-match/RoleMatchInsights.svelte
+++ b/frontend/src/lib/components/role-match/RoleMatchInsights.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import type { RoleMatchViewModel } from '$lib/role-match-presenter';
+  import { ArrowRight, Check, CircleAlert } from '@lucide/svelte';
+
+  interface Props {
+    view: RoleMatchViewModel;
+  }
+
+  let { view }: Props = $props();
+</script>
+
+<div class="grid gap-4 lg:grid-cols-2">
+  <section class="rounded-2xl border border-border bg-card p-5 shadow-sm" aria-labelledby="role-strengths-title">
+    <h3 id="role-strengths-title" class="flex items-center gap-2 text-sm font-semibold text-foreground">
+      <span class="flex h-7 w-7 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-700 dark:text-emerald-300">
+        <Check class="h-4 w-4" aria-hidden="true" />
+      </span>
+      What makes you a good fit
+    </h3>
+
+    {#if view.sections.strengths.items.length}
+      <ul class="mt-4 space-y-3">
+        {#each view.sections.strengths.items as item}
+          <li class="rounded-xl bg-muted/25 p-3.5">
+            <p class="text-sm font-medium text-foreground">{item.title}</p>
+            <p class="mt-1 text-xs leading-5 text-muted-foreground">{item.explanation}</p>
+            {#if item.evidence_label}
+              <p class="mt-2 text-[11px] font-semibold text-emerald-700 dark:text-emerald-300">
+                {item.evidence_label}
+              </p>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    {:else}
+      <p class="mt-4 text-sm leading-6 text-muted-foreground">
+        Review the detailed requirements to identify where stronger evidence can be added.
+      </p>
+    {/if}
+  </section>
+
+  <section class="rounded-2xl border border-border bg-card p-5 shadow-sm" aria-labelledby="role-gaps-title">
+    <h3 id="role-gaps-title" class="flex items-center gap-2 text-sm font-semibold text-foreground">
+      <span class="flex h-7 w-7 items-center justify-center rounded-full bg-amber-500/10 text-amber-700 dark:text-amber-300">
+        <CircleAlert class="h-4 w-4" aria-hidden="true" />
+      </span>
+      What may hold you back
+    </h3>
+
+    {#if view.sections.gaps.items.length}
+      <ul class="mt-4 space-y-3">
+        {#each view.sections.gaps.items as item}
+          <li class="rounded-xl bg-muted/25 p-3.5">
+            <p class="text-sm font-medium text-foreground">{item.title}</p>
+            <p class="mt-1 text-xs leading-5 text-muted-foreground">{item.explanation}</p>
+            {#if item.evidence_label}
+              <p class="mt-2 text-[11px] font-semibold text-amber-700 dark:text-amber-300">
+                {item.evidence_label}
+              </p>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    {:else}
+      <p class="mt-4 text-sm leading-6 text-muted-foreground">
+        No major evidence gaps were identified in the current analysis.
+      </p>
+    {/if}
+  </section>
+</div>
+
+<section class="rounded-2xl border border-primary/20 bg-primary/5 p-5" aria-labelledby="role-next-step-title">
+  <h3 id="role-next-step-title" class="text-sm font-semibold text-primary">Your best next step</h3>
+  <p class="mt-2 flex gap-3 text-sm leading-6 text-foreground">
+    <ArrowRight class="mt-1 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+    <span>{view.sections.nextStep.text}</span>
+  </p>
+</section>

--- a/frontend/src/lib/components/role-match/RoleMatchResult.svelte
+++ b/frontend/src/lib/components/role-match/RoleMatchResult.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { buildRoleMatchViewModel } from '$lib/role-match-presenter';
+  import type { RoleMatchAnalysisResponse } from '$lib/role-match-types';
+  import AnalysisNeedsReview from './AnalysisNeedsReview.svelte';
+  import RoleMatchBreakdown from './RoleMatchBreakdown.svelte';
+  import RoleMatchInsights from './RoleMatchInsights.svelte';
+  import RoleMatchSummary from './RoleMatchSummary.svelte';
+
+  interface Props {
+    analysis: RoleMatchAnalysisResponse;
+    companyName?: string | null;
+    onReanalyze?: () => void;
+    onReview?: () => void;
+    analyzing?: boolean;
+  }
+
+  let {
+    analysis,
+    companyName = null,
+    onReanalyze,
+    onReview,
+    analyzing = false,
+  }: Props = $props();
+
+  const view = $derived(buildRoleMatchViewModel(analysis));
+</script>
+
+<div class="space-y-4">
+  {#if view.showScore}
+    <RoleMatchSummary {view} {companyName} {onReanalyze} {analyzing} />
+    <RoleMatchInsights {view} />
+  {:else}
+    <AnalysisNeedsReview {view} {onReview} onRetry={onReanalyze} retrying={analyzing} />
+  {/if}
+  <RoleMatchBreakdown {analysis} />
+</div>

--- a/frontend/src/lib/components/role-match/RoleMatchReviewPanel.svelte
+++ b/frontend/src/lib/components/role-match/RoleMatchReviewPanel.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+  import type {
+    RoleMatchAnalysisResponse,
+    RoleMatchOverrideInput,
+    RoleMatchRequirementResponse,
+  } from '$lib/role-match-types';
+  import { Link2Off, Save, X } from '@lucide/svelte';
+
+  interface Props {
+    analysis: RoleMatchAnalysisResponse;
+    onSubmit: (overrides: RoleMatchOverrideInput[]) => Promise<void> | void;
+    onClose?: () => void;
+  }
+
+  let { analysis, onSubmit, onClose }: Props = $props();
+  let selectedKey = $state(analysis.requirements[0]?.canonical_key ?? '');
+  let action = $state<'importance' | 'no_experience' | 'not_in_profile' | 'evidence_unlink'>('importance');
+  let priority = $state<'critical' | 'important' | 'supporting'>('important');
+  let evidenceId = $state('');
+  let reason = $state('');
+  let saving = $state(false);
+  let error = $state('');
+
+  const selectedRequirement = $derived(
+    analysis.requirements.find((item) => item.canonical_key === selectedKey) ?? null,
+  );
+
+  function selectRequirement(requirement: RoleMatchRequirementResponse) {
+    selectedKey = requirement.canonical_key;
+    evidenceId = requirement.evidence[0]?.evidence_id ?? '';
+    priority =
+      requirement.importance === 'critical' ||
+      requirement.importance === 'important' ||
+      requirement.importance === 'supporting'
+        ? requirement.importance
+        : 'important';
+  }
+
+  async function saveCorrection() {
+    if (!selectedRequirement) return;
+    if (!reason.trim()) {
+      error = 'Add a short reason so this correction remains auditable.';
+      return;
+    }
+
+    let override: RoleMatchOverrideInput;
+    if (action === 'importance') {
+      override = {
+        requirement_key: selectedRequirement.canonical_key,
+        field_name: 'importance',
+        effective_value: priority,
+        reason: reason.trim(),
+      };
+    } else if (action === 'evidence_unlink') {
+      if (!evidenceId) {
+        error = 'Choose the evidence that should be unlinked.';
+        return;
+      }
+      override = {
+        requirement_key: selectedRequirement.canonical_key,
+        field_name: 'evidence_unlink',
+        effective_value: evidenceId,
+        reason: reason.trim(),
+      };
+    } else {
+      override = {
+        requirement_key: selectedRequirement.canonical_key,
+        field_name: 'experience_status',
+        effective_value: action,
+        reason: reason.trim(),
+      };
+    }
+
+    saving = true;
+    error = '';
+    try {
+      await onSubmit([override]);
+      reason = '';
+    } catch (caught) {
+      error = caught instanceof Error ? caught.message : 'The correction could not be saved.';
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<section class="rounded-2xl border border-border bg-card shadow-sm" aria-labelledby="review-requirements-title">
+  <header class="flex items-start justify-between gap-4 border-b border-border px-5 py-4">
+    <div>
+      <h2 id="review-requirements-title" class="text-base font-semibold text-foreground">Review requirements</h2>
+      <p class="mt-1 text-xs leading-5 text-muted-foreground">
+        Correct a requirement or evidence link when the automated interpretation is not accurate.
+      </p>
+    </div>
+    {#if onClose}
+      <button type="button" onclick={onClose} class="rounded-lg p-2 text-muted-foreground hover:bg-muted hover:text-foreground" aria-label="Close review">
+        <X class="h-4 w-4" aria-hidden="true" />
+      </button>
+    {/if}
+  </header>
+
+  <div class="grid gap-5 p-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+    <div class="space-y-2">
+      <p class="text-xs font-semibold text-muted-foreground">Choose a requirement</p>
+      <div class="max-h-96 space-y-2 overflow-y-auto pr-1">
+        {#each analysis.requirements as requirement}
+          <button
+            type="button"
+            onclick={() => selectRequirement(requirement)}
+            class="w-full rounded-xl border px-3.5 py-3 text-left transition-colors {selectedKey === requirement.canonical_key ? 'border-primary bg-primary/5' : 'border-border hover:bg-muted/30'}"
+          >
+            <span class="block text-sm font-medium text-foreground">{requirement.canonical_text}</span>
+            <span class="mt-1 block text-[11px] text-muted-foreground">
+              {requirement.primary_category.replaceAll('_', ' ')} · {requirement.importance}
+            </span>
+          </button>
+        {/each}
+      </div>
+    </div>
+
+    <div class="space-y-4">
+      <div>
+        <label for="review-action" class="text-xs font-semibold text-muted-foreground">Correction</label>
+        <select id="review-action" bind:value={action} class="mt-2 w-full rounded-lg border border-border bg-background px-3 py-2.5 text-sm text-foreground">
+          <option value="importance">Change requirement priority</option>
+          <option value="no_experience">I don’t have this experience</option>
+          <option value="not_in_profile">Not included in my profile</option>
+          <option value="evidence_unlink">Unlink this evidence</option>
+        </select>
+      </div>
+
+      {#if action === 'importance'}
+        <div>
+          <label for="review-priority" class="text-xs font-semibold text-muted-foreground">New priority</label>
+          <select id="review-priority" bind:value={priority} class="mt-2 w-full rounded-lg border border-border bg-background px-3 py-2.5 text-sm text-foreground">
+            <option value="critical">Essential</option>
+            <option value="important">Important</option>
+            <option value="supporting">Preferred or supporting</option>
+          </select>
+        </div>
+      {:else if action === 'evidence_unlink'}
+        <div>
+          <label for="review-evidence" class="text-xs font-semibold text-muted-foreground">Evidence to unlink</label>
+          <select id="review-evidence" bind:value={evidenceId} class="mt-2 w-full rounded-lg border border-border bg-background px-3 py-2.5 text-sm text-foreground">
+            <option value="">Choose evidence</option>
+            {#each selectedRequirement?.evidence ?? [] as evidence}
+              <option value={evidence.evidence_id}>{evidence.source_text}</option>
+            {/each}
+          </select>
+          <p class="mt-2 flex items-center gap-1.5 text-[11px] text-muted-foreground">
+            <Link2Off class="h-3.5 w-3.5" aria-hidden="true" />
+            The source text stays in the audit history; only this link is removed.
+          </p>
+        </div>
+      {/if}
+
+      <div>
+        <label for="review-reason" class="text-xs font-semibold text-muted-foreground">Reason for this correction</label>
+        <textarea
+          id="review-reason"
+          bind:value={reason}
+          rows="3"
+          placeholder="Explain what the job description or your experience actually says."
+          class="mt-2 w-full resize-y rounded-lg border border-border bg-background px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground"
+        ></textarea>
+      </div>
+
+      <div class="rounded-xl border border-border bg-muted/20 p-3 text-xs leading-5 text-muted-foreground">
+        <p>This correction only changes this analysis and creates a new auditable version.</p>
+        <button type="button" class="mt-1 font-semibold text-primary hover:underline">
+          Add this evidence to my profile separately
+        </button>
+      </div>
+
+      {#if error}
+        <p class="text-xs text-destructive" role="alert">{error}</p>
+      {/if}
+
+      <button
+        type="button"
+        onclick={saveCorrection}
+        disabled={saving || !selectedRequirement}
+        class="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <Save class="h-3.5 w-3.5" aria-hidden="true" />
+        {saving ? 'Saving…' : 'Save correction'}
+      </button>
+    </div>
+  </div>
+</section>

--- a/frontend/src/lib/components/role-match/RoleMatchSummary.svelte
+++ b/frontend/src/lib/components/role-match/RoleMatchSummary.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import type { RoleMatchViewModel } from '$lib/role-match-presenter';
+  import { CircleCheck, RefreshCw, ShieldCheck } from '@lucide/svelte';
+
+  interface Props {
+    view: RoleMatchViewModel;
+    companyName?: string | null;
+    onReanalyze?: () => void;
+    analyzing?: boolean;
+  }
+
+  let {
+    view,
+    companyName = null,
+    onReanalyze,
+    analyzing = false,
+  }: Props = $props();
+</script>
+
+<section class="rounded-2xl border border-border bg-card p-5 shadow-sm sm:p-6" aria-labelledby="role-match-title">
+  <div class="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+    <div class="min-w-0 space-y-2">
+      <div class="flex items-center gap-2 text-xs font-semibold text-muted-foreground">
+        <ShieldCheck class="h-4 w-4 text-primary" aria-hidden="true" />
+        <span>Role Evidence Match{companyName ? ` · ${companyName}` : ''}</span>
+      </div>
+      <h2 id="role-match-title" class="text-xl font-semibold tracking-tight text-foreground">
+        {view.headline}
+      </h2>
+      <p class="max-w-2xl text-sm leading-6 text-muted-foreground">{view.description}</p>
+    </div>
+
+    {#if onReanalyze}
+      <button
+        type="button"
+        onclick={onReanalyze}
+        disabled={analyzing}
+        class="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-border px-3 py-2 text-xs font-semibold text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <RefreshCw class="h-3.5 w-3.5 {analyzing ? 'animate-spin' : ''}" aria-hidden="true" />
+        {analyzing ? 'Analyzing…' : 'Re-analyze'}
+      </button>
+    {/if}
+  </div>
+
+  <div class="mt-5 grid gap-3 sm:grid-cols-[auto_1fr]">
+    <div class="flex min-h-28 min-w-32 flex-col items-center justify-center rounded-xl border border-primary/20 bg-primary/5 px-5 py-4 text-center">
+      <span class="text-3xl font-semibold tracking-tight text-foreground">{view.score}</span>
+      <span class="mt-1 text-xs font-medium text-muted-foreground">out of 100</span>
+      {#if view.scoreBandLabel}
+        <span class="mt-2 rounded-full bg-background px-2.5 py-1 text-[11px] font-semibold text-primary ring-1 ring-primary/20">
+          {view.scoreBandLabel}
+        </span>
+      {/if}
+    </div>
+
+    <div class="grid gap-3 sm:grid-cols-2">
+      <div class="rounded-xl border border-border bg-muted/25 p-4">
+        <p class="text-xs font-semibold text-muted-foreground">Confidence</p>
+        <p class="mt-1 flex items-center gap-2 text-sm font-semibold text-foreground">
+          <CircleCheck class="h-4 w-4 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
+          {view.confidenceLabel ?? 'Not available'}
+        </p>
+        <p class="mt-1.5 text-xs leading-5 text-muted-foreground">
+          Based on the coverage and reliability of the evidence in your profile.
+        </p>
+      </div>
+
+      <div class="rounded-xl border border-border bg-muted/25 p-4">
+        <p class="text-xs font-semibold text-muted-foreground">Eligibility</p>
+        <p class="mt-1 text-sm font-semibold text-foreground">{view.eligibilityLabel}</p>
+        <p class="mt-1.5 text-xs leading-5 text-muted-foreground">
+          Checked separately from your evidence match so missing information is not treated as failure.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/frontend/src/lib/components/role-match/RoleMatchVersionCompare.svelte
+++ b/frontend/src/lib/components/role-match/RoleMatchVersionCompare.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  import type {
+    RoleMatchAnalysisResponse,
+    RoleMatchComparisonResponse,
+    RoleMatchOverrideResponse,
+    RoleMatchVersionsResponse,
+  } from '$lib/role-match-types';
+  import { History, RotateCcw } from '@lucide/svelte';
+
+  interface Props {
+    analysis: RoleMatchAnalysisResponse;
+    versions?: RoleMatchVersionsResponse | null;
+    comparison?: RoleMatchComparisonResponse | null;
+    onRestore?: (override: RoleMatchOverrideResponse) => Promise<void> | void;
+  }
+
+  let { analysis, versions = null, comparison = null, onRestore }: Props = $props();
+  let restoringId = $state<number | null>(null);
+
+  const statusLabels = {
+    carried_forward: 'Carried forward',
+    needs_review: 'Needs review',
+    not_applicable: 'Not applicable',
+  } as const;
+
+  async function restore(override: RoleMatchOverrideResponse) {
+    if (!onRestore) return;
+    restoringId = override.id;
+    try {
+      await onRestore(override);
+    } finally {
+      restoringId = null;
+    }
+  }
+</script>
+
+<section class="rounded-2xl border border-border bg-card p-5 shadow-sm" aria-labelledby="analysis-history-title">
+  <h3 id="analysis-history-title" class="flex items-center gap-2 text-sm font-semibold text-foreground">
+    <History class="h-4 w-4 text-primary" aria-hidden="true" />
+    Analysis history
+  </h3>
+
+  {#if comparison?.score_change !== null && comparison?.score_change !== undefined}
+    <p class="mt-3 rounded-xl bg-primary/5 px-4 py-3 text-sm text-foreground">
+      {#if comparison.score_change > 0}
+        Your match increased from the previous version by {comparison.score_change} points.
+      {:else if comparison.score_change < 0}
+        Your match decreased from the previous version by {Math.abs(comparison.score_change)} points.
+      {:else}
+        Your match score did not change in this version.
+      {/if}
+    </p>
+  {:else}
+    <p class="mt-3 text-xs leading-5 text-muted-foreground">
+      Your match increased from a previous version when new evidence raises the deterministic score.
+    </p>
+  {/if}
+
+  {#if versions?.items.length}
+    <ol class="mt-4 space-y-2">
+      {#each versions.items as version, index}
+        <li class="flex items-center justify-between gap-3 rounded-xl border border-border px-3.5 py-3">
+          <div>
+            <p class="text-xs font-semibold text-foreground">Version {index + 1}</p>
+            <p class="mt-0.5 text-[11px] text-muted-foreground">
+              {new Date(version.created_at).toLocaleString()} · {version.state.replaceAll('_', ' ')}
+            </p>
+          </div>
+          <span class="text-sm font-semibold text-foreground">{version.score ?? '—'}</span>
+        </li>
+      {/each}
+    </ol>
+  {/if}
+
+  {#if analysis.overrides.length}
+    <div class="mt-5 space-y-2">
+      <p class="text-xs font-semibold text-muted-foreground">Corrections in this version</p>
+      {#each analysis.overrides as override}
+        <div class="rounded-xl border border-border p-3.5">
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p class="text-sm font-medium text-foreground">{override.requirement_key.replaceAll('_', ' ')}</p>
+              <p class="mt-1 text-xs leading-5 text-muted-foreground">{override.reason}</p>
+              <span class="mt-2 inline-block rounded-full bg-muted px-2 py-1 text-[11px] font-semibold text-foreground">
+                {statusLabels[override.carry_status]}
+              </span>
+            </div>
+            {#if onRestore && override.source === 'user'}
+              <button
+                type="button"
+                onclick={() => restore(override)}
+                disabled={restoringId === override.id}
+                class="inline-flex shrink-0 items-center gap-2 rounded-lg border border-border px-3 py-2 text-xs font-semibold text-foreground hover:bg-muted disabled:opacity-50"
+              >
+                <RotateCcw class="h-3.5 w-3.5" aria-hidden="true" />
+                {restoringId === override.id ? 'Restoring…' : 'Restore original analysis'}
+              </button>
+            {/if}
+          </div>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</section>

--- a/frontend/src/lib/role-match-api.test.ts
+++ b/frontend/src/lib/role-match-api.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 
-const source = readFileSync(new URL('./api.ts', import.meta.url), 'utf8');
+const source = readFileSync(new URL('./role-match-api.ts', import.meta.url), 'utf8');
 
 describe('role match API contract', () => {
   test('exposes all versioned analysis operations', () => {

--- a/frontend/src/lib/role-match-api.test.ts
+++ b/frontend/src/lib/role-match-api.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('./api.ts', import.meta.url), 'utf8');
+
+describe('role match API contract', () => {
+  test('exposes all versioned analysis operations', () => {
+    expect(source).toContain("'/analyze/role-match'");
+    expect(source).toContain('`/analyze/role-match/${analysisId}`');
+    expect(source).toContain('`/analyze/role-match/${analysisId}/versions`');
+    expect(source).toContain('`/analyze/role-match/${analysisId}/compare/${otherAnalysisId}`');
+    expect(source).toContain('`/analyze/role-match/${analysisId}/reanalyze`');
+    expect(source).toContain('`/analyze/role-match/${analysisId}/overrides`');
+    expect(source).toContain('`/analyze/role-match/${analysisId}/overrides/${overrideId}`');
+  });
+
+  test('uses POST for analysis and DELETE for restoration', () => {
+    expect(source).toContain('export const analyzeRoleMatch');
+    expect(source).toContain("method: 'POST'");
+    expect(source).toContain('export const restoreRoleMatchOverride');
+    expect(source).toContain("method: 'DELETE'");
+  });
+});

--- a/frontend/src/lib/role-match-api.ts
+++ b/frontend/src/lib/role-match-api.ts
@@ -1,0 +1,96 @@
+import { apiFetch } from './api-client';
+import { parseApiError } from './api-error';
+import type {
+  AnalyzeRoleMatchRequest,
+  ReanalyzeRoleMatchRequest,
+  RoleMatchAnalysisResponse,
+  RoleMatchComparisonResponse,
+  RoleMatchOverridesRequest,
+  RoleMatchVersionsResponse,
+} from './role-match-types';
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000/api';
+
+async function request<T>(
+  path: string,
+  options: RequestInit = {},
+  fetchFn: typeof fetch = fetch,
+): Promise<T> {
+  const headers = new Headers(options.headers);
+  if (!headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
+  const response = await apiFetch(`${BASE_URL}${path}`, { ...options, headers }, fetchFn);
+  if (!response.ok) {
+    const payload: unknown = await response.json().catch(() => undefined);
+    throw parseApiError(payload, 'Role match analysis could not be completed.', response.status);
+  }
+  return response.json() as Promise<T>;
+}
+
+export const analyzeRoleMatch = (
+  data: AnalyzeRoleMatchRequest,
+  fetchFn?: typeof fetch,
+) =>
+  request<RoleMatchAnalysisResponse>(
+    '/analyze/role-match',
+    { method: 'POST', body: JSON.stringify(data) },
+    fetchFn,
+  );
+
+export const getRoleMatchAnalysis = (
+  analysisId: number,
+  fetchFn?: typeof fetch,
+) => request<RoleMatchAnalysisResponse>(`/analyze/role-match/${analysisId}`, {}, fetchFn);
+
+export const getRoleMatchVersions = (
+  analysisId: number,
+  fetchFn?: typeof fetch,
+) =>
+  request<RoleMatchVersionsResponse>(
+    `/analyze/role-match/${analysisId}/versions`,
+    {},
+    fetchFn,
+  );
+
+export const compareRoleMatchVersions = (
+  analysisId: number,
+  otherAnalysisId: number,
+  fetchFn?: typeof fetch,
+) =>
+  request<RoleMatchComparisonResponse>(
+    `/analyze/role-match/${analysisId}/compare/${otherAnalysisId}`,
+    {},
+    fetchFn,
+  );
+
+export const reanalyzeRoleMatch = (
+  analysisId: number,
+  data: ReanalyzeRoleMatchRequest,
+  fetchFn?: typeof fetch,
+) =>
+  request<RoleMatchAnalysisResponse>(
+    `/analyze/role-match/${analysisId}/reanalyze`,
+    { method: 'POST', body: JSON.stringify(data) },
+    fetchFn,
+  );
+
+export const applyRoleMatchOverrides = (
+  analysisId: number,
+  data: RoleMatchOverridesRequest,
+  fetchFn?: typeof fetch,
+) =>
+  request<RoleMatchAnalysisResponse>(
+    `/analyze/role-match/${analysisId}/overrides`,
+    { method: 'POST', body: JSON.stringify(data) },
+    fetchFn,
+  );
+
+export const restoreRoleMatchOverride = (
+  analysisId: number,
+  overrideId: number,
+  fetchFn?: typeof fetch,
+) =>
+  request<RoleMatchAnalysisResponse>(
+    `/analyze/role-match/${analysisId}/overrides/${overrideId}`,
+    { method: 'DELETE' },
+    fetchFn,
+  );

--- a/frontend/src/lib/role-match-presenter.test.ts
+++ b/frontend/src/lib/role-match-presenter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { buildRoleMatchViewModel } from './role-match-presenter';
-import type { RoleMatchAnalysisResponse } from './types';
+import type { RoleMatchAnalysisResponse } from './role-match-types';
 
 function strongFixture(): RoleMatchAnalysisResponse {
   return {

--- a/frontend/src/lib/role-match-presenter.test.ts
+++ b/frontend/src/lib/role-match-presenter.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test';
+import { buildRoleMatchViewModel } from './role-match-presenter';
+import type { RoleMatchAnalysisResponse } from './types';
+
+function strongFixture(): RoleMatchAnalysisResponse {
+  return {
+    id: 12,
+    parent_analysis_id: null,
+    created_at: '2026-08-06T06:00:00Z',
+    state: 'success',
+    score: 80,
+    score_band: 'strong_evidence_match',
+    confidence: 'high',
+    eligibility: 'likely_eligible',
+    show_authoritative_score: true,
+    summary: {
+      headline: 'Your profile is a strong match',
+      description: 'Your background supports most important requirements.',
+      strengths: [
+        {
+          title: 'Production Python backend capability',
+          explanation: 'Supported by recent work examples.',
+          evidence_label: 'Work experience',
+        },
+      ],
+      concerns: [
+        {
+          title: 'Terraform experience needs clearer proof',
+          explanation: 'Add a real work example if available.',
+          evidence_label: 'Preferred qualification',
+        },
+      ],
+      next_step: 'Strengthen the Terraform example before applying.',
+    },
+    category_breakdown: [],
+    requirements: [],
+    excluded_items: [],
+    overrides: [],
+    override_review_count: 0,
+    rules_version: 'role-match-v1',
+    prompt_version: 'role-match-extraction-v1',
+    legacy: false,
+    failure_code: null,
+  };
+}
+
+describe('role match presenter', () => {
+  test('uses the approved human-friendly hierarchy', () => {
+    const view = buildRoleMatchViewModel(strongFixture());
+
+    expect(view.headline).toBe('Your profile is a strong match');
+    expect(view.scoreText).toBe('80/100');
+    expect(view.confidenceLabel).toBe('High confidence');
+    expect(view.eligibilityLabel).toBe('Likely eligible');
+    expect(view.sections.strengths.title).toBe('What makes you a good fit');
+    expect(view.sections.gaps.title).toBe('What may hold you back');
+    expect(view.sections.nextStep.title).toBe('Your best next step');
+    expect(JSON.stringify(view)).not.toContain('raw_score');
+    expect(JSON.stringify(view)).not.toContain('soft cap');
+  });
+
+  test('review state hides the authoritative score', () => {
+    const response = strongFixture();
+    response.state = 'needs_review';
+    response.score = null;
+    response.score_band = null;
+    response.show_authoritative_score = false;
+    response.failure_code = 'insufficient_known_coverage';
+    response.summary = null;
+
+    const view = buildRoleMatchViewModel(response);
+
+    expect(view.showScore).toBe(false);
+    expect(view.headline).toBe('Analysis needs review');
+    expect(view.scoreText).toBeNull();
+    expect(view.reviewReason).toContain('enough job requirements');
+  });
+});

--- a/frontend/src/lib/role-match-presenter.ts
+++ b/frontend/src/lib/role-match-presenter.ts
@@ -1,0 +1,115 @@
+import type {
+  RoleMatchAnalysisResponse,
+  RoleMatchInsight,
+  RoleMatchRequirementResponse,
+} from './role-match-types';
+
+const scoreBandLabels: Record<string, string> = {
+  exceptional_evidence_match: 'Exceptional evidence match',
+  strong_evidence_match: 'Strong evidence match',
+  moderate_evidence_match: 'Moderate evidence match',
+  limited_evidence_match: 'Limited evidence match',
+  weak_evidence_match: 'Weak evidence match',
+};
+
+const confidenceLabels = {
+  high: 'High confidence',
+  medium: 'Medium confidence',
+  low: 'Low confidence',
+} as const;
+
+const eligibilityLabels = {
+  eligible: 'Eligible',
+  likely_eligible: 'Likely eligible',
+  eligibility_unclear: 'Eligibility unclear',
+  likely_ineligible: 'Likely ineligible',
+  ineligible: 'Ineligible',
+} as const;
+
+const reviewReasons: Record<string, string> = {
+  insufficient_known_coverage:
+    'We could not confidently identify enough job requirements from the available profile evidence.',
+  insufficient_requirements:
+    'We could not identify enough job requirements to calculate a reliable match.',
+  low_confidence:
+    'Important requirements are still supported by incomplete or inconsistent evidence.',
+  too_many_unresolved_conflicts:
+    'Several requirements need review before the result can be treated as reliable.',
+  invalid_requirement_extraction:
+    'The job requirements could not be extracted reliably. Review the job description and try again.',
+  provider_failure:
+    'The analysis provider could not complete this request. No score was estimated.',
+  scoring_failed:
+    'The evidence could not be evaluated safely. No score was estimated.',
+};
+
+export interface RoleMatchViewModel {
+  showScore: boolean;
+  score: number | null;
+  scoreText: string | null;
+  scoreBandLabel: string | null;
+  headline: string;
+  description: string;
+  confidenceLabel: string | null;
+  eligibilityLabel: string;
+  reviewReason: string | null;
+  sections: {
+    strengths: { title: string; items: RoleMatchInsight[] };
+    gaps: { title: string; items: RoleMatchInsight[] };
+    nextStep: { title: string; text: string };
+  };
+  requirements: RoleMatchRequirementResponse[];
+  analysis: RoleMatchAnalysisResponse;
+}
+
+export function buildRoleMatchViewModel(
+  analysis: RoleMatchAnalysisResponse,
+): RoleMatchViewModel {
+  const showScore =
+    analysis.show_authoritative_score &&
+    analysis.state === 'success' &&
+    typeof analysis.score === 'number';
+  const summary = analysis.summary;
+
+  return {
+    showScore,
+    score: showScore ? analysis.score ?? null : null,
+    scoreText: showScore ? `${analysis.score}/100` : null,
+    scoreBandLabel:
+      showScore && analysis.score_band
+        ? scoreBandLabels[analysis.score_band] ?? 'Evidence match'
+        : null,
+    headline: showScore
+      ? summary?.headline ?? 'Your profile evidence has been assessed'
+      : 'Analysis needs review',
+    description: showScore
+      ? summary?.description ?? 'Review the evidence details below.'
+      : 'We need a little more reliable information before showing a match score.',
+    confidenceLabel: analysis.confidence
+      ? confidenceLabels[analysis.confidence]
+      : null,
+    eligibilityLabel: eligibilityLabels[analysis.eligibility],
+    reviewReason: showScore
+      ? null
+      : reviewReasons[analysis.failure_code ?? ''] ??
+        'Review the extracted requirements and evidence before using this result.',
+    sections: {
+      strengths: {
+        title: 'What makes you a good fit',
+        items: summary?.strengths ?? [],
+      },
+      gaps: {
+        title: 'What may hold you back',
+        items: summary?.concerns ?? [],
+      },
+      nextStep: {
+        title: 'Your best next step',
+        text:
+          summary?.next_step ??
+          'Review the identified requirements and add truthful evidence where it is missing.',
+      },
+    },
+    requirements: analysis.requirements,
+    analysis,
+  };
+}

--- a/frontend/src/lib/role-match-review.test.ts
+++ b/frontend/src/lib/role-match-review.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(
+  new URL('./components/role-match/RoleMatchReviewPanel.svelte', import.meta.url),
+  'utf8',
+);
+
+describe('role match review UI', () => {
+  test('supports the approved review corrections', () => {
+    for (const phrase of [
+      'Change requirement priority',
+      'I don’t have this experience',
+      'Not included in my profile',
+      'Unlink this evidence',
+      'Reason for this correction',
+      'Save correction',
+    ]) {
+      expect(source).toContain(phrase);
+    }
+  });
+
+  test('does not silently add analysis notes to the profile', () => {
+    expect(source).toContain('This correction only changes this analysis');
+    expect(source).toContain('Add this evidence to my profile separately');
+  });
+});

--- a/frontend/src/lib/role-match-types.ts
+++ b/frontend/src/lib/role-match-types.ts
@@ -1,0 +1,162 @@
+export type RoleMatchState = 'success' | 'needs_review' | 'failed';
+export type RoleMatchConfidence = 'high' | 'medium' | 'low';
+export type RoleMatchEligibility =
+  | 'eligible'
+  | 'likely_eligible'
+  | 'eligibility_unclear'
+  | 'likely_ineligible'
+  | 'ineligible';
+export type RoleMatchCarryStatus = 'carried_forward' | 'needs_review' | 'not_applicable';
+
+export interface RoleMatchInsight {
+  title: string;
+  explanation: string;
+  evidence_label?: string | null;
+}
+
+export interface RoleMatchSummaryResponse {
+  headline: string;
+  description: string;
+  strengths: RoleMatchInsight[];
+  concerns: RoleMatchInsight[];
+  next_step: string;
+}
+
+export interface RoleMatchCategoryResponse {
+  category: string;
+  score: number;
+  known_coverage: number;
+  unknown_coverage: number;
+  known_match: number;
+  requirement_count: number;
+}
+
+export interface RoleMatchEvidenceResponse {
+  id: number;
+  evidence_id: string;
+  source_type: string;
+  source_text: string;
+  relationship: string;
+  depth: string;
+  duplicate: boolean;
+  contradiction: boolean;
+  explanation?: string | null;
+}
+
+export interface RoleMatchRequirementResponse {
+  id: number;
+  cluster_id: string;
+  canonical_key: string;
+  canonical_text: string;
+  primary_category: string;
+  importance: string;
+  mention_count: number;
+  importance_conflict: boolean;
+  source_quotes: string[];
+  excluded: boolean;
+  exclusion_reason?: string | null;
+  match_level?: string | null;
+  strength?: number | null;
+  explanation?: string | null;
+  evidence: RoleMatchEvidenceResponse[];
+}
+
+export interface ExcludedAnalysisItemResponse {
+  source_id: string;
+  text: string;
+  reason: string;
+}
+
+export interface RoleMatchOverrideResponse {
+  id: number;
+  requirement_key: string;
+  field_name: string;
+  extracted_value: unknown;
+  effective_value: unknown;
+  reason: string;
+  source: string;
+  carry_status: RoleMatchCarryStatus;
+  source_override_id?: number | null;
+  created_at: string;
+}
+
+export interface RoleMatchAnalysisResponse {
+  id: number;
+  parent_analysis_id?: number | null;
+  created_at: string;
+  state: RoleMatchState;
+  score?: number | null;
+  score_band?: string | null;
+  confidence?: RoleMatchConfidence | null;
+  eligibility: RoleMatchEligibility;
+  show_authoritative_score: boolean;
+  summary?: RoleMatchSummaryResponse | null;
+  category_breakdown: RoleMatchCategoryResponse[];
+  requirements: RoleMatchRequirementResponse[];
+  excluded_items: ExcludedAnalysisItemResponse[];
+  overrides: RoleMatchOverrideResponse[];
+  override_review_count: number;
+  rules_version: string;
+  prompt_version: string;
+  legacy: boolean;
+  failure_code?: string | null;
+}
+
+export interface AnalyzeRoleMatchRequest {
+  profile_id: number;
+  job_description: string;
+  application_id?: number | null;
+  parent_analysis_id?: number | null;
+}
+
+export interface ReanalyzeRoleMatchRequest {
+  profile_id?: number | null;
+  job_description?: string | null;
+  application_id?: number | null;
+}
+
+export type RoleMatchOverrideField =
+  | 'importance'
+  | 'excluded'
+  | 'experience_status'
+  | 'evidence_unlink';
+
+export interface RoleMatchOverrideInput {
+  requirement_key: string;
+  field_name: RoleMatchOverrideField;
+  effective_value: unknown;
+  reason: string;
+}
+
+export interface RoleMatchOverridesRequest {
+  overrides: RoleMatchOverrideInput[];
+}
+
+export interface RoleMatchVersionItem {
+  id: number;
+  parent_analysis_id?: number | null;
+  created_at: string;
+  state: RoleMatchState;
+  score?: number | null;
+  confidence?: RoleMatchConfidence | null;
+  eligibility: RoleMatchEligibility;
+  superseded_by_id?: number | null;
+}
+
+export interface RoleMatchVersionsResponse {
+  items: RoleMatchVersionItem[];
+}
+
+export interface RoleMatchRequirementChange {
+  canonical_key: string;
+  changes: Record<string, { from: unknown; to: unknown }>;
+}
+
+export interface RoleMatchComparisonResponse {
+  from_analysis_id: number;
+  to_analysis_id: number;
+  score_change?: number | null;
+  added_requirements: string[];
+  removed_requirements: string[];
+  changed_requirements: RoleMatchRequirementChange[];
+}

--- a/frontend/src/lib/role-match-ui-policy.test.ts
+++ b/frontend/src/lib/role-match-ui-policy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const files = [
+  './components/role-match/RoleMatchSummary.svelte',
+  './components/role-match/RoleMatchInsights.svelte',
+  './components/role-match/RoleMatchBreakdown.svelte',
+  './components/role-match/AnalysisNeedsReview.svelte',
+];
+const source = files
+  .map((path) => readFileSync(new URL(path, import.meta.url), 'utf8'))
+  .join('\n');
+
+describe('role match UI policy', () => {
+  test('contains the approved information hierarchy', () => {
+    for (const phrase of [
+      'What makes you a good fit',
+      'What may hold you back',
+      'Your best next step',
+      'See detailed breakdown',
+      'How this assessment works',
+      'Analysis needs review',
+    ]) {
+      expect(source).toContain(phrase);
+    }
+  });
+
+  test('does not expose internal engine language in the main UI', () => {
+    for (const forbidden of [
+      'raw_score',
+      'soft cap',
+      'unsupported essential',
+      'contradictory evidence',
+      'AI Suggested Emphasis',
+      'bg-gradient-to',
+    ]) {
+      expect(source).not.toContain(forbidden);
+    }
+  });
+});

--- a/frontend/src/lib/role-match-versioning.test.ts
+++ b/frontend/src/lib/role-match-versioning.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(
+  new URL('./components/role-match/RoleMatchVersionCompare.svelte', import.meta.url),
+  'utf8',
+);
+const legacySource = readFileSync(
+  new URL('./components/role-match/LegacyFitAnalysisNotice.svelte', import.meta.url),
+  'utf8',
+);
+
+describe('role match versioning UI', () => {
+  test('shows safe carry-forward states and restoration', () => {
+    for (const phrase of [
+      'Carried forward',
+      'Needs review',
+      'Not applicable',
+      'Restore original analysis',
+      'Your match increased from',
+    ]) {
+      expect(source).toContain(phrase);
+    }
+  });
+
+  test('clearly labels old model-generated results', () => {
+    expect(legacySource).toContain('Legacy AI fit score');
+    expect(legacySource).toContain('before evidence-based scoring was introduced');
+  });
+});


### PR DESCRIPTION
## Summary

- add typed frontend contracts and versioned role-match API helpers
- add a presenter that hides authoritative scores for review or failure states
- implement the approved human-friendly result hierarchy with separate confidence and eligibility
- add progressive disclosure for category, requirement, evidence, exclusions, and methodology details
- add optional requirement review, immutable correction, audit history, version comparison, and restore UI
- add a clear legacy score notice
- add Bun policy and presenter tests for copy, API coverage, review controls, and internal-language boundaries

## Stack

This is PR 5 of the v1.3.0 Role Evidence Match stack.

- Base: `test/role-match-golden-v1.3.0` / PR #51
- Head: `feat/role-match-ui-v1.3.0`
- Smart Apply, Cover Letter, History, Tracker integration, documentation, and release metadata follow in later stacked PRs.

## Verification

Authoritative verification will run through frontend and backend GitHub Actions on this PR head.

No merge, tag, or release is performed by this PR.