### PR TITLE
feat: AI-tailored CV content with adaptive one-page layout

### DIFF
--- a/backend/app/routes/generate.py
+++ b/backend/app/routes/generate.py
@@ -1,4 +1,5 @@
 import asyncio
+import io
 import json
 import logging
 from collections.abc import AsyncIterable
@@ -46,7 +47,12 @@ from app.services.settings import (
     is_llm_configured,
 )
 from app.utils import format_profile_for_llm, profile_to_schema
-from integration.pdf import PDFRenderError, html_to_pdf
+from integration.pdf import (
+    PDFRenderError,
+    document_to_pdf,
+    html_to_document,
+    html_to_pdf,
+)
 from integration.template import render_cover_letter_template, render_cv_template
 
 logger = logging.getLogger(__name__)
@@ -59,10 +65,109 @@ router = APIRouter()
 # ---------------------------------------------------------------------------
 
 
+def _pdf_page_count(pdf_bytes: bytes) -> int:
+    import pdfplumber
+
+    with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+        return len(pdf.pages)
+
+
+# Projects arrive pre-ranked by relevance (see ATS_SYSTEM_PROMPT instruction 3),
+# so trimming to a prefix keeps the most relevant ones.
+MAX_PROJECTS_WHEN_TRIMMED = 3
+
+# Bounds for stretching inter-section/item spacing to fill a page that has
+# room to spare. 1.8x is roughly where extra whitespace starts reading as
+# sparse rather than spacious, so the search never goes past it.
+MIN_SPACING_SCALE = 1.0
+MAX_SPACING_SCALE = 1.8
+# Second data point for the linear slack estimate below; the midpoint of the
+# scale range gives the widest safety margin against the fallback bisection.
+SPACING_PROBE_SCALE = 1.4
+# Bounded fallback bisection for the rare case where the linear estimate
+# overshoots (line-wrapping shifts mean scale-to-height isn't perfectly linear).
+SPACING_CORRECTION_ITERATIONS = 2
+
+_MM_TO_PT = 2.8346456693
+_PAGE_HEIGHT_PT = 297 * _MM_TO_PT  # A4, matches @page size in modern_v1.html
+_PAGE_BOTTOM_MARGIN_PT = 10 * _MM_TO_PT  # matches @page margin in modern_v1.html
+_MAX_CONTENT_BOTTOM_PT = _PAGE_HEIGHT_PT - _PAGE_BOTTOM_MARGIN_PT
+
+
+def _content_bottom_pt(pdf_bytes: bytes) -> float:
+    import pdfplumber
+
+    with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+        words = pdf.pages[0].extract_words()
+        return max((w["bottom"] for w in words), default=0.0)
+
+
+def _bisect_for_fit(
+    profile_data: dict, base_pdf_bytes: bytes, lo: float, hi: float
+) -> bytes:
+    best_bytes = base_pdf_bytes
+    for _ in range(SPACING_CORRECTION_ITERATIONS):
+        mid = (lo + hi) / 2
+        mid_document = html_to_document(
+            render_cv_template(profile_data, spacing_scale=mid)
+        )
+        if len(mid_document.pages) <= 1:
+            best_bytes = document_to_pdf(mid_document)
+            lo = mid
+        else:
+            hi = mid
+    return best_bytes
+
+
+def _find_max_fitting_spacing_scale(profile_data: dict, base_pdf_bytes: bytes) -> bytes:
+    # base_pdf_bytes must already be a confirmed one-page render at MIN_SPACING_SCALE;
+    # it doubles as the fallback whenever a larger scale can't be confirmed.
+    base_bottom = _content_bottom_pt(base_pdf_bytes)
+    slack = _MAX_CONTENT_BOTTOM_PT - base_bottom
+    if slack <= 0:
+        return base_pdf_bytes
+
+    probe_document = html_to_document(
+        render_cv_template(profile_data, spacing_scale=SPACING_PROBE_SCALE)
+    )
+    if len(probe_document.pages) > 1:
+        return _bisect_for_fit(
+            profile_data, base_pdf_bytes, MIN_SPACING_SCALE, SPACING_PROBE_SCALE
+        )
+
+    # Margins scale linearly with spacing_scale, so two points fully determine
+    # how much extra page height a given scale buys.
+    probe_bottom = _content_bottom_pt(document_to_pdf(probe_document))
+    slope = (probe_bottom - base_bottom) / (SPACING_PROBE_SCALE - MIN_SPACING_SCALE)
+    if slope <= 0:
+        return base_pdf_bytes
+
+    target_scale = min(MIN_SPACING_SCALE + slack / slope, MAX_SPACING_SCALE)
+    target_document = html_to_document(
+        render_cv_template(profile_data, spacing_scale=target_scale)
+    )
+    if len(target_document.pages) == 1:
+        return document_to_pdf(target_document)
+
+    return _bisect_for_fit(profile_data, base_pdf_bytes, MIN_SPACING_SCALE, target_scale)
+
+
 def _render_cv_pdf(profile_data: dict) -> Response:
     try:
         html = render_cv_template(profile_data)
         pdf_bytes = html_to_pdf(html)
