### PR TITLE
fix: stop truncating job descriptions before LLM parsing

### DIFF
--- a/backend/app/services/parse_job_description.py
+++ b/backend/app/services/parse_job_description.py
@@ -15,7 +15,7 @@ def parse_job_description(
     text: str, provider: str, api_key: str
 ) -> ParseJobDescriptionResponse:
     user_prompt = PARSE_JD_USER_TEMPLATE.format(
-        job_description=format_untrusted_input("job_description", text[:4000])
+        job_description=format_untrusted_input("job_description", text)
     )
     raw = call_llm(
         user_prompt,

--- a/backend/tests/test_parse_job_description.py
+++ b/backend/tests/test_parse_job_description.py
@@ -1,0 +1,26 @@
+from app.services import parse_job_description
+
+
+def test_full_job_description_reaches_the_llm_past_the_old_truncation_point(monkeypatch):
+    """Salary/EEO statements are commonly appended at the end of a posting -
+    the parser must not silently drop content past any arbitrary cutoff."""
+    captured = {}
+
+    def fake_call_llm(prompt: str, **kwargs):
+        captured["prompt"] = prompt
+        return '{"company_name": null, "role_title": null, "location": null, "salary": "$100,000-$150,000"}'
+
+    monkeypatch.setattr(parse_job_description, "call_llm", fake_call_llm)
+
+    padding = "Responsibility filler text. " * 200  # well past 4000 chars
+    marker = "SALARY_RANGE_MARKER: $100,000-$150,000"
+    long_description = f"{padding}{marker}"
+    assert len(long_description) > 4000
+
+    parse_job_description.parse_job_description(
+        long_description,
+        "openai/gpt-4.1-mini",
+        "test-key",
+    )
+
+    assert marker in captured["prompt"]


### PR DESCRIPTION
## Summary
`parse_job_description()` (`backend/app/services/parse_job_description.py`) only sent the first 4000 characters of a job posting to the LLM for structured field extraction (company/role/location/salary).

Salary ranges and EEO/pay-transparency statements are commonly appended at the *end* of a posting, so this silently dropped exactly the fields hardest to recover otherwise. Confirmed against a real scraped posting: the salary line landed well past the 4000-character cutoff in a ~6,900-character document, so it never reached the LLM.

Removes the truncation entirely, matching how the rest of the app already handles job description text — the role-match extraction pipeline sends the full text with no length cap on the same class of input.

## Test plan
- New regression test confirms content past the old 4000-char boundary reaches the LLM prompt
- Existing prompt-boundary and scrape-routing tests still pass
- Full backend test suite passes