### PR TITLE
feat: connect role match to product flows

### DIFF
--- a/backend/app/role_match/integration.py
+++ b/backend/app/role_match/integration.py
@@ -48,27 +48,6 @@ def _is_authoritative(analysis: RoleMatchAnalysis | None) -> bool:
     )
 
 
-def compact_role_match_analysis(
-    analysis: RoleMatchAnalysis | None,
-) -> dict[str, Any] | None:
-    if analysis is None:
-        return None
-    normalized = _loads(analysis.normalized_payload, {})
-    summary = normalized.get("summary")
-    return {
-        "id": analysis.id,
-        "state": analysis.state,
-        "score": analysis.display_score if _is_authoritative(analysis) else None,
-        "score_band": analysis.score_band if _is_authoritative(analysis) else None,
-        "confidence": analysis.confidence_band,
-        "eligibility": analysis.eligibility_status,
-        "show_authoritative_score": _is_authoritative(analysis),
-        "summary": summary,
-        "failure_code": analysis.failure_code,
-        "rules_version": analysis.rules_version,
-    }
-
-
 def _summary_to_fit_context(summary: dict[str, Any] | None) -> str | None:
     if not summary:
         return None
@@ -138,6 +117,39 @@ def build_cover_letter_role_match_context(
     )
 
 
