### PR TITLE
fix: fall through to generic scraping when an ATS API tier fails

### DIFF
--- a/backend/app/services/scraper.py
+++ b/backend/app/services/scraper.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Literal
 
@@ -190,6 +191,29 @@ async def _scrape_crawl4ai(url: str) -> str | None:
         return None
 
 
+async def _try_ats_api(
+    handler: Callable[[str, httpx.AsyncClient], Awaitable[ScrapedJob]],
+    url: str,
+    client: httpx.AsyncClient,
+) -> ScrapedJob | None:
+    """Run an ATS API handler, retrying once on a transient failure.
+
+    Returns None instead of raising so the caller can fall through to the
+    generic scraping tiers rather than failing the whole scrape outright.
+    """
+    attempts = 2
+    for attempt in range(attempts):
+        try:
+            return await handler(url, client)
+        except ValueError:
+            # URL doesn't match this ATS's expected shape; retrying won't help.
+            return None
+        except Exception:
+            if attempt == attempts - 1:
+                return None
+    return None
+
+
 async def scrape_job_url(
     url: str, client: httpx.AsyncClient, provider: str = "auto"
 ) -> ScrapedJob:
@@ -204,13 +228,19 @@ async def scrape_job_url(
     ats = _detect_ats(url)
 
     if ats == "greenhouse":
-        return await _scrape_greenhouse(url, client)
+        result = await _try_ats_api(_scrape_greenhouse, url, client)
+        if result is not None:
+            return result
 
-    if ats == "lever":
-        return await _scrape_lever(url, client)
+    elif ats == "lever":
+        result = await _try_ats_api(_scrape_lever, url, client)
+        if result is not None:
+            return result
 
-    if ats == "ashby":
-        return await _scrape_ashby(url, client)
+    elif ats == "ashby":
+        result = await _try_ats_api(_scrape_ashby, url, client)
+        if result is not None:
+            return result
 
     # Tier 2: Jina
     jina_result = await _scrape_jina(url, client)

--- a/backend/tests/test_scraper_ats_fallback.py
+++ b/backend/tests/test_scraper_ats_fallback.py
@@ -1,0 +1,90 @@
+import asyncio
+
+from app.services import scraper
+
+
+def test_greenhouse_failure_falls_through_to_jina(monkeypatch):
+    """A transient Greenhouse API failure should not fail the whole scrape."""
+    call_count = 0
+
+    async def failing_greenhouse(url, client):
+        nonlocal call_count
+        call_count += 1
+        raise TimeoutError("upstream timed out")
+
+    async def fake_jina(url, client):
+        return "Jina markdown content"
+
+    async def unexpected_crawl4ai(url):
+        raise AssertionError("crawl4ai should not run once jina succeeds")
+
+    monkeypatch.setattr(scraper, "validate_public_http_url", lambda url: _noop(), raising=False)
+    monkeypatch.setattr(scraper, "_scrape_greenhouse", failing_greenhouse)
+    monkeypatch.setattr(scraper, "_scrape_jina", fake_jina)
+    monkeypatch.setattr(scraper, "_scrape_crawl4ai", unexpected_crawl4ai)
+
+    result = asyncio.run(
+        scraper.scrape_job_url(
+            "https://job-boards.greenhouse.io/appier/jobs/8102255", object()
+        )
+    )
+
+    assert call_count == 2, "should retry once before giving up"
+    assert result.source == "jina"
+    assert result.job_description == "Jina markdown content"
+
+
+def test_greenhouse_url_shape_mismatch_does_not_retry(monkeypatch):
+    """A URL that doesn't match the expected Greenhouse shape should fail fast."""
+    call_count = 0
+
+    async def bad_shape_greenhouse(url, client):
+        nonlocal call_count
+        call_count += 1
+        raise ValueError("Could not parse Greenhouse URL")
+
+    async def fake_jina(url, client):
+        return "Jina markdown content"
+
+    monkeypatch.setattr(scraper, "validate_public_http_url", lambda url: _noop(), raising=False)
+    monkeypatch.setattr(scraper, "_scrape_greenhouse", bad_shape_greenhouse)
+    monkeypatch.setattr(scraper, "_scrape_jina", fake_jina)
+
+    result = asyncio.run(
+        scraper.scrape_job_url("https://greenhouse.io/not-a-job-url", object())
+    )
+
+    assert call_count == 1, "URL shape mismatches should not be retried"
+    assert result.source == "jina"
+
+
+def test_greenhouse_success_is_returned_without_falling_through(monkeypatch):
+    async def working_greenhouse(url, client):
+        return scraper.ScrapedJob(
+            job_description="Role details",
+            company_name="Appier",
+            role_title="AI Engineer",
+            location="Tokyo, Japan",
+            salary=None,
+            source="greenhouse_api",
+        )
+
+    async def unexpected_jina(url, client):
+        raise AssertionError("jina should not run when greenhouse succeeds")
+
+    monkeypatch.setattr(scraper, "validate_public_http_url", lambda url: _noop(), raising=False)
+    monkeypatch.setattr(scraper, "_scrape_greenhouse", working_greenhouse)
+    monkeypatch.setattr(scraper, "_scrape_jina", unexpected_jina)
+
+    result = asyncio.run(
+        scraper.scrape_job_url(
+            "https://job-boards.greenhouse.io/appier/jobs/8102255", object()
+        )
+    )
+
+    assert result.source == "greenhouse_api"
+    assert result.company_name == "Appier"
+
+
+async def _noop():
+    return None


### PR DESCRIPTION
## Summary
Greenhouse, Lever, and Ashby scraping (`backend/app/services/scraper.py`) each made a single API request and raised on any failure (timeout, non-2xx, malformed JSON) — failing the whole scrape outright even though the generic Jina/Crawl4AI tiers were available right below as a fallback for exactly this situation.

This adds a single retry on transient failures, then falls through to the next tier instead of propagating the error. A URL that doesn't match the ATS's expected shape (a regex-parse failure) fails fast without retrying, since retrying that case can't help.

## Test plan
- New unit tests cover: a transient failure retries once then falls through to Jina, a URL-shape mismatch fails fast without retry, a successful ATS API call is still returned directly without falling through
- Full backend test suite passes