### PR TITLE
feat: surface scrape source next to the job description in Smart Apply

### DIFF
--- a/frontend/src/lib/components/ui/tooltip/index.ts
+++ b/frontend/src/lib/components/ui/tooltip/index.ts
@@ -1,0 +1,19 @@
+import Content from "./tooltip-content.svelte";
+import Portal from "./tooltip-portal.svelte";
+import Provider from "./tooltip-provider.svelte";
+import Trigger from "./tooltip-trigger.svelte";
+import Root from "./tooltip.svelte";
+
+export {
+	Root,
+	Trigger,
+	Content,
+	Provider,
+	Portal,
+	//
+	Root as Tooltip,
+	Content as TooltipContent,
+	Trigger as TooltipTrigger,
+	Provider as TooltipProvider,
+	Portal as TooltipPortal,
+};

--- a/frontend/src/lib/components/ui/tooltip/tooltip-content.svelte
+++ b/frontend/src/lib/components/ui/tooltip/tooltip-content.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+	import type { WithoutChildrenOrChild } from "$lib/utils.js";
+	import TooltipPortal from "./tooltip-portal.svelte";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		sideOffset = 0,
+		side = "top",
+		children,
+		arrowClasses,
+		portalProps,
+		...restProps
+	}: TooltipPrimitive.ContentProps & {
+		arrowClasses?: string;
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof TooltipPortal>>;
+	} = $props();
+</script>
+
+<TooltipPortal {...portalProps}>
+	<TooltipPrimitive.Content
+		bind:ref
+		data-slot="tooltip-content"
+		{sideOffset}
+		{side}
+		class={cn(
+			"inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 z-50 w-fit max-w-xs origin-(--bits-tooltip-content-transform-origin) bg-foreground text-background",
+			className
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+		<TooltipPrimitive.Arrow>
+			{#snippet child({ props })}
+				<div
+					class={cn(
+						"size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] z-50 bg-foreground fill-foreground",
+						"data-[side=top]:translate-x-1/2 data-[side=top]:translate-y-[calc(-50%+2px)]",
+						"data-[side=bottom]:-translate-x-1/2 data-[side=bottom]:-translate-y-[calc(-50%+1px)]",
+						"data-[side=right]:translate-x-[calc(50%+2px)] data-[side=right]:translate-y-1/2",
+						"data-[side=left]:-translate-y-[calc(50%-3px)]",
+						arrowClasses
+					)}
+					{...props}
+				></div>
+			{/snippet}
+		</TooltipPrimitive.Arrow>
+	</TooltipPrimitive.Content>
+</TooltipPortal>

--- a/frontend/src/lib/components/ui/tooltip/tooltip-portal.svelte
+++ b/frontend/src/lib/components/ui/tooltip/tooltip-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+
+	let { ...restProps }: TooltipPrimitive.PortalProps = $props();
+</script>
+
+<TooltipPrimitive.Portal {...restProps} />

--- a/frontend/src/lib/components/ui/tooltip/tooltip-provider.svelte
+++ b/frontend/src/lib/components/ui/tooltip/tooltip-provider.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+
+	let { delayDuration = 0, ...restProps }: TooltipPrimitive.ProviderProps = $props();
+</script>
+
+<TooltipPrimitive.Provider {delayDuration} {...restProps} />

--- a/frontend/src/lib/components/ui/tooltip/tooltip-trigger.svelte
+++ b/frontend/src/lib/components/ui/tooltip/tooltip-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts" generics="T = never">
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: TooltipPrimitive.TriggerProps<T> = $props();
+</script>
+
+<TooltipPrimitive.Trigger bind:ref data-slot="tooltip-trigger" {...restProps} />

--- a/frontend/src/lib/components/ui/tooltip/tooltip.svelte
+++ b/frontend/src/lib/components/ui/tooltip/tooltip.svelte
@@ -1,0 +1,7 @@
+<script lang="ts" generics="T = never">
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+
+	let { open = $bindable(false), ...restProps }: TooltipPrimitive.RootProps<T> = $props();
+</script>
+
+<TooltipPrimitive.Root bind:open {...restProps} />

--- a/frontend/src/lib/smart-apply-scrape-source.test.ts
+++ b/frontend/src/lib/smart-apply-scrape-source.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const page = readFileSync(
+  new URL('../routes/smart-apply/+page.svelte', import.meta.url),
+  'utf8',
+);
+
+describe('smart apply scrape source badge', () => {
+  test('surfaces the scrape source next to the job description toggle', () => {
+    expect(page).toContain('SCRAPE_SOURCE_INFO');
+    expect(page).toContain('jobDescriptionSource');
+    expect(page).toContain('<Badge');
+    expect(page).toContain('<TooltipContent>{jobDescriptionSource.description}</TooltipContent>');
+  });
+
+  test('maps every ScrapeJobResponse source to a label and description', () => {
+    for (const source of ['greenhouse_api', 'lever_api', 'ashby_api', 'jina', 'crawl4ai']) {
+      expect(page).toContain(`${source}:`);
+    }
+  });
+});

--- a/frontend/src/routes/smart-apply/+page.svelte
+++ b/frontend/src/routes/smart-apply/+page.svelte
@@ -12,10 +12,12 @@
   import AiReadinessNotice from '$lib/components/AiReadinessNotice.svelte';
   import type { ReadinessResponse } from '$lib/readiness-types';
   import FitAnalysisDisplay from '$lib/components/FitAnalysisDisplay.svelte';
+  import { Badge } from '$lib/components/ui/badge';
   import { Button } from '$lib/components/ui/button';
   import { Card, CardContent } from '$lib/components/ui/card';
   import { Input } from '$lib/components/ui/input';
   import { Label } from '$lib/components/ui/label';
+  import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '$lib/components/ui/tooltip';
   import { clearDraft, consumeDraft, draftKey, saveDraft } from '$lib/draft-recovery';
   import { consumeStream } from '$lib/stream';
   import { toastState } from '$lib/toast.svelte';
@@ -40,6 +42,37 @@
     data.readiness;
     readinessOverride = null;
   });
+
+  const SCRAPE_SOURCE_INFO: Record<
+    ScrapeJobResponse['source'],
+    { label: string; description: string; variant: 'secondary' | 'outline' }
+  > = {
+    greenhouse_api: {
+      label: 'Greenhouse',
+      description: "Pulled directly from the company's Greenhouse job board API.",
+      variant: 'secondary',
+    },
+    lever_api: {
+      label: 'Lever',
+      description: "Pulled directly from the company's Lever job board API.",
+      variant: 'secondary',
+    },
+    ashby_api: {
+      label: 'Ashby',
+      description: "Pulled directly from the company's Ashby job board API.",
+      variant: 'secondary',
+    },
+    jina: {
+      label: 'Scraped',
+      description: 'Extracted by reading the page content — some fields may be inferred by AI.',
+      variant: 'outline',
+    },
+    crawl4ai: {
+      label: 'Scraped',
+      description: 'Extracted from a rendered version of the page — some fields may be inferred by AI.',
+      variant: 'outline',
+    },
+  };
 
   interface SmartApplyDraft {
     inputMode: 'url' | 'paste';
@@ -439,14 +472,29 @@
         </div>
         <!-- Job Description (collapsible) -->
         {#if scrapeResult?.job_description}
+          {@const jobDescriptionSource = SCRAPE_SOURCE_INFO[scrapeResult.source]}
           <div class="pt-2 border-t border-border/50">
-            <button
-              onclick={() => jobDescriptionExpanded = !jobDescriptionExpanded}
-              class="flex items-center justify-between w-full text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <span>Job Description</span>
-              <ChevronDown class="w-4 h-4 transition-transform {jobDescriptionExpanded ? 'rotate-180' : ''}" />
-            </button>
+            <div class="flex items-center justify-between">
+              <button
+                onclick={() => jobDescriptionExpanded = !jobDescriptionExpanded}
+                class="flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <span>Job Description</span>
+                <ChevronDown class="w-4 h-4 transition-transform {jobDescriptionExpanded ? 'rotate-180' : ''}" />
+              </button>
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger>
+                    {#snippet child({ props })}
+                      <Badge {...props} variant={jobDescriptionSource.variant} class="cursor-default">
+                        {jobDescriptionSource.label}
+                      </Badge>
+                    {/snippet}
+                  </TooltipTrigger>
+                  <TooltipContent>{jobDescriptionSource.description}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
             {#if jobDescriptionExpanded}
               <div class="mt-2 bg-muted/50 rounded-lg p-3 text-sm max-h-60 overflow-y-auto whitespace-pre-wrap">
                 {scrapeResult.job_description}


### PR DESCRIPTION
## Summary
`scrape_analyze()` already returns which tier produced the job description (`greenhouse_api` / `lever_api` / `ashby_api` / `jina` / `crawl4ai`), but Smart Apply never surfaced it — the user had no way to tell whether a posting came from a clean ATS API pull or a generic page scrape.

Adds a small badge with a tooltip next to the Job Description toggle: a structured ATS API pull gets a filled badge, a generic page scrape gets an outline badge, each with a tooltip explaining what it means and why it matters for trusting the extracted content.

Includes the shadcn-svelte Tooltip primitive, since it wasn't previously installed.

## Test plan
- `bun run check` — 0 type errors
- Full frontend test suite passes