### PR TITLE
feat: integrate role matches with applications

### DIFF
--- a/backend/app/role_match/integration.py
+++ b/backend/app/role_match/integration.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.exceptions import InvalidRequestError, RoleMatchAnalysisNotFoundError
+from app.models import GeneratedCoverLetter
+from app.role_match.models import RoleMatchAnalysis
+
+
+@dataclass(frozen=True)
+class CoverLetterRoleMatchContext:
+    analysis_id: int
+    match_score: int | None
+    fit_context: str | None
+
+
+@dataclass(frozen=True)
+class ResolvedApplicationMatch:
+    score: int
+    source: str
+    analysis_id: int | None
+
+
+def _loads(raw: str | None, default: Any) -> Any:
+    if not raw:
+        return default
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _job_description_hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _is_authoritative(analysis: RoleMatchAnalysis | None) -> bool:
+    return bool(
+        analysis
+        and analysis.state == "success"
+        and analysis.show_authoritative_score
+        and analysis.display_score is not None
+    )
+
+
+def compact_role_match_analysis(
+    analysis: RoleMatchAnalysis | None,
+) -> dict[str, Any] | None:
+    if analysis is None:
+        return None
+    normalized = _loads(analysis.normalized_payload, {})
+    summary = normalized.get("summary")
+    return {
+        "id": analysis.id,
+        "state": analysis.state,
+        "score": analysis.display_score if _is_authoritative(analysis) else None,
+        "score_band": analysis.score_band if _is_authoritative(analysis) else None,
+        "confidence": analysis.confidence_band,
+        "eligibility": analysis.eligibility_status,
+        "show_authoritative_score": _is_authoritative(analysis),
+        "summary": summary,
+        "failure_code": analysis.failure_code,
+        "rules_version": analysis.rules_version,
+    }
+
+
+def _summary_to_fit_context(summary: dict[str, Any] | None) -> str | None:
+    if not summary:
+        return None
+    lines: list[str] = []
+    headline = summary.get("headline")
+    description = summary.get("description")
+    if headline:
+        lines.append(str(headline))
+    if description:
+        lines.append(str(description))
+
+    strengths = summary.get("strengths") or []
+    if strengths:
+        lines.append("Strongest supported evidence:")
+        for item in strengths[:3]:
+            title = item.get("title") if isinstance(item, dict) else None
+            explanation = item.get("explanation") if isinstance(item, dict) else None
+            if title:
+                lines.append(f"- {title}: {explanation or 'Supported by profile evidence.'}")
+
+    concerns = summary.get("concerns") or []
+    if concerns:
+        lines.append("Areas that should not be overstated:")
+        for item in concerns[:3]:
+            title = item.get("title") if isinstance(item, dict) else None
+            explanation = item.get("explanation") if isinstance(item, dict) else None
+            if title:
+                lines.append(f"- {title}: {explanation or 'Evidence is limited.'}")
+
+    next_step = summary.get("next_step")
+    if next_step:
+        lines.append(f"Recommended emphasis: {next_step}")
+    return "\n".join(lines) or None
+
+
+def build_cover_letter_role_match_context(
+    db: Session,
+    *,
+    analysis_id: int,
+    profile_id: int,
+    job_description: str,
+) -> CoverLetterRoleMatchContext:
+    analysis = db.query(RoleMatchAnalysis).filter_by(id=analysis_id).first()
+    if analysis is None:
+        raise RoleMatchAnalysisNotFoundError(analysis_id)
+    if analysis.profile_id != profile_id:
+        raise InvalidRequestError(
+            "Role match analysis must use the same profile as the cover letter"
+        )
+    if analysis.job_description_hash != _job_description_hash(job_description):
+        raise InvalidRequestError(
+            "Role match analysis does not match this job description"
+        )
+
+    if not _is_authoritative(analysis):
+        return CoverLetterRoleMatchContext(
+            analysis_id=analysis.id,
+            match_score=None,
+            fit_context=None,
+        )
+
+    normalized = _loads(analysis.normalized_payload, {})
+    return CoverLetterRoleMatchContext(
+        analysis_id=analysis.id,
+        match_score=analysis.display_score,
+        fit_context=_summary_to_fit_context(normalized.get("summary")),
+    )
+
+
+def enrich_cover_letter_role_match(
+    db: Session,
+    entry: GeneratedCoverLetter,
+) -> dict[str, Any]:
+    analysis = None
+    analysis_id = getattr(entry, "role_match_analysis_id", None)
+    if analysis_id is not None:
+        analysis = db.query(RoleMatchAnalysis).filter_by(id=analysis_id).first()
+
+    if _is_authoritative(analysis):
+        score = analysis.display_score
+        source = "role_evidence_match"
+    elif entry.match_score is not None:
+        score = entry.match_score
+        source = "legacy_llm_score"
+    else:
+        score = None
+        source = "none"
+
+    return {
+        "match_score": score,
+        "match_score_source": source,
+        "role_match_analysis_id": analysis.id if analysis is not None else None,
+        "role_match_analysis": compact_role_match_analysis(analysis),
+    }
+
+
+def resolve_application_match_scores(
+    db: Session,
+    application_ids: list[int],
+) -> dict[int, ResolvedApplicationMatch]:
+    if not application_ids:
+        return {}
+
+    resolved: dict[int, ResolvedApplicationMatch] = {}
+    direct_analyses = (
+        db.query(RoleMatchAnalysis)
+        .filter(
+            RoleMatchAnalysis.application_id.in_(application_ids),
+            RoleMatchAnalysis.state == "success",
+            RoleMatchAnalysis.show_authoritative_score.is_(True),
+            RoleMatchAnalysis.display_score.is_not(None),
+        )
+        .order_by(RoleMatchAnalysis.created_at.desc(), RoleMatchAnalysis.id.desc())
+        .all()
+    )
+    for analysis in direct_analyses:
+        application_id = analysis.application_id
+        if application_id is not None and application_id not in resolved:
+            resolved[application_id] = ResolvedApplicationMatch(
+                score=analysis.display_score,
+                source="role_evidence_match",
+                analysis_id=analysis.id,
+            )
+
+    cover_letters = (
+        db.query(GeneratedCoverLetter)
+        .filter(GeneratedCoverLetter.application_id.in_(application_ids))
+        .order_by(
+            GeneratedCoverLetter.created_at.desc(),
+            GeneratedCoverLetter.id.desc(),
+        )
+        .all()
+    )
+    analysis_ids = {
+        entry.role_match_analysis_id
+        for entry in cover_letters
+        if getattr(entry, "role_match_analysis_id", None) is not None
+    }
+    analyses = (
+        db.query(RoleMatchAnalysis).filter(RoleMatchAnalysis.id.in_(analysis_ids)).all()
+        if analysis_ids
+        else []
+    )
+    analysis_map = {analysis.id: analysis for analysis in analyses}
+
+    for entry in cover_letters:
+        application_id = entry.application_id
+        if application_id is None or application_id in resolved:
+            continue
+        analysis = analysis_map.get(getattr(entry, "role_match_analysis_id", None))
+        if _is_authoritative(analysis):
+            resolved[application_id] = ResolvedApplicationMatch(
+                score=analysis.display_score,
+                source="role_evidence_match",
+                analysis_id=analysis.id,
+            )
+
+    for entry in cover_letters:
+        application_id = entry.application_id
+        if (
+            application_id is None
+            or application_id in resolved
+            or entry.match_score is None
+        ):
+            continue
+        resolved[application_id] = ResolvedApplicationMatch(
+            score=entry.match_score,
+            source="legacy_llm_score",
+            analysis_id=None,
+        )
+
+    return resolved

