### PR TITLE
fix: correct JazzHR domain detection and drop BambooHR

### DIFF
--- a/backend/app/services/scraper.py
+++ b/backend/app/services/scraper.py
@@ -42,10 +42,13 @@ def _detect_ats(url: str) -> str:
         return "lever"
     if "ashbyhq.com" in url:
         return "ashby"
-    if "jazzhr.com" in url:
+    if "applytojob.com" in url:
+        # JazzHR's candidate-facing hosted career pages live on applytojob.com,
+        # not jazzhr.com. No dedicated API handler exists (no stable public
+        # read API), so this still falls through to the generic tiers below -
+        # kept as a distinct label rather than "generic" for accurate source
+        # attribution and to make a future handler a smaller diff.
         return "jazzhr"
-    if "bamboohr.com" in url:
-        return "bamboohr"
     return "generic"
 
 

--- a/backend/tests/test_scraper_ats_detection.py
+++ b/backend/tests/test_scraper_ats_detection.py
@@ -1,0 +1,18 @@
+import pytest
+
+from app.services.scraper import _detect_ats
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://job-boards.greenhouse.io/appier/jobs/8102255", "greenhouse"),
+        ("https://jobs.lever.co/acme/abc123", "lever"),
+        ("https://jobs.ashbyhq.com/acme/def456", "ashby"),
+        ("https://acme.applytojob.com/apply/xyz789", "jazzhr"),
+        ("https://acme.bamboohr.com/careers/12", "generic"),
+        ("https://acme.wd1.myworkdayjobs.com/careers/job/456", "generic"),
+    ],
+)
+def test_detect_ats(url: str, expected: str) -> None:
+    assert _detect_ats(url) == expected


### PR DESCRIPTION
## Summary
`_detect_ats()` in `backend/app/services/scraper.py` checked for `jazzhr.com`, but JazzHR's candidate-facing hosted career pages actually live on `applytojob.com` — the old check never matched a real JazzHR job URL in practice. Fixed the domain check; the label is kept distinct from `"generic"` for accurate source attribution, even though there's no dedicated API handler (JazzHR has no public read API without a partner-issued key).

Also removed the `bamboohr.com` detection entirely. BambooHR has no documented public REST API for reading job postings — only an undocumented internal widget endpoint whose shape changes between releases, so there was nothing safe to build a handler against.

## Test plan
- Added parametrized tests for `_detect_ats()`, which previously had no test coverage
- Full backend test suite passes