### PR TITLE
chore: sync role match API fixes into release branch

### DIFF
--- a/backend/app/role_match/extraction.py
+++ b/backend/app/role_match/extraction.py
@@ -22,10 +22,10 @@ class ExtractionResult(BaseModel):
     failure_code: str | None = None
 
 
-def _call_llm(prompt: str, **kwargs) -> str:
+def _call_llm(**kwargs) -> str:
     from app.services.llm import call_llm
 
-    return call_llm(prompt, **kwargs)
+    return call_llm(**kwargs)
 
 
 def extract_atomic_requirements(
@@ -39,12 +39,12 @@ def extract_atomic_requirements(
     user_prompt = "\n".join(
         [
             format_untrusted_input("job_description", job_description),
-            "Extract atomic requirements and return JSON with a requirements array.",
+            "Extract atomic requirements from job_description and return JSON with a requirements array.",
         ]
     )
     for _ in range(EXTRACTION_ATTEMPTS):
         raw = _call_llm(
-            user_prompt,
+            prompt=user_prompt,
             system=REQUIREMENT_EXTRACTION_SYSTEM_PROMPT,
             provider=provider,
             api_key=api_key,

--- a/backend/app/role_match/extraction.py
+++ b/backend/app/role_match/extraction.py
@@ -22,10 +22,10 @@ class ExtractionResult(BaseModel):
     failure_code: str | None = None
 
 
-def _call_llm(**kwargs) -> str:
+def _call_llm(prompt: str, **kwargs) -> str:
     from app.services.llm import call_llm
 
-    return call_llm(**kwargs)
+    return call_llm(prompt, **kwargs)
 
 
 def extract_atomic_requirements(
@@ -44,7 +44,7 @@ def extract_atomic_requirements(
     )
     for _ in range(EXTRACTION_ATTEMPTS):
         raw = _call_llm(
-            user_prompt=user_prompt,
+            user_prompt,
             system=REQUIREMENT_EXTRACTION_SYSTEM_PROMPT,
             provider=provider,
             api_key=api_key,

--- a/backend/app/role_match/linking.py
+++ b/backend/app/role_match/linking.py
@@ -39,10 +39,10 @@ class LinkingResult(BaseModel):
     raw_output: str = ""
 
 
-def _call_llm(**kwargs) -> str:
+def _call_llm(prompt: str, **kwargs) -> str:
     from app.services.llm import call_llm
 
-    return call_llm(**kwargs)
+    return call_llm(prompt, **kwargs)
 
 
 def _last_used(item: EvidenceCatalogItem) -> tuple[date | None, bool]:
@@ -59,20 +59,21 @@ def link_candidate_evidence(
     *,
     profile_id: int | None = None,
 ) -> LinkingResult:
+    user_prompt = "\n".join(
+        [
+            format_untrusted_input(
+                "requirements",
+                [cluster.model_dump(mode="json") for cluster in clusters],
+            ),
+            format_untrusted_input(
+                "evidence_catalog",
+                [item.model_dump(mode="json") for item in catalog],
+            ),
+            "Link only supplied IDs and return JSON with a links array.",
+        ]
+    )
     raw = _call_llm(
-        user_prompt="\n".join(
-            [
-                format_untrusted_input(
-                    "requirements",
-                    [cluster.model_dump(mode="json") for cluster in clusters],
-                ),
-                format_untrusted_input(
-                    "evidence_catalog",
-                    [item.model_dump(mode="json") for item in catalog],
-                ),
-                "Link only supplied IDs and return JSON with a links array.",
-            ]
-        ),
+        user_prompt,
         system=EVIDENCE_LINKING_SYSTEM_PROMPT,
         provider=provider,
         api_key=api_key,

--- a/backend/app/role_match/linking.py
+++ b/backend/app/role_match/linking.py
@@ -39,10 +39,10 @@ class LinkingResult(BaseModel):
     raw_output: str = ""
 
 
-def _call_llm(prompt: str, **kwargs) -> str:
+def _call_llm(**kwargs) -> str:
     from app.services.llm import call_llm
 
-    return call_llm(prompt, **kwargs)
+    return call_llm(**kwargs)
 
 
 def _last_used(item: EvidenceCatalogItem) -> tuple[date | None, bool]:
@@ -69,11 +69,11 @@ def link_candidate_evidence(
                 "evidence_catalog",
                 [item.model_dump(mode="json") for item in catalog],
             ),
-            "Link only supplied IDs and return JSON with a links array.",
+            "Link only supplied IDs from requirements and evidence_catalog and return JSON with a links array.",
         ]
     )
     raw = _call_llm(
-        user_prompt,
+        prompt=user_prompt,
         system=EVIDENCE_LINKING_SYSTEM_PROMPT,
         provider=provider,
         api_key=api_key,

--- a/backend/app/role_match/scoring.py
+++ b/backend/app/role_match/scoring.py
@@ -92,6 +92,11 @@ def round_to_nearest_five(value: float) -> int:
     return int(max(Decimal("0"), min(rounded, Decimal("100"))))
 
 
+def _display_cap(cap: int) -> int:
+    """Convert an internal cap to the highest allowed five-point display value."""
+    return max(0, min(100, (cap // 5) * 5))
+
+
 def score_band(display_score: int) -> str:
     if display_score >= 85:
         return "exceptional_evidence_match"
@@ -126,7 +131,7 @@ def score_role_match(assessments: list[RequirementAssessment]) -> ScoreResult:
     capped_score = min(raw_score, float(cap)) if cap is not None else raw_score
     display_score = round_to_nearest_five(capped_score)
     if cap is not None:
-        display_score = min(display_score, cap)
+        display_score = min(display_score, _display_cap(cap))
     return ScoreResult(
         category_assessments=category_assessments,
         raw_score=raw_score,

--- a/backend/tests/role_match/test_llm_call_contract.py
+++ b/backend/tests/role_match/test_llm_call_contract.py
@@ -1,0 +1,110 @@
+import json
+
+from app.role_match.domain import (
+    EvidenceCatalogItem,
+    EvidenceSource,
+    RequirementCategory,
+    RequirementCluster,
+    RequirementImportance,
+    TechnologyVolatility,
+)
+from app.role_match.extraction import extract_atomic_requirements
+from app.role_match.linking import link_candidate_evidence
+
+
+def requirement_cluster() -> RequirementCluster:
+    return RequirementCluster(
+        cluster_id="req:python-backend",
+        canonical_requirement="Production Python backend capability",
+        canonical_key="python-backend",
+        primary_category=RequirementCategory.RELEVANT_COMPETENCIES,
+        importance=RequirementImportance.CRITICAL,
+        mention_count=1,
+        importance_conflict=False,
+        importance_mentions={
+            RequirementImportance.CRITICAL: 1,
+            RequirementImportance.IMPORTANT: 0,
+            RequirementImportance.SUPPORTING: 0,
+        },
+        source_quotes=["Strong Python experience is required"],
+        source_ids=["jd:1"],
+        is_eligibility=False,
+        is_trainable=False,
+        volatility=TechnologyVolatility.EVOLVING,
+        tool_specificity="capability",
+    )
+
+
+def test_role_match_uses_positional_llm_prompt_contract(monkeypatch) -> None:
+    prompts: list[str] = []
+
+    def strict_call_llm(
+        prompt: str,
+        *,
+        system: str,
+        provider: str,
+        api_key: str,
+        timeout: int,
+        operation: str,
+        profile_id: int | None,
+    ) -> str:
+        del system, provider, api_key, timeout, profile_id
+        prompts.append(prompt)
+        if operation == "role_match_extraction":
+            return json.dumps(
+                {
+                    "requirements": [
+                        {
+                            "source_id": "jd:1",
+                            "text": "Production Python backend capability",
+                            "canonical_key": "python-backend",
+                            "primary_category": "relevant_competencies",
+                            "importance": "critical",
+                            "source_quote": "Strong Python experience is required",
+                            "volatility": "evolving",
+                            "tool_specificity": "capability",
+                        }
+                    ]
+                }
+            )
+        return json.dumps(
+            {
+                "links": [
+                    {
+                        "requirement_id": "req:python-backend",
+                        "evidence_id": "work:0:bullet:0",
+                        "relationship": "exact",
+                        "depth": "production_ownership",
+                        "explanation": "Direct work evidence",
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setattr("app.services.llm.call_llm", strict_call_llm)
+
+    extraction = extract_atomic_requirements(
+        "Strong Python experience is required",
+        "openai",
+        "secret",
+        profile_id=1,
+    )
+    linking = link_candidate_evidence(
+        [requirement_cluster()],
+        [
+            EvidenceCatalogItem(
+                evidence_id="work:0:bullet:0",
+                source=EvidenceSource.WORK_EXPERIENCE,
+                text="Built production Python services",
+            )
+        ],
+        "openai",
+        "secret",
+        profile_id=1,
+    )
+
+    assert len(extraction.requirements) == 1
+    assert len(linking.valid_links) == 1
+    assert len(prompts) == 2
+    assert "job_description" in prompts[0]
+    assert "evidence_catalog" in prompts[1]

--- a/backend/tests/role_match/test_scoring_confidence.py
+++ b/backend/tests/role_match/test_scoring_confidence.py
@@ -94,7 +94,7 @@ def test_display_rounding_and_band() -> None:
     assert score_band(80) == "strong_evidence_match"
 
 
-def test_score_role_match_applies_essential_cap() -> None:
+def test_score_role_match_applies_essential_cap_without_breaking_display_increment() -> None:
     result = score_role_match(
         [
             assessment(
@@ -130,7 +130,8 @@ def test_score_role_match_applies_essential_cap() -> None:
         ]
     )
     assert result.applied_cap == 74
-    assert result.display_score <= 74
+    assert result.display_score == 70
+    assert result.display_score % 5 == 0
 
 
 def test_confidence_formula() -> None:


### PR DESCRIPTION
## Purpose

Bring the latest green fixes from `feat/role-match-api-v1.3.0` into the consolidated `release/role-match-v1.3.0` branch before opening the final release PR to `main`.

This synchronization includes the corrected positional `call_llm` prompt contract, associated regression coverage, and the scoring/test adjustments already verified on PR #49.

No changes are merged into `main` by this PR.