--- a/backend/app/role_match/models.py
+++ b/backend/app/role_match/models.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import Boolean, Column, Date, DateTime, Float, ForeignKey, Integer, String, Text
 
-from app.models import Base
+from app.models import Base, GeneratedCoverLetter
 
 
 class RoleMatchAnalysis(Base):
@@ -36,6 +36,17 @@ class RoleMatchAnalysis(Base):
     show_authoritative_score = Column(Boolean, nullable=False, default=False)
     failure_code = Column(String(64), nullable=True)
     excluded_items = Column(Text, nullable=False, default="[]")
+
+
+# This column belongs to the legacy cover-letter table but is declared here so
+# importing the role-match subsystem is enough to register the complete v1.3
+# ORM metadata without coupling the legacy models module to the new engine.
+GeneratedCoverLetter.role_match_analysis_id = Column(
+    Integer,
+    ForeignKey("role_match_analysis.id", ondelete="SET NULL"),
+    nullable=True,
+    index=True,
+)
 
 
 class RoleMatchRequirement(Base):

--- a/backend/app/role_match/product_schemas.py
+++ b/backend/app/role_match/product_schemas.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from app.schemas import (
+    ApplicationEntry,
+    CoverLetterRequest,
+    GeneratedCoverLetterEntry,
+)
+
+
+class RoleMatchCoverLetterRequest(CoverLetterRequest):
+    role_match_analysis_id: int
+
+
+class CompactRoleMatchAnalysis(BaseModel):
+    id: int
+    state: str
+    score: int | None
+    score_band: str | None
+    confidence: str | None
+    eligibility: str
+    show_authoritative_score: bool
+    summary: dict[str, Any] | None
+    failure_code: str | None
+    rules_version: str
+
+
+class RoleMatchGeneratedCoverLetterEntry(GeneratedCoverLetterEntry):
+    match_score_source: Literal[
+        "role_evidence_match",
+        "legacy_llm_score",
+        "none",
+    ] = "none"
+    role_match_analysis_id: int | None = None
+    role_match_analysis: CompactRoleMatchAnalysis | None = None
+
+
+class RoleMatchGeneratedCoverLetterListResponse(BaseModel):
+    items: list[RoleMatchGeneratedCoverLetterEntry]
+    total: int
+
+
+class RoleMatchApplicationEntry(ApplicationEntry):
+    match_score_source: Literal[
+        "role_evidence_match",
+        "legacy_llm_score",
+        "none",
+    ] = "none"
+    role_match_analysis_id: int | None = None
+
+
+class RoleMatchApplicationListResponse(BaseModel):
+    items: list[RoleMatchApplicationEntry]
+    total: int

--- a/backend/app/role_match/scoring.py
+++ b/backend/app/role_match/scoring.py
@@ -92,6 +92,11 @@ def round_to_nearest_five(value: float) -> int:
     return int(max(Decimal("0"), min(rounded, Decimal("100"))))
 
 