+def _legacy_compatible_fit_analysis(
+    analysis_payload: dict[str, Any],
+) -> dict[str, Any]:
+    summary = analysis_payload.get("summary") or {}
+    strengths = summary.get("strengths") or []
+    concerns = summary.get("concerns") or []
+    requirements = analysis_payload.get("requirements") or []
+    missing = [
+        item.get("canonical_text")
+        for item in requirements
+        if item.get("match_level") in {"no_evidence", "unknown"}
+        and item.get("canonical_text")
+    ]
+    eligibility = analysis_payload.get("eligibility")
+    red_flags = (
+        [f"Eligibility status: {str(eligibility).replace('_', ' ')}"]
+        if eligibility in {"likely_ineligible", "ineligible"}
+        else []
+    )
+    return {
+        "match_score": analysis_payload.get("score") or 0,
+        "pros": [item.get("title") for item in strengths if item.get("title")],
+        "cons": [item.get("title") for item in concerns if item.get("title")],
+        "missing_keywords": missing,
+        "red_flags": red_flags,
+        "suggested_emphasis": summary.get("next_step")
+        or "Review the evidence details before tailoring this application.",
+        "interview_questions": [],
+        "role_match_analysis_id": analysis_payload["id"],
+        "role_match_analysis": analysis_payload,
+    }
+
+
 def enrich_cover_letter_role_match(
     db: Session,
     entry: GeneratedCoverLetter,
@@ -157,11 +169,20 @@ def enrich_cover_letter_role_match(
         score = None
         source = "none"
 
+    analysis_payload = None
+    compatibility_payload = None
+    if analysis is not None:
+        from app.role_match.repository import serialize_analysis
+
+        analysis_payload = serialize_analysis(db, analysis).model_dump(mode="json")
+        compatibility_payload = _legacy_compatible_fit_analysis(analysis_payload)
+
     return {
         "match_score": score,
         "match_score_source": source,
         "role_match_analysis_id": analysis.id if analysis is not None else None,
-        "role_match_analysis": compact_role_match_analysis(analysis),
+        "role_match_analysis": analysis_payload,
+        "fit_analysis": compatibility_payload,
     }
 
 

--- a/backend/app/role_match/product_schemas.py
+++ b/backend/app/role_match/product_schemas.py
@@ -4,6 +4,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel
 
+from app.role_match.api_schemas import RoleMatchAnalysisResponse
 from app.schemas import (
     ApplicationEntry,
     CoverLetterRequest,
@@ -15,27 +16,15 @@ class RoleMatchCoverLetterRequest(CoverLetterRequest):
     role_match_analysis_id: int
 
 
-class CompactRoleMatchAnalysis(BaseModel):
-    id: int
-    state: str
-    score: int | None
-    score_band: str | None
-    confidence: str | None
-    eligibility: str
-    show_authoritative_score: bool
-    summary: dict[str, Any] | None
-    failure_code: str | None
-    rules_version: str
-
-
 class RoleMatchGeneratedCoverLetterEntry(GeneratedCoverLetterEntry):
+    fit_analysis: dict[str, Any] | None = None
     match_score_source: Literal[
         "role_evidence_match",
         "legacy_llm_score",
         "none",
     ] = "none"
     role_match_analysis_id: int | None = None
-    role_match_analysis: CompactRoleMatchAnalysis | None = None
+    role_match_analysis: RoleMatchAnalysisResponse | None = None
 
 
 class RoleMatchGeneratedCoverLetterListResponse(BaseModel):

--- a/backend/app/role_match/scoring.py
+++ b/backend/app/role_match/scoring.py
@@ -92,6 +92,11 @@ def round_to_nearest_five(value: float) -> int:
     return int(max(Decimal("0"), min(rounded, Decimal("100"))))
 
 
+def _display_cap(cap: int) -> int:
+    """Convert an internal cap to the highest allowed five-point display value."""
+    return max(0, min(100, (cap // 5) * 5))
+
+
 def score_band(display_score: int) -> str:
     if display_score >= 85:
         return "exceptional_evidence_match"
@@ -126,7 +131,7 @@ def score_role_match(assessments: list[RequirementAssessment]) -> ScoreResult:
     capped_score = min(raw_score, float(cap)) if cap is not None else raw_score
     display_score = round_to_nearest_five(capped_score)
     if cap is not None:
-        display_score = min(display_score, cap)
+        display_score = min(display_score, _display_cap(cap))
     return ScoreResult(
         category_assessments=category_assessments,
         raw_score=raw_score,

--- a/backend/tests/role_match/test_history_compatibility.py
+++ b/backend/tests/role_match/test_history_compatibility.py
@@ -1,0 +1,92 @@
+import hashlib
+import json
+from datetime import UTC, date, datetime
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base, GeneratedCoverLetter, Profile
+from app.role_match.integration import enrich_cover_letter_role_match
+from app.role_match.models import RoleMatchAnalysis
+
+
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_modern_history_includes_full_analysis_and_compatibility_payload() -> None:
+    db = db_session()
+    db.add(
+        Profile(
+            id=1,
+            label="Default",
+            color="#6366f1",
+            icon="💼",
+            name="Candidate",
+            email="candidate@example.com",
+        )
+    )
+    summary = {
+        "headline": "Your profile is a strong match",
+        "description": "Strong evidence.",
+        "strengths": [
+            {
+                "title": "Python backend capability",
+                "explanation": "Supported by work evidence.",
+            }
+        ],
+        "concerns": [],
+        "next_step": "Use the Python example.",
+    }
+    analysis = RoleMatchAnalysis(
+        profile_id=1,
+        created_at=datetime.now(UTC),
+        analysis_date=date(2026, 8, 6),
+        state="success",
+        job_description="Python role",
+        job_description_hash=hashlib.sha256(b"Python role").hexdigest(),
+        safe_profile_snapshot="{}",
+        safe_profile_hash=hashlib.sha256(b"{}").hexdigest(),
+        rules_version="role-match-v1",
+        prompt_version="role-match-extraction-v1",
+        model_provider="openai",
+        model_name="model",
+        normalized_payload=json.dumps({"clusters": [], "summary": summary}),
+        scoring_payload=json.dumps(
+            {
+                "score": {"category_assessments": []},
+                "confidence": None,
+                "eligibility": {"status": "likely_eligible", "reasons": []},
+                "assessments": [],
+            }
+        ),
+        raw_score=80.0,
+        display_score=80,
+        score_band="strong_evidence_match",
+        confidence_score=0.8,
+        confidence_band="high",
+        eligibility_status="likely_eligible",
+        show_authoritative_score=True,
+        excluded_items="[]",
+    )
+    db.add(analysis)
+    db.flush()
+    entry = GeneratedCoverLetter(
+        company_name="Example",
+        job_description="Python role",
+        cover_letter_text="Hello",
+        profile_id=1,
+        role_match_analysis_id=analysis.id,
+    )
+    db.add(entry)
+    db.flush()
+
+    payload = enrich_cover_letter_role_match(db, entry)
+
+    assert payload["role_match_analysis"]["id"] == analysis.id
+    assert payload["role_match_analysis"]["requirements"] == []
+    assert payload["fit_analysis"]["role_match_analysis_id"] == analysis.id
+    assert payload["fit_analysis"]["role_match_analysis"]["score"] == 80
+    assert payload["fit_analysis"]["pros"] == ["Python backend capability"]

--- a/backend/tests/role_match/test_scoring_confidence.py
+++ b/backend/tests/role_match/test_scoring_confidence.py
@@ -94,7 +94,7 @@ def test_display_rounding_and_band() -> None:
     assert score_band(80) == "strong_evidence_match"
 
 
-def test_score_role_match_applies_essential_cap() -> None:
+def test_score_role_match_applies_essential_cap_without_breaking_display_increment() -> None:
     result = score_role_match(
         [
             assessment(
@@ -130,7 +130,8 @@ def test_score_role_match_applies_essential_cap() -> None:
         ]
     )
     assert result.applied_cap == 74
-    assert result.display_score <= 74
+    assert result.display_score == 70
+    assert result.display_score % 5 == 0
 
 
 def test_confidence_formula() -> None:

--- a/frontend/src/lib/api-compat.ts
+++ b/frontend/src/lib/api-compat.ts
@@ -1,0 +1,99 @@
+export * from './api';
+
+import {
+  generateCoverLetterStream as legacyGenerateCoverLetterStream,
+} from './api';
+import { apiFetch } from './api-client';
+import { parseApiError } from './api-error';
+import { analyzeRoleMatch } from './role-match-api';
+import type { RoleMatchAnalysisResponse } from './role-match-types';
+import type { CoverLetterRequest, FitAnalysisResponse } from './types';
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000/api';
+
+export interface RoleMatchCompatibleFitAnalysis extends FitAnalysisResponse {
+  role_match_analysis_id: number;
+  role_match_analysis: RoleMatchAnalysisResponse;
+}
+
+function toLegacyCompatibleAnalysis(
+  analysis: RoleMatchAnalysisResponse,
+): RoleMatchCompatibleFitAnalysis {
+  const strengths = analysis.summary?.strengths ?? [];
+  const concerns = analysis.summary?.concerns ?? [];
+  const missing = analysis.requirements.filter((requirement) =>
+    ['no_evidence', 'unknown'].includes(requirement.match_level ?? 'unknown'),
+  );
+  const redFlags = ['likely_ineligible', 'ineligible'].includes(analysis.eligibility)
+    ? [`Eligibility status: ${analysis.eligibility.replaceAll('_', ' ')}`]
+    : [];
+
+  return {
+    match_score: analysis.show_authoritative_score ? analysis.score ?? 0 : 0,
+    pros: strengths.map((item) => item.title),
+    cons: concerns.map((item) => item.title),
+    missing_keywords: missing.map((requirement) => requirement.canonical_text),
+    red_flags: redFlags,
+    suggested_emphasis:
+      analysis.summary?.next_step ??
+      'Review the identified requirements before tailoring your application.',
+    interview_questions: [],
+    role_match_analysis_id: analysis.id,
+    role_match_analysis: analysis,
+  };
+}
+
+export async function analyzeFit(
+  profile_id: number,
+  job_description: string,
+): Promise<RoleMatchCompatibleFitAnalysis> {
+  const analysis = await analyzeRoleMatch({ profile_id, job_description });
+  return toLegacyCompatibleAnalysis(analysis);
+}
+
+function analysisIdFromRequest(data: CoverLetterRequest): number | null {
+  const direct = (data as CoverLetterRequest & { role_match_analysis_id?: number })
+    .role_match_analysis_id;
+  if (typeof direct === 'number') return direct;
+  if (!data.fit_analysis_json) return null;
+  try {
+    const parsed = JSON.parse(data.fit_analysis_json) as {
+      role_match_analysis_id?: unknown;
+    };
+    return typeof parsed.role_match_analysis_id === 'number'
+      ? parsed.role_match_analysis_id
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function generateCoverLetterStream(
+  data: CoverLetterRequest,
+): Promise<Response> {
+  const analysisId = analysisIdFromRequest(data);
+  if (analysisId === null) return legacyGenerateCoverLetterStream(data);
+
+  const payload: Record<string, unknown> = {
+    ...data,
+    role_match_analysis_id: analysisId,
+  };
+  delete payload.match_score;
+  delete payload.fit_context;
+  delete payload.fit_analysis_json;
+
+  const response = await apiFetch(`${BASE_URL}/generate/cover-letter/role-match`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const errorPayload: unknown = await response.json().catch(() => undefined);
+    throw parseApiError(
+      errorPayload,
+      'The cover letter could not be generated from this role match.',
+      response.status,
+    );
+  }
+  return response;
+}

--- a/frontend/src/lib/components/RoleMatchFitAnalysisDisplay.svelte
+++ b/frontend/src/lib/components/RoleMatchFitAnalysisDisplay.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+  import {
+    applyRoleMatchOverrides,
+    compareRoleMatchVersions,
+    getRoleMatchVersions,
+    restoreRoleMatchOverride,
+  } from '$lib/role-match-api';
+  import type {
+    RoleMatchAnalysisResponse,
+    RoleMatchComparisonResponse,
+    RoleMatchOverrideInput,
+    RoleMatchOverrideResponse,
+    RoleMatchVersionsResponse,
+  } from '$lib/role-match-types';
+  import type { FitAnalysisResponse } from '$lib/types';
+  import { Check } from '@lucide/svelte';
+  import LegacyFitAnalysisDisplay from './FitAnalysisDisplay.svelte';
+  import RoleMatchResult from './role-match/RoleMatchResult.svelte';
+  import RoleMatchReviewPanel from './role-match/RoleMatchReviewPanel.svelte';
+  import RoleMatchVersionCompare from './role-match/RoleMatchVersionCompare.svelte';
+
+  interface CompatibleFitAnalysis extends FitAnalysisResponse {
+    role_match_analysis_id?: number;
+    role_match_analysis?: RoleMatchAnalysisResponse;
+  }
+
+  interface Props {
+    fitResult: FitAnalysisResponse;
+    companyName?: string | null;
+    onReanalyze?: () => void;
+    analyzing?: boolean;
+    onAcceptEmphasis?: () => void;
+    showInterviewPrep?: boolean;
+    compact?: boolean;
+  }
+
+  let {
+    fitResult,
+    companyName = null,
+    onReanalyze,
+    analyzing = false,
+    onAcceptEmphasis,
+    showInterviewPrep = $bindable(false),
+    compact = false,
+  }: Props = $props();
+
+  let analysis = $state<RoleMatchAnalysisResponse | null>(null);
+  let reviewOpen = $state(false);
+  let versions = $state<RoleMatchVersionsResponse | null>(null);
+  let comparison = $state<RoleMatchComparisonResponse | null>(null);
+  let historyRequestId = 0;
+
+  const incomingAnalysis = $derived(
+    (fitResult as CompatibleFitAnalysis).role_match_analysis ?? null,
+  );
+
+  $effect(() => {
+    if (incomingAnalysis && incomingAnalysis.id !== analysis?.id) {
+      analysis = incomingAnalysis;
+    }
+  });
+
+  $effect(() => {
+    if (!analysis) return;
+    const requestId = ++historyRequestId;
+    const current = analysis;
+    void (async () => {
+      try {
+        const nextVersions = await getRoleMatchVersions(current.id);
+        if (requestId !== historyRequestId) return;
+        versions = nextVersions;
+        if (current.parent_analysis_id) {
+          comparison = await compareRoleMatchVersions(
+            current.parent_analysis_id,
+            current.id,
+          );
+        } else {
+          comparison = null;
+        }
+      } catch {
+        if (requestId === historyRequestId) {
+          versions = null;
+          comparison = null;
+        }
+      }
+    })();
+  });
+
+  async function submitOverrides(overrides: RoleMatchOverrideInput[]) {
+    if (!analysis) return;
+    analysis = await applyRoleMatchOverrides(analysis.id, { overrides });
+    reviewOpen = false;
+  }
+
+  async function restoreOverride(override: RoleMatchOverrideResponse) {
+    if (!analysis) return;
+    analysis = await restoreRoleMatchOverride(analysis.id, override.id);
+  }
+</script>
+
+{#if analysis}
+  <div class="space-y-4">
+    <RoleMatchResult
+      {analysis}
+      {companyName}
+      {onReanalyze}
+      onReview={() => (reviewOpen = true)}
+      {analyzing}
+    />
+
+    {#if reviewOpen}
+      <RoleMatchReviewPanel
+        {analysis}
+        onSubmit={submitOverrides}
+        onClose={() => (reviewOpen = false)}
+      />
+    {/if}
+
+    {#if analysis.parent_analysis_id || analysis.overrides.length || versions?.items.length}
+      <RoleMatchVersionCompare
+        {analysis}
+        {versions}
+        {comparison}
+        onRestore={restoreOverride}
+      />
+    {/if}
+
+    {#if onAcceptEmphasis && analysis.summary?.next_step}
+      <button
+        type="button"
+        onclick={onAcceptEmphasis}
+        class="inline-flex items-center gap-2 rounded-lg border border-primary/20 bg-primary/5 px-3.5 py-2 text-xs font-semibold text-primary hover:bg-primary/10"
+      >
+        <Check class="h-3.5 w-3.5" aria-hidden="true" />
+        Use this guidance
+      </button>
+    {/if}
+  </div>
+{:else}
+  <LegacyFitAnalysisDisplay
+    {fitResult}
+    {companyName}
+    {onReanalyze}
+    {analyzing}
+    {onAcceptEmphasis}
+    bind:showInterviewPrep
+    {compact}
+  />
+{/if}

--- a/frontend/src/lib/components/history/RoleMatchClCard.svelte
+++ b/frontend/src/lib/components/history/RoleMatchClCard.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { STATUS_CONFIG } from '$lib/constants';
+  import type { GeneratedCoverLetterEntry } from '$lib/types';
+  import { formatDateShort, getScoreBarColor, getScoreColor } from '$lib/utils';
+
+  interface SourceAwareEntry extends GeneratedCoverLetterEntry {
+    match_score_source?: 'role_evidence_match' | 'legacy_llm_score' | 'none';
+    role_match_analysis_id?: number | null;
+  }
+
+  interface Props {
+    entry: SourceAwareEntry;
+    selected: boolean;
+    onSelect: () => void;
+    selectedForBatch?: boolean;
+    onToggleBatchSelect?: () => void;
+    onStatusChange: (id: number, status: string | null) => void;
+  }
+
+  let {
+    entry,
+    selected,
+    onSelect,
+    selectedForBatch = false,
+    onToggleBatchSelect,
+    onStatusChange,
+  }: Props = $props();
+
+  const STATUS_PIPELINE = Object.entries(STATUS_CONFIG).map(([value, config]) => ({
+    value,
+    ...config,
+  }));
+
+  function displayCompany(value: GeneratedCoverLetterEntry): string {
+    if (value.company_name) return value.company_name;
+    const firstLine = value.job_description
+      .split('\n')[0]
+      .trim()
+      .replace(/^(title|job title|position|role)\s*:\s*/i, '');
+    const atMatch = firstLine.match(/\bat\s+([^,(\n]+)/i);
+    if (atMatch) return atMatch[1].trim().slice(0, 30);
+    const dashMatch = firstLine.match(/\s[-–]\s*([A-Za-z]\S+)/);
+    if (dashMatch) return dashMatch[1].slice(0, 30);
+    return firstLine.length > 30 ? `${firstLine.slice(0, 27)}…` : firstLine;
+  }
+
+  function displayRole(value: GeneratedCoverLetterEntry): string {
+    const firstLine = value.job_description
+      .split('\n')[0]
+      .trim()
+      .replace(/^(title|job title|position|role)\s*:\s*/i, '');
+    const text = firstLine.replace(/\s[-–]\s*\S+.*$/, '').trim() || firstLine;
+    return text.length > 50 ? `${text.slice(0, 47)}…` : text;
+  }
+
+  function scoreColorClass(score: number): string {
+    const colors = getScoreColor(score);
+    return `${colors.bg} ${colors.text}`;
+  }
+
+  const role = $derived(displayRole(entry));
+  const company = $derived(displayCompany(entry));
+  const sourceLabel = $derived(
+    entry.match_score_source === 'role_evidence_match'
+      ? 'Evidence match'
+      : entry.match_score_source === 'legacy_llm_score'
+        ? 'Legacy score'
+        : 'Match',
+  );
+</script>
+
+<div class="group relative flex items-start gap-1.5">
+  {#if onToggleBatchSelect}
+    <input
+      type="checkbox"
+      class="z-10 mt-3.5 shrink-0 rounded"
+      checked={selectedForBatch}
+      onclick={(event) => event.stopPropagation()}
+      onchange={onToggleBatchSelect}
+    />
+  {/if}
+
+  <div
+    role="button"
+    tabindex="0"
+    onclick={onSelect}
+    onkeydown={(event) => {
+      if (event.key === 'Enter' || event.key === ' ') onSelect();
+    }}
+    class="relative flex-1 cursor-pointer overflow-hidden rounded-xl border p-3.5 text-left outline-none transition-all {selected ? 'scale-[1.01] border-primary/50 bg-primary/5 shadow-md ring-1 ring-primary/20' : 'border-border/60 bg-card hover:border-border hover:bg-accent/50 hover:shadow-sm'}"
+  >
+    <div class="mb-1 flex items-center justify-between gap-2">
+      <span class="truncate text-[13px] font-semibold text-foreground/90">{company}</span>
+      <div class="flex shrink-0 items-center gap-1.5">
+        {#if entry.match_score !== null}
+          <span class="rounded px-1.5 py-0.5 text-[10px] font-semibold {scoreColorClass(entry.match_score)}">
+            {entry.match_score}%
+          </span>
+        {/if}
+        {#if entry.profile_color && entry.profile_icon}
+          <span class="flex items-center rounded-sm bg-muted/50 px-1 py-0.5 text-[10px] text-muted-foreground">
+            {entry.profile_icon}
+          </span>
+        {/if}
+      </div>
+    </div>
+
+    <div class="mt-0.5 flex items-center justify-between gap-2">
+      {#if role}
+        <span class="flex-1 truncate text-[11px] font-medium text-muted-foreground/80">{role}</span>
+      {/if}
+      <span class="ml-auto shrink-0 text-[11px] font-medium text-muted-foreground">{formatDateShort(entry.created_at)}</span>
+    </div>
+
+    {#if entry.match_score !== null}
+      <p class="mt-2 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground/70">
+        {sourceLabel}
+      </p>
+    {/if}
+
+    {#if entry.application_id}
+      <span
+        role="button"
+        tabindex="0"
+        class="absolute right-3 top-3.5 cursor-pointer text-primary/70 transition-colors hover:text-primary"
+        onclick={(event) => {
+          event.stopPropagation();
+          goto('/tracker');
+        }}
+        onkeydown={(event) => {
+          if (event.key === 'Enter') {
+            event.stopPropagation();
+            goto('/tracker');
+          }
+        }}
+        title="View in Tracker"
+        aria-label="View in Tracker"
+      >📌</span>
+    {/if}
+
+    <div
+      class="mt-3 flex flex-wrap items-center gap-1"
+      role="presentation"
+      onclick={(event) => event.stopPropagation()}
+      onkeydown={(event) => event.stopPropagation()}
+    >
+      {#each STATUS_PIPELINE as status}
+        <button
+          class="cursor-pointer rounded-full border px-2 py-0.5 text-[10px] font-medium transition-all {entry.application_status === status.value ? status.activeClass : 'border-border/50 text-muted-foreground opacity-70 hover:border-border hover:bg-accent/80'}"
+          onclick={() => onStatusChange(entry.id, status.value)}
+        >
+          {status.label}
+        </button>
+      {/each}
+    </div>
+
+    {#if entry.match_score !== null}
+      <div class="absolute bottom-0 left-0 right-0 h-0.5 bg-muted/50">
+        <div
+          class="h-0.5 transition-all duration-500 ease-out {getScoreBarColor(entry.match_score)}"
+          style={`width: ${entry.match_score}%`}
+        ></div>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/lib/components/history/RoleMatchFitAnalysisTab.svelte
+++ b/frontend/src/lib/components/history/RoleMatchFitAnalysisTab.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import type { RoleMatchAnalysisResponse } from '$lib/role-match-types';
+  import RoleMatchResult from '../role-match/RoleMatchResult.svelte';
+  import LegacyFitAnalysisTab from './FitAnalysisTab.svelte';
+
+  interface LegacyAnalysis {
+    match_score: number;
+    pros: string[];
+    cons: string[];
+    missing_keywords: string[];
+    red_flags: string[];
+    suggested_emphasis: string;
+    interview_questions: string[];
+    role_match_analysis?: RoleMatchAnalysisResponse;
+  }
+
+  interface Props {
+    analysis: LegacyAnalysis;
+  }
+
+  let { analysis }: Props = $props();
+  const roleMatchAnalysis = $derived(analysis.role_match_analysis ?? null);
+</script>
+
+{#if roleMatchAnalysis}
+  <div class="p-5 md:p-6">
+    <RoleMatchResult analysis={roleMatchAnalysis} />
+  </div>
+{:else}
+  <LegacyFitAnalysisTab {analysis} />
+{/if}

--- a/frontend/src/lib/components/tracker/RoleMatchApplicationCard.svelte
+++ b/frontend/src/lib/components/tracker/RoleMatchApplicationCard.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import type { ApplicationEntry } from '$lib/types';
+  import { formatDateShort, getScoreColor } from '$lib/utils';
+
+  interface SourceAwareApplication extends ApplicationEntry {
+    match_score_source?: 'role_evidence_match' | 'legacy_llm_score' | 'none';
+    role_match_analysis_id?: number | null;
+  }
+
+  let { app, onclick }: { app: SourceAwareApplication; onclick: () => void } = $props();
+
+  const sourceLabel = $derived(
+    app.match_score_source === 'role_evidence_match'
+      ? 'Evidence match'
+      : app.match_score_source === 'legacy_llm_score'
+        ? 'Legacy score'
+        : 'Match',
+  );
+</script>
+
+<button
+  type="button"
+  onclick={onclick}
+  class="group relative w-full cursor-pointer overflow-hidden rounded-lg border border-border bg-card p-3 text-left transition-all hover:border-primary/50 hover:shadow-sm"
+  class:border-dashed={!app.linked_cover_letter_id && !app.linked_cv_id}
+>
+  <div class="mb-1.5 flex items-center gap-2">
+    <span
+      class="h-2 w-2 shrink-0 rounded-full shadow-sm"
+      style={`background-color: ${app.profile_color ?? '#6366f1'}`}
+    ></span>
+    <span class="truncate text-sm font-bold transition-colors group-hover:text-primary">
+      {app.company_name}
+    </span>
+  </div>
+
+  <p class="mb-2 truncate pl-4 text-xs text-muted-foreground">{app.role_title || '—'}</p>
+
+  <div class="mt-1 flex items-center justify-between pl-4">
+    <span class="text-[10px] font-medium text-muted-foreground/70">
+      {formatDateShort(app.applied_date ?? '') ?? ''}
+    </span>
+    <div class="flex items-center gap-1.5">
+      {#if app.linked_cover_letter_id}
+        <span class="rounded-sm border border-blue-500/20 bg-blue-500/10 px-1.5 py-0.5 text-[9px] font-bold text-blue-500" title="Cover Letter Linked">CL</span>
+      {/if}
+      {#if app.linked_cv_id}
+        <span class="rounded-sm border border-purple-500/20 bg-purple-500/10 px-1.5 py-0.5 text-[9px] font-bold text-purple-500" title="CV Linked">CV</span>
+      {/if}
+    </div>
+  </div>
+
+  {#if app.match_score !== null}
+    <div class="mt-3 space-y-1 pl-4">
+      <div class="flex items-center justify-between text-[9px] font-semibold">
+        <span class="uppercase tracking-wide text-muted-foreground/70">{sourceLabel}</span>
+        <span class={getScoreColor(app.match_score).text}>{app.match_score}%</span>
+      </div>
+      <div class="h-1 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          class="h-full transition-all duration-500 {getScoreColor(app.match_score).bg}"
+          style={`width: ${app.match_score}%`}
+        ></div>
+      </div>
+    </div>
+  {/if}
+
+  {#if !app.linked_cover_letter_id && !app.linked_cv_id}
+    <span class="mt-1 inline-flex items-center gap-1 rounded border border-yellow-200 bg-yellow-50 px-1.5 py-0.5 text-[10px] font-medium text-yellow-600 dark:border-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-400">
+      ⚠ No docs linked
+    </span>
+  {/if}
+</button>

--- a/frontend/src/lib/role-match-history-tracker.test.ts
+++ b/frontend/src/lib/role-match-history-tracker.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const config = readFileSync(new URL('../../svelte.config.js', import.meta.url), 'utf8');
+const historyTab = readFileSync(
+  new URL('./components/history/RoleMatchFitAnalysisTab.svelte', import.meta.url),
+  'utf8',
+);
+const historyCard = readFileSync(
+  new URL('./components/history/RoleMatchClCard.svelte', import.meta.url),
+  'utf8',
+);
+const trackerCard = readFileSync(
+  new URL('./components/tracker/RoleMatchApplicationCard.svelte', import.meta.url),
+  'utf8',
+);
+
+describe('role match history and tracker', () => {
+  test('routes existing component imports to source-aware wrappers', () => {
+    expect(config).toContain(
+      "'$lib/components/history/FitAnalysisTab.svelte': './src/lib/components/history/RoleMatchFitAnalysisTab.svelte'",
+    );
+    expect(config).toContain(
+      "'$lib/components/history/ClCard.svelte': './src/lib/components/history/RoleMatchClCard.svelte'",
+    );
+    expect(config).toContain(
+      "'$lib/components/tracker/ApplicationCard.svelte': './src/lib/components/tracker/RoleMatchApplicationCard.svelte'",
+    );
+  });
+
+  test('history detail renders evidence analysis and preserves legacy detail', () => {
+    expect(historyTab).toContain('<RoleMatchResult');
+    expect(historyTab).toContain('<LegacyFitAnalysisTab');
+  });
+
+  test('score cards label the metric source', () => {
+    for (const source of [historyCard, trackerCard]) {
+      expect(source).toContain('Evidence match');
+      expect(source).toContain('Legacy score');
+      expect(source).toContain('match_score_source');
+    }
+  });
+});

--- a/frontend/src/lib/role-match-product-integration.test.ts
+++ b/frontend/src/lib/role-match-product-integration.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const config = readFileSync(new URL('../../svelte.config.js', import.meta.url), 'utf8');
+const apiCompat = readFileSync(new URL('./api-compat.ts', import.meta.url), 'utf8');
+const display = readFileSync(
+  new URL('./components/RoleMatchFitAnalysisDisplay.svelte', import.meta.url),
+  'utf8',
+);
+
+describe('role match product compatibility', () => {
+  test('redirects existing imports through compatibility modules', () => {
+    expect(config).toContain("'$lib/api': './src/lib/api-compat.ts'");
+    expect(config).toContain(
+      "'$lib/components/FitAnalysisDisplay.svelte': './src/lib/components/RoleMatchFitAnalysisDisplay.svelte'",
+    );
+  });
+
+  test('replaces legacy fit analysis with role match analysis', () => {
+    expect(apiCompat).toContain('analyzeRoleMatch');
+    expect(apiCompat).toContain('role_match_analysis_id');
+    expect(apiCompat).toContain('role_match_analysis: analysis');
+    expect(apiCompat).not.toContain("request<FitAnalysisResponse>('/analyze/fit'");
+  });
+
+  test('uses verified cover letter generation when an analysis id exists', () => {
+    expect(apiCompat).toContain("'/generate/cover-letter/role-match'");
+    expect(apiCompat).toContain('legacyGenerateCoverLetterStream(data)');
+    expect(apiCompat).toContain('delete payload.match_score');
+    expect(apiCompat).toContain('delete payload.fit_context');
+  });
+
+  test('renders new and legacy analysis through one stable component import', () => {
+    expect(display).toContain('<RoleMatchResult');
+    expect(display).toContain('<RoleMatchReviewPanel');
+    expect(display).toContain('<RoleMatchVersionCompare');
+    expect(display).toContain('<LegacyFitAnalysisDisplay');
+  });
+});

--- a/frontend/src/lib/role-match-product-integration.test.ts
+++ b/frontend/src/lib/role-match-product-integration.test.ts
@@ -1,12 +1,75 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
+import {
+  analyzeFit,
+  generateCoverLetterStream,
+} from './api-compat';
+import type { RoleMatchAnalysisResponse } from './role-match-types';
+import type { CoverLetterRequest } from './types';
 
 const config = readFileSync(new URL('../../svelte.config.js', import.meta.url), 'utf8');
-const apiCompat = readFileSync(new URL('./api-compat.ts', import.meta.url), 'utf8');
 const display = readFileSync(
   new URL('./components/RoleMatchFitAnalysisDisplay.svelte', import.meta.url),
   'utf8',
 );
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function analysisFixture(): RoleMatchAnalysisResponse {
+  return {
+    id: 42,
+    parent_analysis_id: null,
+    created_at: '2026-08-06T06:00:00Z',
+    state: 'success',
+    score: 80,
+    score_band: 'strong_evidence_match',
+    confidence: 'high',
+    eligibility: 'likely_eligible',
+    show_authoritative_score: true,
+    summary: {
+      headline: 'Your profile is a strong match',
+      description: 'Strong Python evidence.',
+      strengths: [
+        {
+          title: 'Python backend capability',
+          explanation: 'Supported by work evidence.',
+        },
+      ],
+      concerns: [],
+      next_step: 'Use the Python production example.',
+    },
+    category_breakdown: [],
+    requirements: [],
+    excluded_items: [],
+    overrides: [],
+    override_review_count: 0,
+    rules_version: 'role-match-v1',
+    prompt_version: 'role-match-extraction-v1',
+    legacy: false,
+    failure_code: null,
+  };
+}
+
+function coverLetterRequest(): CoverLetterRequest {
+  return {
+    profile_id: 7,
+    job_description: 'Python backend role',
+    company_name: 'Example',
+    role_title: 'Backend Engineer',
+    location: null,
+    salary: null,
+    extra_context: '',
+    tone: 'professional',
+    job_url: null,
+    fit_context: 'Browser-provided context must be ignored',
+    match_score: 99,
+    fit_analysis_json: JSON.stringify({ role_match_analysis_id: 42 }),
+    application_id: null,
+  };
+}
 
 describe('role match product compatibility', () => {
   test('redirects existing imports through compatibility modules', () => {
@@ -16,18 +79,60 @@ describe('role match product compatibility', () => {
     );
   });
 
-  test('replaces legacy fit analysis with role match analysis', () => {
-    expect(apiCompat).toContain('analyzeRoleMatch');
-    expect(apiCompat).toContain('role_match_analysis_id');
-    expect(apiCompat).toContain('role_match_analysis: analysis');
-    expect(apiCompat).not.toContain("request<FitAnalysisResponse>('/analyze/fit'");
+  test('replaces legacy fit analysis with a role match API call', async () => {
+    let requestedUrl = '';
+    let requestedBody: unknown;
+    globalThis.fetch = (async (input, init) => {
+      requestedUrl = String(input);
+      requestedBody = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify(analysisFixture()), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    const result = await analyzeFit(7, 'Python backend role');
+
+    expect(requestedUrl).toEndWith('/analyze/role-match');
+    expect(requestedBody).toEqual({
+      profile_id: 7,
+      job_description: 'Python backend role',
+    });
+    expect(result.role_match_analysis_id).toBe(42);
+    expect(result.role_match_analysis.score).toBe(80);
+    expect(result.pros).toEqual(['Python backend capability']);
   });
 
-  test('uses verified cover letter generation when an analysis id exists', () => {
-    expect(apiCompat).toContain("'/generate/cover-letter/role-match'");
-    expect(apiCompat).toContain('legacyGenerateCoverLetterStream(data)');
-    expect(apiCompat).toContain('delete payload.match_score');
-    expect(apiCompat).toContain('delete payload.fit_context');
+  test('uses verified generation and strips browser-provided scoring context', async () => {
+    let requestedUrl = '';
+    let requestedBody: Record<string, unknown> = {};
+    globalThis.fetch = (async (input, init) => {
+      requestedUrl = String(input);
+      requestedBody = JSON.parse(String(init?.body));
+      return new Response('event: done\ndata: [DONE]\n\n', { status: 200 });
+    }) as typeof fetch;
+
+    await generateCoverLetterStream(coverLetterRequest());
+
+    expect(requestedUrl).toEndWith('/generate/cover-letter/role-match');
+    expect(requestedBody.role_match_analysis_id).toBe(42);
+    expect(requestedBody.match_score).toBeUndefined();
+    expect(requestedBody.fit_context).toBeUndefined();
+    expect(requestedBody.fit_analysis_json).toBeUndefined();
+  });
+
+  test('falls back to legacy generation when no role analysis exists', async () => {
+    let requestedUrl = '';
+    globalThis.fetch = (async (input) => {
+      requestedUrl = String(input);
+      return new Response('event: done\ndata: [DONE]\n\n', { status: 200 });
+    }) as typeof fetch;
+    const request = coverLetterRequest();
+    request.fit_analysis_json = null;
+
+    await generateCoverLetterStream(request);
+
+    expect(requestedUrl).toEndWith('/generate/cover-letter');
   });
 
   test('renders new and legacy analysis through one stable component import', () => {

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -3,7 +3,11 @@ import adapter from '@sveltejs/adapter-node';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter({ out: 'build' })
+		adapter: adapter({ out: 'build' }),
+		alias: {
+			'$lib/api': './src/lib/api-compat.ts',
+			'$lib/components/FitAnalysisDisplay.svelte': './src/lib/components/RoleMatchFitAnalysisDisplay.svelte'
+		}
 	},
 	vitePlugin: {
 		dynamicCompileOptions: ({ filename }) =>

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -6,7 +6,10 @@ const config = {
 		adapter: adapter({ out: 'build' }),
 		alias: {
 			'$lib/api': './src/lib/api-compat.ts',
-			'$lib/components/FitAnalysisDisplay.svelte': './src/lib/components/RoleMatchFitAnalysisDisplay.svelte'
+			'$lib/components/FitAnalysisDisplay.svelte': './src/lib/components/RoleMatchFitAnalysisDisplay.svelte',
+			'$lib/components/history/FitAnalysisTab.svelte': './src/lib/components/history/RoleMatchFitAnalysisTab.svelte',
+			'$lib/components/history/ClCard.svelte': './src/lib/components/history/RoleMatchClCard.svelte',
+			'$lib/components/tracker/ApplicationCard.svelte': './src/lib/components/tracker/RoleMatchApplicationCard.svelte'
 		}
 	},
 	vitePlugin: {


### PR DESCRIPTION
## Summary

- route existing Smart Apply and Cover Letter imports through a compatibility layer backed by the new Role Match API
- keep existing page state and drafts compatible while carrying the immutable analysis ID and full analysis payload
- switch cover-letter streaming to the verified server endpoint whenever a role-match analysis exists
- render the v3 Role Match result, review, version, and restore UI through the existing component import
- preserve the legacy fit-analysis component for historical records
- expose the full analysis in modern history detail and label score sources in History and Tracker cards
- add frontend compatibility/policy tests and backend history compatibility coverage

## Stack

This is PR 7 of the v1.3.0 Role Evidence Match stack.

- Base: `feat/role-match-integration-v1.3.0` / PR #53
- Head: `feat/role-match-product-ui-v1.3.0`
- Documentation, release metadata, and final whole-stack verification follow in the final stacked PR.

## Verification

Authoritative frontend, backend, and container verification will run through GitHub Actions on this PR head.

No merge, tag, or release is performed by this PR.