### PR TITLE
feat: replace header navigation with an icon-only sidebar

### DIFF
--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '$lib/components/ui/tooltip';
+	import { House, Mail, FileUser, Zap, Clock, Briefcase, Settings } from '@lucide/svelte';
+	import type { Component } from 'svelte';
+
+	const NAV_ITEMS = [
+		{ href: '/', label: 'Dashboard', icon: House },
+		{ href: '/cover-letter', label: 'Cover Letter', icon: Mail },
+		{ href: '/generate', label: 'Generate CV', icon: FileUser },
+		{ href: '/smart-apply', label: 'Smart Apply', icon: Zap },
+		{ href: '/history', label: 'History', icon: Clock },
+		{ href: '/tracker', label: 'Tracker', icon: Briefcase }
+	];
+
+	function isActive(href: string): boolean {
+		return page.url.pathname === href;
+	}
+
+	// Matches SettingsButton.svelte's own readiness-dot logic, since we render
+	// a sidebar-styled trigger here instead of that component directly.
+	const settingsDotColor = $derived(
+		page.data.readiness?.ai.ready === false ? 'bg-yellow-500' : null
+	);
+</script>
+
+{#snippet iconLink(href: string, label: string, icon: Component, active: boolean, dotColor: string | null = null)}
+	{@const Icon = icon}
+	<Tooltip>
+		<TooltipTrigger>
+			{#snippet child({ props })}
+				<a
+					{...props}
+					{href}
+					aria-label={label}
+					aria-current={active ? 'page' : undefined}
+					class="relative flex items-center justify-center w-10 h-10 rounded-md transition-colors {active
+						? 'bg-accent text-accent-foreground'
+						: 'text-muted-foreground hover:text-foreground hover:bg-accent/50'}"
+				>
+					<Icon class="w-5 h-5" />
+					{#if dotColor}
+						<span
+							class="absolute top-1.5 right-1.5 w-2 h-2 rounded-full {dotColor} ring-1 ring-background"
+						></span>
+					{/if}
+				</a>
+			{/snippet}
+		</TooltipTrigger>
+		<TooltipContent side="right" class="z-70">{label}</TooltipContent>
+	</Tooltip>
+{/snippet}
+
+<aside
+	class="hidden md:flex flex-col items-center w-14 shrink-0 border-r border-border bg-card py-3 gap-1 sticky top-0 h-screen overflow-y-auto"
+>
+	<TooltipProvider delayDuration={200}>
+		{#each NAV_ITEMS as item (item.href)}
+			{@render iconLink(item.href, item.label, item.icon, isActive(item.href))}
+		{/each}
+
+		<div class="mt-auto">
+			{@render iconLink('/settings', 'Settings', Settings, page.url.pathname.startsWith('/settings'), settingsDotColor)}
+		</div>
+	</TooltipProvider>
+</aside>
+
+<!-- Mobile fallback: a bottom tab bar, since hover tooltips don't translate to touch -->
+<nav
+	class="md:hidden fixed bottom-0 inset-x-0 z-50 flex items-center justify-around border-t border-border bg-card py-1.5"
+>
+	{#each NAV_ITEMS as item (item.href)}
+		<a
+			href={item.href}
+			aria-label={item.label}
+			aria-current={isActive(item.href) ? 'page' : undefined}
+			class="flex flex-col items-center gap-0.5 px-2 py-1 rounded-md text-[10px] font-medium transition-colors {isActive(item.href)
+				? 'text-accent-foreground'
+				: 'text-muted-foreground'}"
+		>
+			<item.icon class="w-5 h-5" />
+			{item.label}
+		</a>
+	{/each}
+</nav>

--- a/frontend/src/lib/components/ui/tooltip/index.ts
+++ b/frontend/src/lib/components/ui/tooltip/index.ts
@@ -1,0 +1,19 @@
+import Content from "./tooltip-content.svelte";
+import Portal from "./tooltip-portal.svelte";
+import Provider from "./tooltip-provider.svelte";
+import Trigger from "./tooltip-trigger.svelte";
+import Root from "./tooltip.svelte";
+
+export {
+	Root,
+	Trigger,
+	Content,
+	Provider,
+	Portal,
+	//
+	Root as Tooltip,
+	Content as TooltipContent,
+	Trigger as TooltipTrigger,
+	Provider as TooltipProvider,
+	Portal as TooltipPortal,
+};

--- a/frontend/src/lib/components/ui/tooltip/tooltip-content.svelte
+++ b/frontend/src/lib/components/ui/tooltip/tooltip-content.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+	import type { WithoutChildrenOrChild } from "$lib/utils.js";
+	import TooltipPortal from "./tooltip-portal.svelte";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		sideOffset = 0,
+		side = "top",
+		children,
+		arrowClasses,
+		portalProps,
+		...restProps
+	}: TooltipPrimitive.ContentProps & {
+		arrowClasses?: string;
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof TooltipPortal>>;
+	} = $props();
+</script>
+
+<TooltipPortal {...portalProps}>
+	<TooltipPrimitive.Content
+		bind:ref
+		data-slot="tooltip-content"
+		{sideOffset}
+		{side}
+		class={cn(
+			"inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 z-50 w-fit max-w-xs origin-(--bits-tooltip-content-transform-origin) bg-foreground text-background",
+			className
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+		<TooltipPrimitive.Arrow>
+			{#snippet child({ props })}
+				<div
+					class={cn(
+						"size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] z-50 bg-foreground fill-foreground",
+						"data-[side=top]:translate-x-1/2 data-[side=top]:translate-y-[calc(-50%+2px)]",
+						"data-[side=bottom]:-translate-x-1/2 data-[side=bottom]:-translate-y-[calc(-50%+1px)]",
+						"data-[side=right]:translate-x-[calc(50%+2px)] data-[side=right]:translate-y-1/2",
+						"data-[side=left]:-translate-y-[calc(50%-3px)]",
+						arrowClasses
+					)}
+					{...props}
+				></div>
+			{/snippet}
+		</TooltipPrimitive.Arrow>
+	</TooltipPrimitive.Content>
+</TooltipPortal>

--- a/frontend/src/lib/components/ui/tooltip/tooltip-portal.svelte
+++ b/frontend/src/lib/components/ui/tooltip/tooltip-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+
+	let { ...restProps }: TooltipPrimitive.PortalProps = $props();
+</script>
+
+<TooltipPrimitive.Portal {...restProps} />

--- a/frontend/src/lib/components/ui/tooltip/tooltip-provider.svelte
+++ b/frontend/src/lib/components/ui/tooltip/tooltip-provider.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+
+	let { delayDuration = 0, ...restProps }: TooltipPrimitive.ProviderProps = $props();
+</script>
+
+<TooltipPrimitive.Provider {delayDuration} {...restProps} />

--- a/frontend/src/lib/components/ui/tooltip/tooltip-trigger.svelte
+++ b/frontend/src/lib/components/ui/tooltip/tooltip-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts" generics="T = never">
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: TooltipPrimitive.TriggerProps<T> = $props();
+</script>
+
+<TooltipPrimitive.Trigger bind:ref data-slot="tooltip-trigger" {...restProps} />

--- a/frontend/src/lib/components/ui/tooltip/tooltip.svelte
+++ b/frontend/src/lib/components/ui/tooltip/tooltip.svelte
@@ -1,0 +1,7 @@
+<script lang="ts" generics="T = never">
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+
+	let { open = $bindable(false), ...restProps }: TooltipPrimitive.RootProps<T> = $props();
+</script>
+
+<TooltipPrimitive.Root bind:open {...restProps} />

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -5,13 +5,14 @@
   import { authState } from '$lib/auth-state.svelte';
   import ProfileSwitcher from '$lib/components/ProfileSwitcher.svelte';
   import SessionExpiryBanner from '$lib/components/SessionExpiryBanner.svelte';
+  import Sidebar from '$lib/components/Sidebar.svelte';
   import SettingsButton from '$lib/components/SettingsButton.svelte';
   import SettingsNav from '$lib/components/SettingsNav.svelte';
   import ThemeToggle from '$lib/components/ThemeToggle.svelte';
   import Toaster from '$lib/components/Toaster.svelte';
   import { themeState } from '$lib/theme.svelte';
   import { toastState } from '$lib/toast.svelte';
-  import { LogOut, Menu, X, Zap } from '@lucide/svelte';
+  import { LogOut } from '@lucide/svelte';
   import '../app.css';
 
   let { data, children } = $props();
@@ -20,24 +21,7 @@
   const shellWidth = $derived(
     page.url.pathname === '/cover-letter' ? 'max-w-[80rem]' : 'max-w-5xl',
   );
-  let mobileMenuOpen = $state(false);
   let signingOut = $state(false);
-
-  function navClass(href: string) {
-    return `px-3 py-1.5 rounded-md text-sm transition-colors ${
-      page.url.pathname === href
-        ? 'bg-accent text-accent-foreground font-medium'
-        : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
-    }`;
-  }
-
-  function mobileNavClass(href: string) {
-    return `flex items-center gap-2 px-4 py-3 text-sm transition-colors border-b border-border/50 last:border-0 ${
-      page.url.pathname === href
-        ? 'bg-accent text-accent-foreground font-medium'
-        : 'text-foreground hover:bg-accent/50'
-    }`;
-  }
 
   async function signOut() {
     if (signingOut) return;
@@ -52,11 +36,6 @@
       signingOut = false;
     }
   }
-
-  $effect(() => {
-    page.url.pathname;
-    mobileMenuOpen = false;
-  });
 
   $effect(() => {
     const isDark = themeState.current === 'dark';
@@ -81,95 +60,47 @@
   {@render children()}
   <Toaster />
 {:else}
-  <div class="min-h-screen flex flex-col bg-muted/40">
-    <header class="sticky top-0 z-60 border-b bg-card">
-      <div class="mx-auto {shellWidth} px-4 py-3 flex items-center justify-between gap-3">
-        <div class="flex items-center gap-4 min-w-0">
+  <div class="min-h-screen flex bg-muted/40">
+    <Sidebar />
+
+    <div class="flex-1 flex flex-col min-w-0">
+      <header class="sticky top-0 z-60 border-b bg-card">
+        <div class="px-4 py-3 flex items-center justify-between gap-3">
           <a
             href="/"
             class="font-bold text-lg tracking-tight hover:text-primary transition-colors shrink-0"
           >ApplyKit</a>
 
-          <nav class="hidden md:flex items-center gap-1 animate-in fade-in slide-in-from-left-2 duration-500">
-              <a href="/" class={navClass('/')}>Dashboard</a>
-              <span class="w-px h-4 bg-border mx-2 shrink-0"></span>
-              <a href="/cover-letter" class={navClass('/cover-letter')}>Cover Letter</a>
-              <a href="/generate" class={navClass('/generate')}>Generate CV</a>
-              <a href="/smart-apply" class="{navClass('/smart-apply')} flex items-center gap-1.5">
-                <Zap class="w-3.5 h-3.5" />
-                Smart Apply
-              </a>
-              <span class="w-px h-4 bg-border mx-2 shrink-0"></span>
-              <a href="/history" class={navClass('/history')}>History</a>
-              <a href="/tracker" class={navClass('/tracker')}>Tracker</a>
-          </nav>
-        </div>
-
-        <div class="flex items-center gap-2 shrink-0">
+          <div class="flex items-center gap-2 shrink-0">
             <ProfileSwitcher />
             <ThemeToggle />
-            <SettingsButton />
+            <div class="md:hidden"><SettingsButton /></div>
             {#if authState.authMode === 'password'}
               <button
                 type="button"
                 onclick={signOut}
                 disabled={signingOut}
-                class="hidden md:inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+                class="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
               >
-                <LogOut class="h-4 w-4" />Sign out
+                <LogOut class="h-4 w-4" />
+                <span class="hidden sm:inline">Sign out</span>
               </button>
             {/if}
-            <button
-              onclick={() => mobileMenuOpen = !mobileMenuOpen}
-              class="md:hidden flex items-center justify-center w-8 h-8 rounded-md hover:bg-accent transition-colors"
-              aria-label="Toggle menu"
-            >
-              {#if mobileMenuOpen}
-                <X class="w-4.5 h-4.5" />
-              {:else}
-                <Menu class="w-4.5 h-4.5" />
-              {/if}
-            </button>
+          </div>
         </div>
-      </div>
+      </header>
 
-      {#if mobileMenuOpen}
-        <div class="md:hidden border-t border-border bg-card animate-in slide-in-from-top-2 duration-200">
-          <nav class="mx-auto {shellWidth}">
-            <a href="/" class={mobileNavClass('/')}>Dashboard</a>
-            <a href="/cover-letter" class={mobileNavClass('/cover-letter')}>Cover Letter</a>
-            <a href="/generate" class={mobileNavClass('/generate')}>Generate CV</a>
-            <a href="/smart-apply" class="{mobileNavClass('/smart-apply')} gap-2">
-              <Zap class="w-3.5 h-3.5 text-primary" />
-              Smart Apply
-            </a>
-            <a href="/history" class={mobileNavClass('/history')}>History</a>
-            <a href="/tracker" class={mobileNavClass('/tracker')}>Tracker</a>
-            {#if authState.authMode === 'password'}
-              <button
-                type="button"
-                onclick={signOut}
-                disabled={signingOut}
-                class="flex w-full items-center gap-2 px-4 py-3 text-left text-sm text-foreground transition-colors hover:bg-accent/50 disabled:opacity-50"
-              >
-                <LogOut class="h-4 w-4" />Sign out
-              </button>
-            {/if}
-          </nav>
-        </div>
+      {#if authState.authMode === 'password' && authState.authenticated}
+        <SessionExpiryBanner />
       {/if}
-    </header>
 
-    {#if authState.authMode === 'password' && authState.authenticated}
-      <SessionExpiryBanner />
-    {/if}
-
-    <main class="flex-1 mx-auto w-full {shellWidth} px-4 py-8">
-      {#if onSettings}
-        <div class="mb-6"><SettingsNav /></div>
-      {/if}
-      {@render children()}
-    </main>
+      <main class="flex-1 w-full mx-auto {shellWidth} px-4 py-8 pb-24 md:pb-8">
+        {#if onSettings}
+          <div class="mb-6"><SettingsNav /></div>
+        {/if}
+        {@render children()}
+      </main>
+    </div>
 
     <Toaster />
   </div>


### PR DESCRIPTION
## Summary
Adds a persistent, icon-only left sidebar (Dashboard, Cover Letter, Generate CV, Smart Apply, History, Tracker) with tooltips for labels and active-route highlighting, replacing the horizontal nav that lived in the header. Utility controls (profile switcher, theme toggle, settings, sign out) stay in a simplified top bar alongside the brand mark, since the sidebar is navigation only.

On mobile, where hover tooltips don't apply, the sidebar is replaced by a fixed bottom tab bar with visible labels instead of an off-canvas hamburger menu.

Adds the shadcn-svelte Tooltip primitive via the official CLI.

## Heads up: possible overlap with your in-progress work
I noticed the open v1.4 product-foundation draft PR touches navigation/routing too. This PR is purely a visual nav-shell change (same routes, same pages) with no route renames, so it may or may not still be relevant depending on where that work lands — happy to rebase, close, or adapt this if it conflicts with your direction. Wanted to be upfront about that rather than assume it's still wanted as-is.

## Test plan
- `bun run check` — 0 type errors
- Full frontend test suite passes