+
+        projects = profile_data.get("projects") or []
+        if len(projects) > MAX_PROJECTS_WHEN_TRIMMED and _pdf_page_count(pdf_bytes) > 1:
+            profile_data = {
+                **profile_data,
+                "projects": projects[:MAX_PROJECTS_WHEN_TRIMMED],
+            }
+            trimmed_html = render_cv_template(profile_data)
+            pdf_bytes = html_to_pdf(trimmed_html)
+
+        if _pdf_page_count(pdf_bytes) == 1:
+            pdf_bytes = _find_max_fitting_spacing_scale(profile_data, pdf_bytes)
     except PDFRenderError as exc:
         raise PDFRenderFailedError() from exc
     return Response(
@@ -113,6 +218,19 @@ def _build_cover_letter_prompt(p: ProfileData, req: CoverLetterRequest) -> str:
     )
     parts.append(f"TONE INSTRUCTION: {tone_modifier}")
     return "\n".join(parts)
+
+
+def _apply_ats_enhancement(
+    profile_data: ProfileData, ats: ATSEnhancement
+) -> ProfileData:
+    return profile_data.model_copy(
+        update={
+            "summary": ats.summary,
+            "work_experience": ats.work_experience,
+            "projects": ats.projects or profile_data.projects,
+            "skill_categories": ats.skill_categories or None,
+        }
+    )
 
 
 def _build_cv_enhancement_prompt(
@@ -170,12 +288,7 @@ def generate_cv(req: GenerateCvRequest, db: Session = Depends(get_db)):
                 profile_id=req.profile_id,
             )
             ats = parse_structured_output(llm_output, ATSEnhancement)
-            result_profile = profile_data.model_copy(
-                update={
-                    "summary": ats.summary,
-                    "work_experience": ats.work_experience,
-                }
-            )
+            result_profile = _apply_ats_enhancement(profile_data, ats)
             enhanced = True
         except RateLimitError:
             raise