+def _display_cap(cap: int) -> int:
+    """Convert an internal cap to the highest allowed five-point display value."""
+    return max(0, min(100, (cap // 5) * 5))
+
+
 def score_band(display_score: int) -> str:
     if display_score >= 85:
         return "exceptional_evidence_match"
@@ -126,7 +131,7 @@ def score_role_match(assessments: list[RequirementAssessment]) -> ScoreResult:
     capped_score = min(raw_score, float(cap)) if cap is not None else raw_score
     display_score = round_to_nearest_five(capped_score)
     if cap is not None:
-        display_score = min(display_score, cap)
+        display_score = min(display_score, _display_cap(cap))
     return ScoreResult(
         category_assessments=category_assessments,
         raw_score=raw_score,

--- a/backend/app/routes/applications.py
+++ b/backend/app/routes/applications.py
@@ -6,12 +6,12 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.exceptions import ApplicationNotFoundError
 from app.models import Application, GeneratedCoverLetter, GeneratedCV
-from app.schemas import (
-    ApplicationEntry,
-    ApplicationListResponse,
-    CreateApplicationRequest,
-    UpdateApplicationRequest,
+from app.role_match.integration import resolve_application_match_scores
+from app.role_match.product_schemas import (
+    RoleMatchApplicationEntry,
+    RoleMatchApplicationListResponse,
 )
+from app.schemas import CreateApplicationRequest, UpdateApplicationRequest
 from app.utils import batch_load_profiles
 
 router = APIRouter()
@@ -25,8 +25,8 @@ def _get_application_or_404(db: Session, application_id: int) -> Application:
 
 
 def _enrich_app(app: Application, profiles: dict) -> dict:
-    """Build ApplicationEntry dict from ORM object + profile map."""
-    p = profiles.get(app.profile_id) if app.profile_id else None
+    """Build an application response from the ORM object and profile map."""
+    profile = profiles.get(app.profile_id) if app.profile_id else None
     return {
         "id": app.id,
         "company_name": app.company_name,
@@ -37,10 +37,12 @@ def _enrich_app(app: Application, profiles: dict) -> dict:
         "applied_date": app.applied_date,
         "created_at": app.created_at,
         "profile_id": app.profile_id,
-        "profile_label": p.label if p else None,
-        "profile_color": p.color if p else None,
-        "profile_icon": p.icon if p else None,
+        "profile_label": profile.label if profile else None,
+        "profile_color": profile.color if profile else None,
+        "profile_icon": profile.icon if profile else None,
         "match_score": None,
+        "match_score_source": "none",
+        "role_match_analysis_id": None,
         "linked_cover_letter_id": None,
         "linked_cv_id": None,
         "location": app.location,
@@ -49,63 +51,61 @@ def _enrich_app(app: Application, profiles: dict) -> dict:
     }
 
 
-def _resolve_docs(app_ids: list[int], db: Session) -> tuple[dict, dict, dict]:
-    """
-    Returns three dicts keyed by application_id:
-      - cl_id: most recent cover letter id per application
-      - cv_id: most recent cv id per application
-      - match_score: match_score from most recent cover letter with a score
-    """
+def _resolve_docs(
+    app_ids: list[int],
+    db: Session,
+) -> tuple[dict[int, int], dict[int, int], dict]:
+    """Resolve latest documents and the preferred score source per application."""
     if not app_ids:
         return {}, {}, {}
 
-    cls = (
+    cover_letters = (
         db.query(GeneratedCoverLetter)
         .filter(GeneratedCoverLetter.application_id.in_(app_ids))
-        .order_by(GeneratedCoverLetter.created_at.desc())
+        .order_by(
+            GeneratedCoverLetter.created_at.desc(),
+            GeneratedCoverLetter.id.desc(),
+        )
         .all()
     )
     cvs = (
         db.query(GeneratedCV)
         .filter(GeneratedCV.application_id.in_(app_ids))
-        .order_by(GeneratedCV.created_at.desc())
+        .order_by(GeneratedCV.created_at.desc(), GeneratedCV.id.desc())
         .all()
     )
 
-    cl_id: dict = {}
-    match_scores: dict = {}
-    for cl in cls:
-        aid = cl.application_id
-        if aid not in cl_id:
-            cl_id[aid] = cl.id
-        score = getattr(cl, "match_score", None)
-        if aid not in match_scores and score is not None:
-            match_scores[aid] = score
+    cover_letter_ids: dict[int, int] = {}
+    for cover_letter in cover_letters:
+        application_id = cover_letter.application_id
+        if application_id is not None and application_id not in cover_letter_ids:
+            cover_letter_ids[application_id] = cover_letter.id
 
-    cv_id: dict = {}
+    cv_ids: dict[int, int] = {}
     for cv in cvs:
-        aid = cv.application_id
-        if aid not in cv_id:
-            cv_id[aid] = cv.id
+        application_id = cv.application_id
+        if application_id is not None and application_id not in cv_ids:
+            cv_ids[application_id] = cv.id
 
-    return cl_id, cv_id, match_scores
-
-
-def _build_app_entry(app: Application, db: Session) -> ApplicationEntry:
-    """Fully enrich a single Application into an ApplicationEntry."""
-    pm = batch_load_profiles([app], db)
-    entry = _enrich_app(app, pm)
-    cl_id, cv_id, scores = _resolve_docs([app.id], db)
-    entry["linked_cover_letter_id"] = cl_id.get(app.id)
-    entry["linked_cv_id"] = cv_id.get(app.id)
-    entry["match_score"] = scores.get(app.id)
-    return ApplicationEntry(**entry)
+    matches = resolve_application_match_scores(db, app_ids)
+    return cover_letter_ids, cv_ids, matches
 
 
-# --- Endpoints ---
+def _build_app_entry(app: Application, db: Session) -> RoleMatchApplicationEntry:
+    profiles = batch_load_profiles([app], db)
+    entry = _enrich_app(app, profiles)
+    cover_letter_ids, cv_ids, matches = _resolve_docs([app.id], db)
+    entry["linked_cover_letter_id"] = cover_letter_ids.get(app.id)
+    entry["linked_cv_id"] = cv_ids.get(app.id)
+    match = matches.get(app.id)
+    if match is not None:
+        entry["match_score"] = match.score
+        entry["match_score_source"] = match.source
+        entry["role_match_analysis_id"] = match.analysis_id
+    return RoleMatchApplicationEntry(**entry)
 
 
-@router.post("/applications", response_model=ApplicationEntry)
+@router.post("/applications", response_model=RoleMatchApplicationEntry)
 def create_application(body: CreateApplicationRequest, db: Session = Depends(get_db)):
     app = Application(
         company_name=body.company_name,
@@ -125,7 +125,7 @@ def create_application(body: CreateApplicationRequest, db: Session = Depends(get
     return _build_app_entry(app, db)
 
 
-@router.get("/applications", response_model=ApplicationListResponse)
+@router.get("/applications", response_model=RoleMatchApplicationListResponse)
 def list_applications(
     db: Session = Depends(get_db),
     profile_id: int | None = Query(default=None),
@@ -137,59 +137,63 @@ def list_applications(
     match_max: int | None = Query(default=None),
     sort: str = Query(default="date_desc"),
 ):
-    q = db.query(Application)
+    query = db.query(Application)
     if profile_id is not None:
-        q = q.filter(Application.profile_id == profile_id)
+        query = query.filter(Application.profile_id == profile_id)
     if status:
-        q = q.filter(Application.status == status)
+        query = query.filter(Application.status == status)
     if search:
         term = f"%{search}%"
-        q = q.filter(
+        query = query.filter(
             Application.company_name.ilike(term) | Application.role_title.ilike(term)
         )
     if date_from:
-        q = q.filter(Application.applied_date >= date_from)
+        query = query.filter(Application.applied_date >= date_from)
     if date_to:
-        q = q.filter(Application.applied_date <= date_to)
+        query = query.filter(Application.applied_date <= date_to)
     if sort == "date_asc":
-        q = q.order_by(
-            Application.applied_date.asc().nullslast(), Application.created_at.asc()
+        query = query.order_by(
+            Application.applied_date.asc().nullslast(),
+            Application.created_at.asc(),
         )
     else:
-        q = q.order_by(
-            Application.applied_date.desc().nullslast(), Application.created_at.desc()
+        query = query.order_by(
+            Application.applied_date.desc().nullslast(),
+            Application.created_at.desc(),
         )
 
-    apps = q.all()
-    pm = batch_load_profiles(apps, db)
-    app_ids = [a.id for a in apps]
-    cl_id, cv_id, scores = _resolve_docs(app_ids, db)
+    apps = query.all()
+    profiles = batch_load_profiles(apps, db)
+    app_ids = [app.id for app in apps]
+    cover_letter_ids, cv_ids, matches = _resolve_docs(app_ids, db)
 
-    items = []
-    for a in apps:
-        entry = _enrich_app(a, pm)
-        entry["linked_cover_letter_id"] = cl_id.get(a.id)
-        entry["linked_cv_id"] = cv_id.get(a.id)
-        entry["match_score"] = scores.get(a.id)
+    items: list[RoleMatchApplicationEntry] = []
+    for app in apps:
+        entry = _enrich_app(app, profiles)
+        entry["linked_cover_letter_id"] = cover_letter_ids.get(app.id)
+        entry["linked_cv_id"] = cv_ids.get(app.id)
+        match = matches.get(app.id)
+        if match is not None:
+            entry["match_score"] = match.score
+            entry["match_score_source"] = match.source
+            entry["role_match_analysis_id"] = match.analysis_id
 
-        # Apply match_min / match_max filter (post-query since score is derived)
         score = entry["match_score"]
         if match_min is not None and (score is None or score < match_min):
             continue
         if match_max is not None and (score is None or score > match_max):
             continue
+        items.append(RoleMatchApplicationEntry(**entry))
 
-        items.append(ApplicationEntry(**entry))
-
-    return ApplicationListResponse(items=items, total=len(items))
+    return RoleMatchApplicationListResponse(items=items, total=len(items))
 
 
-@router.get("/applications/{app_id}", response_model=ApplicationEntry)
+@router.get("/applications/{app_id}", response_model=RoleMatchApplicationEntry)
 def get_application(app_id: int, db: Session = Depends(get_db)):
     return _build_app_entry(_get_application_or_404(db, app_id), db)
 
 
-@router.patch("/applications/{app_id}", response_model=ApplicationEntry)
+@router.patch("/applications/{app_id}", response_model=RoleMatchApplicationEntry)
 def update_application(
     app_id: int, body: UpdateApplicationRequest, db: Session = Depends(get_db)
 ):
@@ -207,7 +211,6 @@ def update_application(
 @router.delete("/applications/{app_id}")
 def delete_application(app_id: int, db: Session = Depends(get_db)):
     app = _get_application_or_404(db, app_id)
-    # Nullify FKs on linked documents before deleting
     db.query(GeneratedCoverLetter).filter_by(application_id=app_id).update(
         {"application_id": None}
     )

--- a/backend/app/routes/history.py
+++ b/backend/app/routes/history.py
@@ -8,10 +8,13 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.exceptions import HistoryEntryNotFoundError
 from app.models import Application, GeneratedCoverLetter, GeneratedCV
+from app.role_match.integration import enrich_cover_letter_role_match
+from app.role_match.product_schemas import (
+    RoleMatchGeneratedCoverLetterEntry,
+    RoleMatchGeneratedCoverLetterListResponse,
+)
 from app.schemas import (
     BulkDeleteRequest,
-    GeneratedCoverLetterEntry,
-    GeneratedCoverLetterListResponse,
     GeneratedCVEntry,
     GeneratedCVListResponse,
     UpdateStatusRequest,
@@ -55,7 +58,7 @@ def _enrich_cv(entry: GeneratedCV, profiles: dict) -> dict:
     }
 
 
-def _enrich_cl(entry: GeneratedCoverLetter, profiles: dict) -> dict:
+def _enrich_cl(entry: GeneratedCoverLetter, profiles: dict, db: Session) -> dict:
     p = profiles.get(entry.profile_id) if entry.profile_id else None
     fit = None
     if entry.fit_analysis:
@@ -63,6 +66,7 @@ def _enrich_cl(entry: GeneratedCoverLetter, profiles: dict) -> dict:
             fit = json.loads(entry.fit_analysis)
         except Exception:
             fit = None
+    role_match = enrich_cover_letter_role_match(db, entry)
     return {
         "id": entry.id,
         "created_at": entry.created_at,
@@ -75,7 +79,6 @@ def _enrich_cl(entry: GeneratedCoverLetter, profiles: dict) -> dict:
         "cover_letter_text": entry.cover_letter_text,
         "tone": entry.tone or "professional",
         "job_url": entry.job_url,
-        "match_score": entry.match_score,
         "fit_analysis": fit,
         "application_status": entry.application_status,
         "application_id": entry.application_id,
@@ -83,6 +86,7 @@ def _enrich_cl(entry: GeneratedCoverLetter, profiles: dict) -> dict:
         "profile_label": p.label if p else None,
         "profile_color": p.color if p else None,
         "profile_icon": p.icon if p else None,
+        **role_match,
     }
 
 
@@ -144,7 +148,10 @@ def update_cv_status(
 # --- Cover letter history ---
 
 
-@router.get("/history/cover-letter", response_model=GeneratedCoverLetterListResponse)
+@router.get(
+    "/history/cover-letter",
+    response_model=RoleMatchGeneratedCoverLetterListResponse,
+)
 def list_cover_letter_history(
     db: Session = Depends(get_db),
     profile_id: int | None = Query(default=None),
@@ -165,36 +172,54 @@ def list_cover_letter_history(
             GeneratedCoverLetter.company_name.ilike(term)
             | GeneratedCoverLetter.job_description.ilike(term)
         )
-    if match_min is not None:
-        q = q.filter(GeneratedCoverLetter.match_score >= match_min)
-    if match_max is not None:
-        q = q.filter(GeneratedCoverLetter.match_score <= match_max)
     if status:
         q = q.filter(GeneratedCoverLetter.application_status == status)
     if sort == "date_asc":
         q = q.order_by(GeneratedCoverLetter.created_at.asc())
-    elif sort == "match_desc":
-        q = q.order_by(GeneratedCoverLetter.match_score.desc().nullslast())
     elif sort == "company_asc":
         q = q.order_by(GeneratedCoverLetter.company_name.asc().nullslast())
     else:
         q = q.order_by(GeneratedCoverLetter.created_at.desc())
-    total = q.count()
-    items = q.offset(offset).limit(limit).all()
-    pm = batch_load_profiles(items, db)
-    return GeneratedCoverLetterListResponse(
-        items=[_enrich_cl(e, pm) for e in items], total=total
-    )
+
+    entries = q.all()
+    profiles = batch_load_profiles(entries, db)
+    enriched = [_enrich_cl(entry, profiles, db) for entry in entries]
+    if match_min is not None:
+        enriched = [
+            item
+            for item in enriched
+            if item["match_score"] is not None and item["match_score"] >= match_min
+        ]
+    if match_max is not None:
+        enriched = [
+            item
+            for item in enriched
+            if item["match_score"] is not None and item["match_score"] <= match_max
+        ]
+    if sort == "match_desc":
+        enriched.sort(
+            key=lambda item: (
+                item["match_score"] is not None,
+                item["match_score"] or -1,
+                item["created_at"],
+            ),
+            reverse=True,
+        )
+
+    total = len(enriched)
+    page = enriched[offset : offset + limit]
+    return RoleMatchGeneratedCoverLetterListResponse(items=page, total=total)
 
 
 @router.get(
-    "/history/cover-letter/{entry_id}", response_model=GeneratedCoverLetterEntry
+    "/history/cover-letter/{entry_id}",
+    response_model=RoleMatchGeneratedCoverLetterEntry,
 )
 def get_cover_letter_history_entry(entry_id: int, db: Session = Depends(get_db)):
     entry = db.query(GeneratedCoverLetter).filter_by(id=entry_id).first()
     if not entry:
         raise HistoryEntryNotFoundError("Cover letter", entry_id)
-    return _enrich_cl(entry, batch_load_profiles([entry], db))
+    return _enrich_cl(entry, batch_load_profiles([entry], db), db)
 
 
 @router.delete("/history/cover-letter/{entry_id}", status_code=204)
@@ -207,7 +232,8 @@ def delete_cover_letter_history_entry(entry_id: int, db: Session = Depends(get_d
 
 
 @router.patch(
-    "/history/cover-letter/{entry_id}/status", response_model=GeneratedCoverLetterEntry
+    "/history/cover-letter/{entry_id}/status",
+    response_model=RoleMatchGeneratedCoverLetterEntry,
 )
 def update_cover_letter_status(
     entry_id: int, body: UpdateStatusRequest, db: Session = Depends(get_db)
@@ -218,12 +244,10 @@ def update_cover_letter_status(
     entry.application_status = body.status
     if body.status:
         if entry.application_id:
-            # Sync status to the linked Application
             linked = db.query(Application).filter_by(id=entry.application_id).first()
             if linked:
                 linked.status = body.status
         else:
-            # Auto-create an Application record and link it
             app = Application(
                 company_name=entry.company_name or "Unknown",
                 role_title=entry.role_title or "",
@@ -238,9 +262,8 @@ def update_cover_letter_status(
             db.add(app)
             db.flush()
             entry.application_id = app.id
-    # Note: clearing to "—" does not unlink the Application — manage it from Tracker
     db.commit()
-    return _enrich_cl(entry, batch_load_profiles([entry], db))
+    return _enrich_cl(entry, batch_load_profiles([entry], db), db)
 
 
 @router.delete("/history/cover-letter")

--- a/backend/app/routes/role_match_generate.py
+++ b/backend/app/routes/role_match_generate.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterable
+
+from fastapi import APIRouter, Depends
+from fastapi.sse import EventSourceResponse, ServerSentEvent
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies import get_profile_or_404, require_llm_config
+from app.exceptions import stream_error_event
+from app.models import GeneratedCoverLetter
+from app.role_match.integration import build_cover_letter_role_match_context
+from app.role_match.product_schemas import RoleMatchCoverLetterRequest
+from app.routes.generate import _build_cover_letter_prompt
+from app.services.llm import OPERATION_COVER_LETTER, stream_llm
+from app.services.prompts import COVER_LETTER_SYSTEM_PROMPT
+from app.utils import profile_to_schema
+
+router = APIRouter()
+
+
+@router.post(
+    "/generate/cover-letter/role-match",
+    response_class=EventSourceResponse,
+)
+async def generate_role_match_cover_letter(
+    req: RoleMatchCoverLetterRequest,
+    db: Session = Depends(get_db),
+    llm: tuple[str, str] = Depends(require_llm_config),
+) -> AsyncIterable[ServerSentEvent]:
+    profile = get_profile_or_404(req.profile_id, db)
+    profile_data = profile_to_schema(profile)
+    provider, api_key = llm
+
+    role_match = build_cover_letter_role_match_context(
+        db,
+        analysis_id=req.role_match_analysis_id,
+        profile_id=req.profile_id,
+        job_description=req.job_description,
+    )
+    effective_request = req.model_copy(
+        update={
+            "fit_context": role_match.fit_context,
+            "match_score": None,
+            "fit_analysis_json": None,
+        }
+    )
+    prompt = _build_cover_letter_prompt(profile_data, effective_request)
+
+    accumulated: list[str] = []
+    try:
+        async for chunk in stream_llm(
+            prompt,
+            system=COVER_LETTER_SYSTEM_PROMPT,
+            provider=provider,
+            api_key=api_key,
+            operation=OPERATION_COVER_LETTER,
+            profile_id=req.profile_id,
+        ):
+            accumulated.append(str(chunk))
+            yield ServerSentEvent(data=str(chunk), event="token")
+    except Exception as exc:
+        yield stream_error_event(exc)
+        return
+
+    entry = GeneratedCoverLetter(
+        company_name=req.company_name,
+        role_title=req.role_title,
+        location=req.location,
+        salary=req.salary,
+        job_description=req.job_description,
+        extra_context=req.extra_context or None,
+        cover_letter_text="".join(accumulated),
+        profile_id=req.profile_id,
+        job_url=req.job_url,
+        tone=req.tone or "professional",
+        match_score=None,
+        fit_analysis=None,
+        application_id=req.application_id,
+        role_match_analysis_id=role_match.analysis_id,
+    )
+    db.add(entry)
+    db.commit()
+
+    yield ServerSentEvent(data="[DONE]", event="done")

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,7 @@ from app.routes import (
     profile,
     profiles,
     readiness,
+    role_match_generate,
     scrape,
     settings,
     usage,
@@ -73,6 +74,7 @@ app.include_router(profile.router, prefix="/api")
 app.include_router(profiles.router, prefix="/api")
 app.include_router(readiness.router, prefix="/api", tags=["readiness"])
 app.include_router(generate.router, prefix="/api")
+app.include_router(role_match_generate.router, prefix="/api")
 app.include_router(analyze.router, prefix="/api")
 app.include_router(history.router, prefix="/api")
 app.include_router(import_cv.router, prefix="/api")

--- a/backend/migrations/versions/d9f4a2c7e1b3_link_cover_letters_to_role_match.py
+++ b/backend/migrations/versions/d9f4a2c7e1b3_link_cover_letters_to_role_match.py
@@ -1,0 +1,46 @@
+"""link cover letters to role match analyses
+
+Revision ID: d9f4a2c7e1b3
+Revises: c4a7e9f21b6d
+Create Date: 2026-08-06 14:10:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d9f4a2c7e1b3"
+down_revision: str | Sequence[str] | None = "c4a7e9f21b6d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("generated_cover_letter") as batch_op:
+        batch_op.add_column(
+            sa.Column("role_match_analysis_id", sa.Integer(), nullable=True)
+        )
+        batch_op.create_foreign_key(
+            "fk_generated_cover_letter_role_match_analysis_id",
+            "role_match_analysis",
+            ["role_match_analysis_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+        batch_op.create_index(
+            "ix_generated_cover_letter_role_match_analysis_id",
+            ["role_match_analysis_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("generated_cover_letter") as batch_op:
+        batch_op.drop_index("ix_generated_cover_letter_role_match_analysis_id")
+        batch_op.drop_constraint(
+            "fk_generated_cover_letter_role_match_analysis_id",
+            type_="foreignkey",
+        )
+        batch_op.drop_column("role_match_analysis_id")

--- a/backend/tests/role_match/test_product_integration.py
+++ b/backend/tests/role_match/test_product_integration.py
@@ -1,0 +1,298 @@
+import hashlib
+import json
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.exceptions import InvalidRequestError
+from app.models import Application, Base, GeneratedCoverLetter, Profile
+from app.role_match.integration import (
+    build_cover_letter_role_match_context,
+    enrich_cover_letter_role_match,
+    resolve_application_match_scores,
+)
+from app.role_match.models import RoleMatchAnalysis
+
+
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def add_profile(db, profile_id: int = 1) -> Profile:
+    profile = Profile(
+        id=profile_id,
+        label="Default",
+        color="#6366f1",
+        icon="💼",
+        name="Candidate",
+        email="candidate@example.com",
+    )
+    db.add(profile)
+    db.flush()
+    return profile
+
+
+def add_application(db, profile_id: int = 1) -> Application:
+    application = Application(
+        company_name="Example",
+        role_title="Backend Engineer",
+        status="applied",
+        profile_id=profile_id,
+        job_description="Python backend role",
+    )
+    db.add(application)
+    db.flush()
+    return application
+
+
+def add_analysis(
+    db,
+    *,
+    profile_id: int,
+    job_description: str = "Python backend role",
+    application_id: int | None = None,
+    score: int | None = 80,
+    authoritative: bool = True,
+    created_at: datetime | None = None,
+) -> RoleMatchAnalysis:
+    summary = {
+        "headline": "Your profile is a strong match",
+        "description": "Strong Python backend evidence.",
+        "strengths": [
+            {
+                "title": "Production Python backend capability",
+                "explanation": "Supported by recent work evidence.",
+                "evidence_label": "Work experience",
+            }
+        ],
+        "concerns": [],
+        "next_step": "Use the production Python example in your application.",
+    }
+    analysis = RoleMatchAnalysis(
+        profile_id=profile_id,
+        application_id=application_id,
+        created_at=created_at or datetime.now(UTC),
+        analysis_date=date(2026, 8, 6),
+        state="success" if authoritative else "needs_review",
+        job_description=job_description,
+        job_description_hash=hashlib.sha256(job_description.encode()).hexdigest(),
+        safe_profile_snapshot="{}",
+        safe_profile_hash=hashlib.sha256(b"{}").hexdigest(),
+        rules_version="role-match-v1",
+        prompt_version="role-match-extraction-v1",
+        model_provider="openai",
+        model_name="model",
+        raw_llm_output="{}",
+        normalized_payload=json.dumps({"clusters": [], "summary": summary}),
+        scoring_payload="{}",
+        raw_score=float(score) if score is not None else None,
+        display_score=score if authoritative else None,
+        score_band="strong_evidence_match" if authoritative else None,
+        confidence_score=0.8,
+        confidence_band="high",
+        eligibility_status="likely_eligible",
+        show_authoritative_score=authoritative,
+        failure_code=None if authoritative else "insufficient_known_coverage",
+        excluded_items="[]",
+    )
+    db.add(analysis)
+    db.flush()
+    return analysis
+
+
+def add_cover_letter(
+    db,
+    *,
+    profile_id: int,
+    application_id: int | None,
+    legacy_score: int | None,
+    role_match_analysis_id: int | None = None,
+    created_at: datetime | None = None,
+) -> GeneratedCoverLetter:
+    entry = GeneratedCoverLetter(
+        created_at=created_at or datetime.now(UTC),
+        company_name="Example",
+        role_title="Backend Engineer",
+        job_description="Python backend role",
+        cover_letter_text="Hello",
+        profile_id=profile_id,
+        application_id=application_id,
+        role_match_analysis_id=role_match_analysis_id,
+        match_score=legacy_score,
+        tone="professional",
+    )
+    db.add(entry)
+    db.flush()
+    return entry
+
+
+def test_cover_letter_context_uses_server_analysis_values() -> None:
+    db = db_session()
+    add_profile(db)
+    analysis = add_analysis(db, profile_id=1, score=80)
+
+    context = build_cover_letter_role_match_context(
+        db,
+        analysis_id=analysis.id,
+        profile_id=1,
+        job_description="Python backend role",
+    )
+
+    assert context.analysis_id == analysis.id
+    assert context.match_score == 80
+    assert "Production Python backend capability" in context.fit_context
+    assert "Use the production Python example" in context.fit_context
+
+
+def test_cover_letter_context_rejects_wrong_profile() -> None:
+    db = db_session()
+    add_profile(db, 1)
+    add_profile(db, 2)
+    analysis = add_analysis(db, profile_id=1)
+
+    with pytest.raises(InvalidRequestError, match="same profile"):
+        build_cover_letter_role_match_context(
+            db,
+            analysis_id=analysis.id,
+            profile_id=2,
+            job_description="Python backend role",
+        )
+
+
+def test_cover_letter_context_rejects_changed_job_description() -> None:
+    db = db_session()
+    add_profile(db)
+    analysis = add_analysis(db, profile_id=1)
+
+    with pytest.raises(InvalidRequestError, match="job description"):
+        build_cover_letter_role_match_context(
+            db,
+            analysis_id=analysis.id,
+            profile_id=1,
+            job_description="Different role",
+        )
+
+
+def test_non_authoritative_analysis_links_without_exposing_score() -> None:
+    db = db_session()
+    add_profile(db)
+    analysis = add_analysis(db, profile_id=1, authoritative=False)
+
+    context = build_cover_letter_role_match_context(
+        db,
+        analysis_id=analysis.id,
+        profile_id=1,
+        job_description="Python backend role",
+    )
+
+    assert context.analysis_id == analysis.id
+    assert context.match_score is None
+    assert context.fit_context is None
+
+
+def test_history_labels_evidence_and_legacy_scores() -> None:
+    db = db_session()
+    add_profile(db)
+    analysis = add_analysis(db, profile_id=1, score=80)
+    modern = add_cover_letter(
+        db,
+        profile_id=1,
+        application_id=None,
+        legacy_score=99,
+        role_match_analysis_id=analysis.id,
+    )
+    legacy = add_cover_letter(
+        db,
+        profile_id=1,
+        application_id=None,
+        legacy_score=72,
+    )
+
+    modern_payload = enrich_cover_letter_role_match(db, modern)
+    legacy_payload = enrich_cover_letter_role_match(db, legacy)
+
+    assert modern_payload["match_score"] == 80
+    assert modern_payload["match_score_source"] == "role_evidence_match"
+    assert modern_payload["role_match_analysis_id"] == analysis.id
+    assert modern_payload["role_match_analysis"]["confidence"] == "high"
+    assert legacy_payload["match_score"] == 72
+    assert legacy_payload["match_score_source"] == "legacy_llm_score"
+    assert legacy_payload["role_match_analysis"] is None
+
+
+def test_application_prefers_latest_direct_authoritative_analysis() -> None:
+    db = db_session()
+    add_profile(db)
+    application = add_application(db)
+    old = datetime.now(UTC) - timedelta(days=2)
+    linked_analysis = add_analysis(
+        db,
+        profile_id=1,
+        application_id=None,
+        score=75,
+        created_at=old,
+    )
+    add_cover_letter(
+        db,
+        profile_id=1,
+        application_id=application.id,
+        legacy_score=95,
+        role_match_analysis_id=linked_analysis.id,
+        created_at=old,
+    )
+    direct = add_analysis(
+        db,
+        profile_id=1,
+        application_id=application.id,
+        score=85,
+        created_at=datetime.now(UTC),
+    )
+
+    resolved = resolve_application_match_scores(db, [application.id])
+
+    assert resolved[application.id].score == 85
+    assert resolved[application.id].source == "role_evidence_match"
+    assert resolved[application.id].analysis_id == direct.id
+
+
+def test_application_uses_cover_letter_analysis_before_legacy_score() -> None:
+    db = db_session()
+    add_profile(db)
+    application = add_application(db)
+    analysis = add_analysis(db, profile_id=1, score=80)
+    add_cover_letter(
+        db,
+        profile_id=1,
+        application_id=application.id,
+        legacy_score=95,
+        role_match_analysis_id=analysis.id,
+    )
+
+    resolved = resolve_application_match_scores(db, [application.id])
+
+    assert resolved[application.id].score == 80
+    assert resolved[application.id].source == "role_evidence_match"
+
+
+def test_non_authoritative_analysis_does_not_replace_legacy_score() -> None:
+    db = db_session()
+    add_profile(db)
+    application = add_application(db)
+    analysis = add_analysis(db, profile_id=1, authoritative=False)
+    add_cover_letter(
+        db,
+        profile_id=1,
+        application_id=application.id,
+        legacy_score=70,
+        role_match_analysis_id=analysis.id,
+    )
+
+    resolved = resolve_application_match_scores(db, [application.id])
+
+    assert resolved[application.id].score == 70
+    assert resolved[application.id].source == "legacy_llm_score"
+    assert resolved[application.id].analysis_id is None

--- a/backend/tests/role_match/test_scoring_confidence.py
+++ b/backend/tests/role_match/test_scoring_confidence.py
@@ -94,7 +94,7 @@ def test_display_rounding_and_band() -> None:
     assert score_band(80) == "strong_evidence_match"
 
 
-def test_score_role_match_applies_essential_cap() -> None:
+def test_score_role_match_applies_essential_cap_without_breaking_display_increment() -> None:
     result = score_role_match(
         [
             assessment(
@@ -130,7 +130,8 @@ def test_score_role_match_applies_essential_cap() -> None:
         ]
     )
     assert result.applied_cap == 74
-    assert result.display_score <= 74
+    assert result.display_score == 70
+    assert result.display_score % 5 == 0
 
 
 def test_confidence_formula() -> None:


### PR DESCRIPTION
## Summary

- link generated cover letters to immutable role-match analyses
- add a verified server-side cover-letter generation endpoint that ignores client-supplied scores and fit context
- add shared score-source resolution for history and the application tracker
- prefer the latest direct authoritative analysis, then a linked cover-letter analysis, then a legacy model-generated score
- expose `role_evidence_match`, `legacy_llm_score`, and `none` source labels
- preserve legacy generation and history fields for backward compatibility
- add migration and focused product-integration tests

## Stack

This is PR 6 of the v1.3.0 Role Evidence Match stack.

- Base: `feat/role-match-ui-v1.3.0` / PR #52
- Head: `feat/role-match-integration-v1.3.0`
- Frontend page integration and release documentation follow in later stacked PRs.

## Verification

Authoritative backend and container verification will run through GitHub Actions on this PR head.

No merge, tag, or release is performed by this PR.