### PR TITLE
fix: hide literal "None" in CV PDF date ranges when a date is missing

### DIFF
--- a/backend/integration/template.py
+++ b/backend/integration/template.py
@@ -4,10 +4,22 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 TEMPLATE_DIR = Path(__file__).parent / "templates"
 
+
+def format_date_range(start: str | None, end: str | None) -> str:
+    """Render a start-end date range, omitting whichever side is missing
+    instead of Jinja's default stringification of None as the text "None"."""
+    if not start and not end:
+        return ""
+    if not start:
+        return end
+    return f"{start} – {end or 'Present'}"
+
+
 env = Environment(
     loader=FileSystemLoader(str(TEMPLATE_DIR)),
     autoescape=select_autoescape(["html", "xml"]),
 )
+env.filters["format_date_range"] = format_date_range
 
 
 def render_cv_template(profile_data: dict) -> str:

--- a/backend/integration/templates/cv/modern_v1.html
+++ b/backend/integration/templates/cv/modern_v1.html
@@ -139,7 +139,7 @@
     <div class="experience-item">
       <div class="exp-header">
         <span class="exp-role">{{ exp.role }}</span>
-        <span class="exp-date">{{ exp.start_date }} – {{ exp.end_date or 'Present' }}</span>
+        <span class="exp-date">{{ exp.start_date | format_date_range(exp.end_date) }}</span>
       </div>
       <div class="exp-company">{{ exp.company }}</div>
       {% if exp.bullets %}
@@ -161,7 +161,7 @@
     <div class="education-item">
       <div class="edu-header">
         <span class="edu-degree">{{ edu.degree }} in {{ edu.field }}</span>
-        <span class="edu-date">{{ edu.start_date }} – {{ edu.end_date or 'Present' }}</span>
+        <span class="edu-date">{{ edu.start_date | format_date_range(edu.end_date) }}</span>
       </div>
       <div class="edu-institution">{{ edu.institution }}</div>
     </div>
@@ -200,7 +200,7 @@
     {% for cert in profile.certifications %}
     <div class="certification-item">
       <span class="cert-name">{{ cert.name }} — <span class="cert-issuer">{{ cert.issuer }}</span></span>
-      <span class="cert-date">{{ cert.date }}</span>
+      <span class="cert-date">{{ cert.date or '' }}</span>
     </div>
     {% endfor %}
   </section>

--- a/backend/tests/test_cv_date_formatting.py
+++ b/backend/tests/test_cv_date_formatting.py
@@ -1,0 +1,70 @@
+from integration.template import format_date_range, render_cv_template
+
+
+def _profile(**overrides) -> dict:
+    base = {
+        "name": "Jane Doe",
+        "email": "jane@example.com",
+        "phone": None,
+        "location": None,
+        "linkedin": None,
+        "github": None,
+        "portfolio": None,
+        "summary": None,
+        "work_experience": [],
+        "education": [],
+        "skills": [],
+        "skill_categories": None,
+        "projects": [],
+        "certifications": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_format_date_range_hides_missing_start_and_end():
+    assert format_date_range(None, None) == ""
+    assert format_date_range("", "") == ""
+
+
+def test_format_date_range_omits_dash_when_only_end_present():
+    assert format_date_range(None, "Jun 2022") == "Jun 2022"
+
+
+def test_format_date_range_defaults_missing_end_to_present():
+    assert format_date_range("Sep 2018", None) == "Sep 2018 – Present"
+
+
+def test_format_date_range_renders_full_range():
+    assert format_date_range("Sep 2018", "Jun 2022") == "Sep 2018 – Jun 2022"
+
+
+def test_cv_template_never_renders_the_literal_string_none():
+    profile = _profile(
+        work_experience=[
+            {
+                "role": "Engineer",
+                "company": "Acme",
+                "start_date": None,
+                "end_date": None,
+                "bullets": [],
+            },
+        ],
+        education=[
+            {
+                "institution": "State University",
+                "degree": "BS",
+                "field": "Computer Science",
+                "start_date": None,
+                "end_date": "Jun 2016",
+            },
+        ],
+        certifications=[
+            {"name": "AWS Certified", "issuer": "Amazon", "date": None},
+        ],
+    )
+
+    html = render_cv_template(profile)
+
+    assert "None" not in html
+    assert "Jun 2016" in html


### PR DESCRIPTION
## Summary
Jinja stringifies `None` as the literal text "None", so a work experience or education entry with a missing `start_date` rendered as "None – Present" (or "None – <end date>") in the generated CV PDF instead of hiding the missing piece.

Added a `format_date_range` Jinja filter (registered on the shared template environment) that omits whichever side is absent, and hides the date range entirely when both start and end are missing. Also guarded the certification `date` field, which had the identical underlying issue (a bare `{{ cert.date }}`).

## Test plan
- New unit tests for `format_date_range` cover: both missing, only end present, only start present (defaults to "Present"), full range
- New template-level test renders a profile with missing dates and asserts the literal string "None" never appears in the output HTML
- Full backend test suite passes, including the existing CV PDF page-fit tests