@@ -221,9 +334,7 @@ async def generate_cv_stream(req: GenerateCvRequest, db: Session = Depends(get_d
                 profile_id=req.profile_id,
             )
             ats = parse_structured_output(llm_output, ATSEnhancement)
-            result_profile = profile_data.model_copy(
-                update={"summary": ats.summary, "work_experience": ats.work_experience}
-            )
+            result_profile = _apply_ats_enhancement(profile_data, ats)
             enhanced = True
         except RateLimitError as exc:
             yield stream_error_event(exc)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -34,6 +34,11 @@ class Certification(BaseModel):
     date: str | None = None
 
 
+class SkillCategory(BaseModel):
+    label: str
+    skills: list[str]
+
+
 class ProfileData(BaseModel):
     id: int | None = None
     label: str = "Default"
@@ -50,6 +55,7 @@ class ProfileData(BaseModel):
     work_experience: list[WorkExperience] = []
     education: list[Education] = []
     skills: list[str] = []
+    skill_categories: list[SkillCategory] | None = None
     projects: list[Project] = []
     certifications: list[Certification] = []
     updated_at: datetime | None = None
@@ -145,6 +151,8 @@ class CoverLetterPdfRequest(BaseModel):
 class ATSEnhancement(BaseModel):
     summary: str
     work_experience: list[WorkExperience]
+    projects: list[Project] = []
+    skill_categories: list[SkillCategory] = []
 
 
 class GenerateSummaryRequest(BaseModel):

--- a/backend/app/services/prompts.py
+++ b/backend/app/services/prompts.py
@@ -39,13 +39,17 @@ INSTRUCTIONS:
    - Include measurable outcomes only when exact figures are explicitly present in the candidate data. Never infer or invent metrics, team size, system scale, revenue, or user counts.
    - Mirror keywords and phrases from the target job description when the candidate genuinely has that experience. Do NOT fabricate skills or experience.
    - Keep each bullet to 1-2 lines. Aim for 3-5 bullets per role.
-3. Preserve all factual information: company names, roles, dates, education, skills, projects, certifications. Never invent, fabricate, or add any data that was not present in the original profile.
-4. If no job description is provided, optimize generically for the candidate's apparent field.
+3. Reorder "projects" by relevance to the job description, most relevant first. Return every project from the original profile exactly once, with its original name, description, tech_stack, and link unchanged - only the order changes. If no job description is provided, keep the original order.
+4. Group "skills" into 3-6 short, natural categories for readability (for example: "AI/Voice", "Backend/Cloud", "Languages/Frontend", "Engineering Practices" - pick labels that fit this candidate's actual skills, don't force a fixed taxonomy). Every skill from the original profile must appear in exactly one category, using its original wording. Never drop, merge, rename, or invent skills. Order categories and skills within them by relevance to the job description when one is provided, otherwise by general importance.
+5. Preserve all other factual information exactly: company names, roles, dates, education, certifications. Never invent, fabricate, or add any data that was not present in the original profile.
+6. If no job description is provided, optimize generically for the candidate's apparent field.
 
 OUTPUT FORMAT:
-Return ONLY valid JSON with exactly two keys:
+Return ONLY valid JSON with exactly four keys:
 - "summary": string
 - "work_experience": array of objects, each with: company (string), role (string), start_date (string), end_date (string or null), bullets (array of strings)
+- "projects": array of objects, each with: name (string), description (string or null), tech_stack (array of strings), link (string or null)
+- "skill_categories": array of objects, each with: label (string), skills (array of strings)
 
 No markdown, no explanation, no wrapping - just the raw JSON object.""")
 

--- a/backend/integration/pdf.py
+++ b/backend/integration/pdf.py
@@ -1,16 +1,29 @@
 from weasyprint import HTML
+from weasyprint.document import Document
 
 
 class PDFRenderError(Exception):
     pass
 
 
-def html_to_pdf(html_content: str) -> bytes:
+def html_to_document(html_content: str) -> Document:
+    # Skips PDF encoding; cheaper than html_to_pdf() when only page count is needed.
     try:
-        return HTML(string=html_content).write_pdf()
+        return HTML(string=html_content).render()
     except ImportError as e:
         raise PDFRenderError(
             "weasyprint is not installed. Run: pip install weasyprint"
         ) from e
     except Exception as e:
         raise PDFRenderError(str(e)) from e
+
+
+def document_to_pdf(document: Document) -> bytes:
+    try:
+        return document.write_pdf()
+    except Exception as e:
+        raise PDFRenderError(str(e)) from e
+
+
+def html_to_pdf(html_content: str) -> bytes:
+    return document_to_pdf(html_to_document(html_content))

--- a/backend/integration/template.py
+++ b/backend/integration/template.py
@@ -10,9 +10,9 @@ env = Environment(
 )
 
 
-def render_cv_template(profile_data: dict) -> str:
+def render_cv_template(profile_data: dict, spacing_scale: float = 1.0) -> str:
     template = env.get_template("cv/modern_v1.html")
-    return template.render(profile=profile_data)
+    return template.render(profile=profile_data, spacing_scale=spacing_scale)
 
 
 def render_cover_letter_template(letter_data: dict) -> str:

--- a/backend/integration/templates/cv/modern_v1.html
+++ b/backend/integration/templates/cv/modern_v1.html
@@ -5,41 +5,43 @@
 </head>
 <body>
 <style>
+  @page {
+    size: A4;
+    margin: 10mm 13mm;
+  }
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
     font-family: Helvetica, Arial, sans-serif;
-    font-size: 13px;
-    line-height: 1.25;
+    font-size: 12px;
+    line-height: 1.15;
     color: #000;
+    --spacing-scale: {{ spacing_scale | default(1.0) }};
   }
   .cv-container {
     max-width: 210mm;
     margin: 0 auto;
-    padding: 32px;
   }
   .cv-header {
     text-align: center;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid #d1d5db;
+    margin-bottom: calc(4px * var(--spacing-scale));
   }
   .cv-header .name {
-    font-size: 24px;
+    font-size: 22px;
     font-weight: bold;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    margin-bottom: 4px;
+    margin-bottom: 3px;
   }
   .cv-header .contact-line {
-    font-size: 12px;
+    font-size: 11px;
     color: #6b7280;
     display: flex;
     justify-content: center;
     flex-wrap: wrap;
-    gap: 4px 12px;
+    gap: 3px 10px;
   }
   .cv-section {
-    margin-bottom: 16px;
+    margin-bottom: calc(6px * var(--spacing-scale));
   }
   .section-title {
     font-size: 12px;
@@ -48,7 +50,7 @@
     letter-spacing: 0.1em;
     border-bottom: 1px solid #d1d5db;
     padding-bottom: 2px;
-    margin-bottom: 8px;
+    margin-bottom: calc(4px * var(--spacing-scale));
   }
   .summary-text {
     color: #4b5563;
@@ -57,11 +59,10 @@
   .education-item,
   .project-item,
   .certification-item {
-    margin-bottom: 12px;
+    margin-bottom: calc(4px * var(--spacing-scale));
   }
   .exp-header,
-  .edu-header,
-  .proj-header {
+  .edu-header {
     display: flex;
     justify-content: space-between;
     align-items: baseline;
@@ -72,41 +73,44 @@
   .cert-name {
     font-weight: bold;
   }
+  .proj-name {
+    color: inherit;
+    text-decoration: none;
+  }
   .exp-date,
   .edu-date,
   .cert-date {
-    font-size: 12px;
+    font-size: 11px;
     color: #6b7280;
   }
   .exp-company,
-  .edu-institution,
-  .proj-company {
-    font-size: 12px;
+  .edu-institution {
+    font-size: 11px;
     color: #6b7280;
-    margin-bottom: 4px;
+    margin-bottom: 2px;
   }
   .exp-bullets {
     margin-left: 16px;
   }
   .exp-bullets li {
-    margin-bottom: 2px;
+    margin-bottom: 1px;
   }
   .skills-text {
     color: #4b5563;
+    margin-bottom: 2px;
   }
-  .proj-description {
-    color: #4b5563;
-    margin-top: 4px;
+  .skills-category-label {
+    font-weight: bold;
+    color: #000;
   }
   .proj-tech {
-    font-size: 12px;
+    font-size: 11px;
     color: #6b7280;
-    margin-top: 2px;
   }
   .certification-item {
     display: flex;
     justify-content: space-between;
-    margin-bottom: 4px;
+    margin-bottom: calc(3px * var(--spacing-scale));
   }
   .cert-issuer {
     color: #6b7280;
@@ -169,27 +173,14 @@
   </section>
   {% endif %}
 
-  {% if profile.skills %}
-  <section class="cv-section">
-    <h2 class="section-title">Skills</h2>
-    <p class="skills-text">{{ profile.skills | join(' · ') }}</p>
-  </section>
-  {% endif %}
-
   {% if profile.projects %}
   <section class="cv-section">
     <h2 class="section-title">Projects</h2>
     {% for proj in profile.projects %}
-    <div class="project-item">
-      <div class="proj-header">
-        <span class="proj-name">{{ proj.name }}</span>
-        {% if proj.link %}<span class="proj-link">{{ proj.link }}</span>{% endif %}
-      </div>
-      <p class="proj-description">{{ proj.description }}</p>
-      {% if proj.tech_stack %}
-      <p class="proj-tech">{{ proj.tech_stack | join(', ') }}</p>
-      {% endif %}
-    </div>
+    <p class="project-item">
+      {% if proj.link %}<a class="proj-name" href="{{ proj.link }}">{{ proj.name }}</a>{% else %}<span class="proj-name">{{ proj.name }}</span>{% endif %}:
+      {{ proj.description }}{% if proj.tech_stack %} <span class="proj-tech">({{ proj.tech_stack | join(', ') }})</span>{% endif %}
+    </p>
     {% endfor %}
   </section>
   {% endif %}
@@ -203,6 +194,20 @@
       <span class="cert-date">{{ cert.date }}</span>
     </div>
     {% endfor %}
+  </section>
+  {% endif %}
+
+  {% if profile.skill_categories %}
+  <section class="cv-section">
+    <h2 class="section-title">Skills</h2>
+    {% for category in profile.skill_categories %}
+    <p class="skills-text"><span class="skills-category-label">{{ category.label }}:</span> {{ category.skills | join(', ') }}</p>
+    {% endfor %}
+  </section>
+  {% elif profile.skills %}
+  <section class="cv-section">
+    <h2 class="section-title">Skills</h2>
+    <p class="skills-text">{{ profile.skills | join(' · ') }}</p>
   </section>
   {% endif %}
 </div>

--- a/backend/tests/test_cv_pdf_page_fit.py
+++ b/backend/tests/test_cv_pdf_page_fit.py
@@ -1,0 +1,148 @@
+import io
+
+import pdfplumber
+
+from app.routes import generate as generate_routes
+
+
+def _profile(project_count: int) -> dict:
+    long_description = (
+        "A synthetic project description repeated to occupy enough vertical "
+        "space that including all of these projects pushes the resume past "
+        "a single page during the test. "
+    ) * 12
+    return {
+        "name": "Jane Doe",
+        "email": "jane@example.com",
+        "phone": None,
+        "location": None,
+        "linkedin": None,
+        "github": None,
+        "portfolio": None,
+        "summary": None,
+        "work_experience": [],
+        "education": [],
+        "skills": [],
+        "skill_categories": None,
+        "projects": [
+            {
+                "name": f"Project {i}",
+                "description": long_description,
+                "tech_stack": ["Python"],
+                "link": None,
+            }
+            for i in range(project_count)
+        ],
+        "certifications": [],
+    }
+
+
+def _page_count(pdf_bytes: bytes) -> int:
+    with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+        return len(pdf.pages)
+
+
+def test_render_cv_pdf_keeps_all_projects_when_they_fit_one_page():
+    response = generate_routes._render_cv_pdf(_profile(project_count=2))
+
+    assert _page_count(response.body) == 1
+
+
+def _content_bottom(pdf_bytes: bytes) -> float:
+    with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+        words = pdf.pages[0].extract_words()
+        return max(w["bottom"] for w in words)
+
+
+def test_render_cv_pdf_stretches_spacing_when_page_has_slack():
+    profile = _profile(project_count=0)
+    profile["work_experience"] = [
+        {
+            "company": "Acme",
+            "role": "Engineer",
+            "start_date": "2022",
+            "end_date": None,
+            "bullets": ["Did a thing.", "Did another thing."],
+        }
+    ]
+
+    base_pdf = generate_routes.html_to_pdf(generate_routes.render_cv_template(profile))
+    assert _page_count(base_pdf) == 1
+
+    response = generate_routes._render_cv_pdf(profile)
+
+    assert _page_count(response.body) == 1
+    assert _content_bottom(response.body) > _content_bottom(base_pdf)
+
+
+def _many_short_projects_profile(project_count: int) -> dict:
+    # Many short (margin-dominated) items reach a fit tight enough that the
+    # spacing estimate's probe render overflows, exercising the bisection fallback.
+    return {
+        "name": "Jane Doe",
+        "email": "jane@example.com",
+        "phone": None,
+        "location": None,
+        "linkedin": None,
+        "github": None,
+        "portfolio": None,
+        "summary": None,
+        "work_experience": [],
+        "education": [],
+        "skills": [],
+        "skill_categories": None,
+        "projects": [
+            {
+                "name": f"Project {i}",
+                "description": "Short desc.",
+                "tech_stack": ["Python"],
+                "link": None,
+            }
+            for i in range(project_count)
+        ],
+        "certifications": [],
+    }
+
+
+def test_render_cv_pdf_falls_back_when_spacing_probe_overflows():
+    profile = _many_short_projects_profile(project_count=52)
+
+    base_pdf = generate_routes.html_to_pdf(generate_routes.render_cv_template(profile))
+    assert _page_count(base_pdf) == 1, "fixture must fit one page at the base scale"
+
+    probe_document = generate_routes.html_to_document(
+        generate_routes.render_cv_template(
+            profile, spacing_scale=generate_routes.SPACING_PROBE_SCALE
+        )
+    )
+    assert len(probe_document.pages) > 1, (
+        "fixture must overflow at the probe scale for this test to exercise "
+        "the bisection fallback"
+    )
+
+    response = generate_routes._render_cv_pdf(profile)
+
+    assert _page_count(response.body) == 1
+
+
+def test_render_cv_pdf_trims_to_top_projects_when_they_would_overflow():
+    profile = _profile(project_count=8)
+
+    unrimmed_html = generate_routes.render_cv_template(profile)
+    assert _page_count(generate_routes.html_to_pdf(unrimmed_html)) > 1, (
+        "test fixture must actually overflow one page before trimming for "
+        "this test to prove anything"
+    )
+
+    response = generate_routes._render_cv_pdf(profile)
+
+    assert _page_count(response.body) == 1
+    with pdfplumber.open(io.BytesIO(response.body)) as pdf:
+        text = pdf.pages[0].extract_text()
+    kept = [f"Project {i}" for i in range(generate_routes.MAX_PROJECTS_WHEN_TRIMMED)]
+    dropped = [
+        f"Project {i}"
+        for i in range(generate_routes.MAX_PROJECTS_WHEN_TRIMMED, 8)
+    ]
+    assert all(name in text for name in kept)
+    assert not any(name in text for name in dropped)

--- a/backend/tests/test_keyless_cv_enhancement.py
+++ b/backend/tests/test_keyless_cv_enhancement.py
@@ -75,3 +75,67 @@ def test_streaming_cv_enhancement_runs_for_keyless_provider(monkeypatch):
         assert db.query(GeneratedCV).one().enhanced == 1
     finally:
         db.close()
+
+
+def test_cv_enhancement_applies_reordered_projects_and_skill_categories(monkeypatch):
+    """When the LLM returns projects/skill_categories, they replace the originals."""
+    db = _make_session()
+    try:
+        profile = _add_profile(db)
+        profile.projects = (
+            '[{"name":"A","description":"d","tech_stack":[],"link":null},'
+            '{"name":"B","description":"d","tech_stack":[],"link":null}]'
+        )
+        db.commit()
+
+        monkeypatch.setattr(
+            generate_routes,
+            "_get_llm_config_raw",
+            lambda db: ("ollama/llama3.2", ""),
+        )
+        monkeypatch.setattr(
+            generate_routes,
+            "call_llm",
+            lambda *args, **kwargs: (
+                '{"summary":"s","work_experience":[],'
+                '"projects":[{"name":"B","description":"d","tech_stack":[],"link":null},'
+                '{"name":"A","description":"d","tech_stack":[],"link":null}],'
+                '"skill_categories":[{"label":"Core","skills":["Python"]}]}'
+            ),
+        )
+
+        response = generate_routes.generate_cv(
+            GenerateCvRequest(profile_id=profile.id, enhance=True),
+            db,
+        )
+
+        assert [p.name for p in response.profile.projects] == ["B", "A"]
+        assert [c.model_dump() for c in response.profile.skill_categories] == [
+            {"label": "Core", "skills": ["Python"]}
+        ]
+    finally:
+        db.close()
+
+
+def test_cv_enhancement_falls_back_to_original_projects_when_llm_omits_them(
+    monkeypatch,
+):
+    """An LLM response with no projects/skill_categories keeps the original order."""
+    db = _make_session()
+    try:
+        profile = _add_profile(db)
+        profile.projects = (
+            '[{"name":"A","description":"d","tech_stack":[],"link":null}]'
+        )
+        db.commit()
+        _configure_keyless_llm(monkeypatch)
+
+        response = generate_routes.generate_cv(
+            GenerateCvRequest(profile_id=profile.id, enhance=True),
+            db,
+        )
+
+        assert [p.name for p in response.profile.projects] == ["A"]
+        assert response.profile.skill_categories is None
+    finally:
+        db.close()

--- a/frontend/src/lib/components/CvPreview.svelte
+++ b/frontend/src/lib/components/CvPreview.svelte
@@ -66,27 +66,14 @@
     </section>
   {/if}
 
-  {#if profile.skills.length}
-    <section class="mb-4">
-      <h2 class="text-xs font-bold uppercase tracking-widest border-b border-border dark:border-zinc-700 print:border-black pb-0.5 mb-2 text-foreground dark:text-zinc-200">Skills</h2>
-      <p class="text-muted-foreground dark:text-zinc-300 print:text-black">{profile.skills.join(' · ')}</p>
-    </section>
-  {/if}
-
   {#if profile.projects.length}
     <section class="mb-4">
       <h2 class="text-xs font-bold uppercase tracking-widest border-b border-border dark:border-zinc-700 print:border-black pb-0.5 mb-2 text-foreground dark:text-zinc-200">Projects</h2>
       {#each profile.projects as p}
-        <div class="mb-2">
-          <div class="flex justify-between items-baseline">
-            <span class="font-semibold text-foreground dark:text-zinc-200">{p.name}</span>
-            {#if p.link}<a href={toHref(p.link)} target="_blank" rel="noopener noreferrer" class="text-xs text-primary dark:text-blue-400 print:text-blue-600 hover:underline">{p.link}</a>{/if}
-          </div>
-          <p class="text-muted-foreground dark:text-zinc-300 print:text-black">{p.description}</p>
-          {#if p.tech_stack.length}
-            <p class="text-xs text-muted-foreground dark:text-zinc-500 print:text-gray-500 mt-0.5">{p.tech_stack.join(', ')}</p>
-          {/if}
-        </div>
+        <p class="mb-1 text-muted-foreground dark:text-zinc-300 print:text-black">
+          {#if p.link}<a href={toHref(p.link)} target="_blank" rel="noopener noreferrer" class="font-semibold text-foreground dark:text-zinc-200 hover:underline">{p.name}</a>{:else}<span class="font-semibold text-foreground dark:text-zinc-200">{p.name}</span>{/if}:
+          {p.description}{#if p.tech_stack.length} <span class="text-xs text-muted-foreground dark:text-zinc-500 print:text-gray-500">({p.tech_stack.join(', ')})</span>{/if}
+        </p>
       {/each}
     </section>
   {/if}
@@ -100,6 +87,22 @@
           <span class="text-xs text-muted-foreground dark:text-zinc-500 print:text-gray-500">{c.date}</span>
         </div>
       {/each}
+    </section>
+  {/if}
+
+  {#if profile.skill_categories?.length}
+    <section class="mb-4">
+      <h2 class="text-xs font-bold uppercase tracking-widest border-b border-border dark:border-zinc-700 print:border-black pb-0.5 mb-2 text-foreground dark:text-zinc-200">Skills</h2>
+      {#each profile.skill_categories as category}
+        <p class="text-muted-foreground dark:text-zinc-300 print:text-black">
+          <span class="font-semibold text-foreground dark:text-zinc-200">{category.label}:</span> {category.skills.join(', ')}
+        </p>
+      {/each}
+    </section>
+  {:else if profile.skills.length}
+    <section class="mb-4">
+      <h2 class="text-xs font-bold uppercase tracking-widest border-b border-border dark:border-zinc-700 print:border-black pb-0.5 mb-2 text-foreground dark:text-zinc-200">Skills</h2>
+      <p class="text-muted-foreground dark:text-zinc-300 print:text-black">{profile.skills.join(' · ')}</p>
     </section>
   {/if}
 </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -27,6 +27,11 @@ export interface Certification {
   date: string;
 }
 
+export interface SkillCategory {
+  label: string;
+  skills: string[];
+}
+
 export interface ProfileData {
   id?: number | null;
   label?: string;
@@ -43,6 +48,7 @@ export interface ProfileData {
   work_experience: WorkExperience[];
   education: Education[];
   skills: string[];
+  skill_categories?: SkillCategory[] | null;
   projects: Project[];
   certifications: Certification[];
   updated_at?: string | null;


### PR DESCRIPTION
## Summary
- Tightens the CV PDF layout (page margins, spacing, typography) so resumes use noticeably less vertical space per section, reducing page count for the same content.
- Extends the existing AI CV-tailoring call to also reorder projects by relevance to the job description and group skills into readable categories, falling back to the original order/flat list when the LLM doesn't return them or isn't configured.
- Makes section spacing dynamic: when a one-page resume has slack left on the page, spacing between sections and items stretches (capped at 1.8x) to fill it, instead of leaving it as dead whitespace at the bottom.
- Optimizes the spacing search: instead of blindly bisecting across the full range, it takes two rendered data points and solves directly for the target scale (margins scale linearly with the multiplier), with a bounded bisection fallback for the rare case the linear estimate overshoots. Cuts worst-case PDF renders per request from 8 down to about 3, and search iterations skip PDF serialization entirely until a winning candidate is found.
- Fixes a section-ordering mismatch between the live CV preview and the actual generated PDF (Skills was last in the PDF but not in the preview).

## Changes
- `backend/integration/templates/cv/modern_v1.html` — tighter `@page` margins/typography, spacing driven by a `--spacing-scale` CSS variable, projects consolidated into single-paragraph items, skills rendered as categories when present.
- `backend/app/routes/generate.py` — top-3-project trimming when content overflows a page, plus the linear-estimate spacing search (`_find_max_fitting_spacing_scale`, `_bisect_for_fit`).
- `backend/integration/pdf.py` — split `html_to_pdf` into `html_to_document`/`document_to_pdf` so page-count checks can skip PDF serialization.
- `backend/integration/template.py` — `render_cv_template` accepts a `spacing_scale` parameter.
- `backend/app/schemas.py` — `SkillCategory` model; `ProfileData.skill_categories`; `ATSEnhancement` gains `projects`/`skill_categories`.
- `backend/app/services/prompts.py` — `ATS_SYSTEM_PROMPT` instructs the LLM to reorder projects by relevance and group skills into categories.
- `frontend/src/lib/components/CvPreview.svelte`, `frontend/src/lib/types.ts` — mirror the categorized-skills/reordered-projects rendering and fix the section order to match the PDF.
- Test coverage for page-fit trimming, spacing stretch, and the bisection fallback path.

## Test plan
- `uv run pytest` — full backend suite passing
- `bun run check` — 0 type errors
- Verified end-to-end: enhancement produces categorized skills and relevance-ordered projects, PDF stays one page with dynamic spacing applied
- Verified the spacing-search bisection fallback path with a synthetic near-boundary profile

## Security notes
One low-severity item worth a maintainer's eyes: `proj.link` is now rendered as an `href` attribute in the PDF template (previously inert text). Jinja2 autoescaping prevents HTML/attribute injection, but doesn't strip a `javascript:` scheme the way the frontend's `toHref()` allowlist does. Real-world impact is minimal — WeasyPrint doesn't execute JavaScript when rendering PDFs, and this is single-user profile data rather than adversarial multi-tenant input — but the two rendering paths aren't consistent.